### PR TITLE
Don't crash on rebar3's pkg aliases

### DIFF
--- a/src/elvis_project.erl
+++ b/src/elvis_project.erl
@@ -171,6 +171,8 @@ is_rebar_hex_dep({_AppName, _Vsn})
 is_rebar_hex_dep(_) ->
     false.
 
+is_rebar_not_git_dep({_AppName, {pkg, _OtherName}}, _Regex) ->
+    false;
 is_rebar_not_git_dep({_AppName, {_SCM, Url, _Branch}}, Regex) ->
     nomatch == re:run(Url, Regex, []);
 is_rebar_not_git_dep({_AppName, {_SCM, Url}}, Regex) ->


### PR DESCRIPTION
rebar3 allows dependency declarations like
```
{deps,[
  {rebar, {pkg, rebar_fork}}, % rebar app under a different pkg name
]}
```

elvis crashes at a declaration like this 

```
# rebar.config [FAIL]
Error: 'badarg' while applying rule 'protocol_for_deps_rebar'.
# rebar.config [FAIL]
Error: 'badarg' while applying rule 'protocol_for_deps_rebar'.
```

This fix prevents elvis from crashing and accepts the declaration as valid.