### PR TITLE
Don't automatically strip leading underscore, allow it by regex

### DIFF
--- a/src/elvis_rulesets.erl
+++ b/src/elvis_rulesets.erl
@@ -33,7 +33,7 @@ rules(erl_files) ->
   , {elvis_style, no_debug_call, #{ignore => [elvis, elvis_utils]}}
   , { elvis_style
     , variable_naming_convention
-    , #{regex => "^([A-Z][0-9a-zA-Z]*)$"}
+    , #{regex => "^_?([A-Z][0-9a-zA-Z]*)$"}
     }
   ];
 rules(makefiles) ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -636,14 +636,7 @@ no_nested_try_catch(Config, Target, _RuleConfig) ->
 %% Variables name
 check_variables_name(_Regex, []) -> [];
 check_variables_name(Regex, [Variable | RemainingVars]) ->
-    VariableName = atom_to_list(ktn_code:attr(name, Variable)),
-    %% Replace the leading underline (if any) in the variable name.
-    VariableNameStr = case length(VariableName) of
-        (N) when N > 1 ->
-            [_ | TempStr] = re:replace(VariableName, "^_?", ""),
-            binary_to_list(TempStr);
-        (_) -> VariableName
-    end,
+    VariableNameStr = atom_to_list(ktn_code:attr(name, Variable)),
     case re:run(VariableNameStr, Regex) of
         nomatch when VariableNameStr == "_" ->
             check_variables_name(Regex, RemainingVars);

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -95,7 +95,7 @@ verify_variable_naming_convention(_Config) ->
     ElvisConfig = elvis_config:default(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
-    RuleConfig = #{regex => "^([A-Z][0-9a-zA-Z]*)$"},
+    RuleConfig = #{regex => "^_?([A-Z][0-9a-zA-Z]*)$"},
 
     PathPass = "pass_variable_naming_convention.erl",
     {ok, FilePass} = elvis_test_utils:find_file(SrcDirs, PathPass),


### PR DESCRIPTION
This way, the regex says everything about what is allowed and what is not, and error message shows the real variable name (not stripped). Less confusion, more transparency, and flexibility.