### PR TITLE
[Fix inaka/elvis#362] Correctly distinguish macros from variables

### DIFF
--- a/src/elvis_rulesets.erl
+++ b/src/elvis_rulesets.erl
@@ -31,6 +31,10 @@ rules(erl_files) ->
   , {elvis_style, no_spec_with_records}
   , {elvis_style, dont_repeat_yourself, #{min_complexity => 10}}
   , {elvis_style, no_debug_call, #{ignore => [elvis, elvis_utils]}}
+  , { elvis_style
+    , variable_naming_convention
+    , #{regex => "^([A-Z][0-9a-zA-Z]*)$"}
+    }
   ];
 rules(makefiles) ->
   [ {elvis_project, no_deps_master_erlang_mk, #{ignore => []}}

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -946,7 +946,7 @@ is_var(Zipper) ->
         var ->
             PrevLocation =
                 case ktn_code:attr(location, zipper:node(Zipper)) of
-                    {L, 1} -> {L-1, 9999};
+                    {L, 1} -> {L - 1, 9999};
                     {L, C} -> {L, C - 1}
                 end,
             case elvis_code:find_token(zipper:root(Zipper), PrevLocation) of

--- a/test/examples/pass_variable_naming_convention.erl
+++ b/test/examples/pass_variable_naming_convention.erl
@@ -13,7 +13,7 @@ should_pass(Should, Pass, Way2Home, Fun1, Fun2) ->
     Should = "Should",
     Pass = "Pass",
     Way2Home = "Way to home",
-    Fun1 = Should ++ Pass,
+Fun1 = Should ++ Pass,
     Fun2 = Fun1 ++ Way2Home.
 
 should_pass() ->

--- a/test/examples/pass_variable_naming_convention.erl
+++ b/test/examples/pass_variable_naming_convention.erl
@@ -1,6 +1,7 @@
 -module(pass_variable_naming_convention).
 
 -export([should_pass/5]).
+-export([should_pass/0, should_pass/1]).
 
 %% CamelCase must be used for variables. Don’t
 %% separate words in variables with _.
@@ -14,3 +15,8 @@ should_pass(Should, Pass, Way2Home, Fun1, Fun2) ->
     Way2Home = "Way to home",
     Fun1 = Should ++ Pass,
     Fun2 = Fun1 ++ Way2Home.
+
+should_pass() ->
+  ?MODULE_STRING.
+
+should_pass(_) -> ?MODULE_STRING.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -449,7 +449,9 @@ verify_max_module_length(_Config) ->
     [_] = elvis_style:max_module_length(ElvisConfig, FileFail, RuleConfig7),
 
     RuleConfig8 = NoCountRuleConfig#{max_length => 3},
-    [] = elvis_style:max_module_length(ElvisConfig, FileFail, RuleConfig8).
+    [] = elvis_style:max_module_length(ElvisConfig, FileFail, RuleConfig8),
+
+    {comment, ""}.
 
 -spec verify_max_function_length(config()) -> any().
 verify_max_function_length(_Config) ->
@@ -504,7 +506,9 @@ verify_max_function_length(_Config) ->
         elvis_style:max_function_length(ElvisConfig, FileFail, RuleConfig9),
 
     RuleConfig10 = NoCountRuleConfig#{max_length => 2},
-    [] = elvis_style:max_function_length(ElvisConfig, FileFail, RuleConfig10).
+    [] = elvis_style:max_function_length(ElvisConfig, FileFail, RuleConfig10),
+
+    {comment, ""}.
 
 -spec verify_no_debug_call(config()) -> any().
 verify_no_debug_call(_Config) ->


### PR DESCRIPTION
[Fix inaka/elvis#362] Correctly distinguish macros from variables