### PR TITLE
[#371] [Fix inaka/elvis#371] Move deps to app.src

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ DEP_PLUGINS = inaka_mk hexer_mk
 
 dep_lager       = git https://github.com/basho/lager.git         3.1.0
 dep_zipper      = hex 0.2.0
-dep_katana      = git https://github.com/inaka/erlang-katana.git 0.2.23
 dep_katana_code = git https://github.com/inaka/katana-code.git   0.0.3
 dep_katana_test = git https://github.com/inaka/katana-test.git   0.0.5
 dep_mixer       = git https://github.com/inaka/mixer.git         0.1.5

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = elvis
 
-DEPS = lager zipper katana katana_code
+DEPS = lager zipper katana_code
 TEST_DEPS = katana_test mixer meck
 SHELL_DEPS = sync
 BUILD_DEPS = inaka_mk hexer_mk
@@ -9,7 +9,7 @@ DEP_PLUGINS = inaka_mk hexer_mk
 dep_lager       = git https://github.com/basho/lager.git         3.1.0
 dep_zipper      = hex 0.2.0
 dep_katana      = git https://github.com/inaka/erlang-katana.git 0.2.23
-dep_katana_code = git https://github.com/inaka/katana-code.git   0.0.2
+dep_katana_code = git https://github.com/inaka/katana-code.git   0.0.3
 dep_katana_test = git https://github.com/inaka/katana-test.git   0.0.5
 dep_mixer       = git https://github.com/inaka/mixer.git         0.1.5
 dep_meck        = git https://github.com/eproxus/meck            0.8.4

--- a/src/elvis.app.src
+++ b/src/elvis.app.src
@@ -3,7 +3,7 @@
   [
    {description, "Core library for the Erlang style reviewer"},
    {vsn, "0.2.10"},
-   {applications, [kernel, stdlib, lager, zipper]},
+   {applications, [kernel, stdlib, lager, zipper, katana_code]},
    {modules,
     [
      elvis_core,

--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -51,8 +51,8 @@ find(Pred, Root) ->
            find_options()) ->
     [ktn_code:tree_node()].
 find(Pred, Root, Opts) ->
-    Mode = ktn_maps:get(mode, Opts, node),
-    ZipperMode = ktn_maps:get(traverse, Opts, content),
+    Mode = maps:get(mode, Opts, node),
+    ZipperMode = maps:get(traverse, Opts, content),
     Zipper = code_zipper(Root, ZipperMode),
     Results = find(Pred, Zipper, [], Mode),
     lists:reverse(Results).


### PR DESCRIPTION
In this PR:
- `katana_code` added to app.src
- `katana` removed (it was only used for `ktn_maps` and `maps` already comes with that functionality now)