### PR TITLE
Add support to ignore files

### DIFF
--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -166,6 +166,11 @@ resolve_files(Config) when is_list(Config) ->
     lists:map(fun resolve_files/1, Config);
 resolve_files(RuleGroup = #{files := _Files}) ->
     RuleGroup;
+resolve_files(RuleGroup = #{dirs := Dirs, filter := Filter, ignore := Ignore}) ->
+    IgnoreRegExp = lists:map(fun ignore_to_regexp/1, Ignore),
+    Files = elvis_file:find_files(Dirs, Filter, local),
+    FilteredFiles = elvis_file:filter_files(Files, Dirs, Filter, IgnoreRegExp),
+    RuleGroup#{files => FilteredFiles};
 resolve_files(RuleGroup = #{dirs := Dirs, filter := Filter}) ->
     Files = elvis_file:find_files(Dirs, Filter, local),
     RuleGroup#{files => Files};


### PR DESCRIPTION
Add support to ignore files from the elvis.config (see bellow example).

```
[{elvis, [
  {config, [
    #{dirs => ["src", "test"],
      filter => "*.erl",
      ignore => [swirl_ql_lexer, swirl_ql_parser],
      rules => [
        {elvis_style, dont_repeat_yourself, #{min_complexity => 10}},
        {elvis_style, god_modules, #{limit => 25}},
        {elvis_style, invalid_dynamic_call, #{ignore => []}},
        {elvis_style, line_length, #{limit => 80, skip_comments => false}},
        {elvis_style, macro_module_names},
        {elvis_style, macro_names},
        {elvis_style, module_naming_convention, #{regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$", ignore => []}},
        {elvis_style, nesting_level, #{level => 3}},
        {elvis_style, no_behavior_info},
        {elvis_style, no_if_expression},
        {elvis_style, no_spec_with_records},
        {elvis_style, no_tabs},
        {elvis_style, no_trailing_whitespace},
        {elvis_style, operator_spaces, #{rules => [{right, ","}, {right, "++"}, {left, "++"}]}},
        {elvis_style, state_record_and_type},
        {elvis_style, used_ignored_variable}
      ]}
  ]}
]}].
```