### PR TITLE
Remove Lager as a direct dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,8 +4,7 @@
 %% == Erlang Compiler ==
 
 %% Erlang compiler options
-{erl_opts, [ {parse_transform, lager_transform}
-           , warn_unused_vars
+{erl_opts, [ warn_unused_vars
            , warn_export_all
            , warn_shadow_vars
            , warn_unused_import
@@ -66,8 +65,7 @@
 
 %% == Dependencies ==
 
-{deps, [ {lager, "3.0.2"}
-       , {zipper, "1.0.1"}
+{deps, [ {zipper, "1.0.1"}
        , {katana_code, "0.1.0"}
        ]}.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,14 +3,12 @@
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.7">>},1},
  {<<"katana_code">>,{pkg,<<"katana_code">>,<<"0.1.0">>},0},
  {<<"lager">>,{pkg,<<"lager">>,<<"3.0.2">>},0},
- {<<"zipper">>,
-  {git,"https://github.com/inaka/zipper.git",
-       {ref,"47358be662a6749b5b0b932fc0aaad405f537a1c"}},
-  0}]}.
+ {<<"zipper">>,{pkg,<<"zipper">>,<<"1.0.1">>},0}]}.
 [
 {pkg_hash,[
  {<<"aleppo">>, <<"8DB14CF16BB8C263C14FF4C3F69F64D7C849D40888944F4204D2CA74F1114CEB">>},
  {<<"goldrush">>, <<"349A351D17C71C2FDAA18A6C2697562ABE136FEC945F147B381F0CF313160228">>},
  {<<"katana_code">>, <<"C34F3926A258D6BEACD8D21F140F3D47D175501936431C460B144339D5271A0B">>},
- {<<"lager">>, <<"25DC81BC3659B62F5AB9BD073E97DDD894FC4C242019FCCEF96F3889D7366C97">>}]}
+ {<<"lager">>, <<"25DC81BC3659B62F5AB9BD073E97DDD894FC4C242019FCCEF96F3889D7366C97">>},
+ {<<"zipper">>, <<"3CCB4F14B97C06B2749B93D8B6C204A1ECB6FAFC6050CACC3B93B9870C05952A">>}]}
 ].

--- a/src/elvis.app.src
+++ b/src/elvis.app.src
@@ -4,7 +4,7 @@
    {pkg_name, elvis_core},
    {description, "Core library for the Erlang style reviewer"},
    {vsn, "0.3.2"},
-   {applications, [kernel, stdlib, lager, zipper, katana_code]},
+   {applications, [kernel, stdlib, zipper, katana_code]},
    {modules,
     [
      elvis_core,

--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -182,7 +182,7 @@ print_node(Node = #{type := Type}, CurrentLevel) ->
     Indentation = lists:duplicate(CurrentLevel * 4, $ ),
     Content = ktn_code:content(Node),
 
-    ok = lager:info("~s - [~p] ~p~n", [Indentation, CurrentLevel, Type]),
+    ok = elvis_utils:info("~s - [~p] ~p~n", [Indentation, CurrentLevel, Type]),
     _ = lists:map(fun(Child) -> print_node(Child, CurrentLevel + 1) end,
                      Content),
     ok.

--- a/src/elvis_utils.erl
+++ b/src/elvis_utils.erl
@@ -150,6 +150,7 @@ error_prn(Message, Args) ->
     ColoredMessage = "{{red}}Error: {{reset}}" ++ Message ++ "{{reset}}~n",
     print(ColoredMessage, Args).
 
+-spec print(string(), [term()]) -> ok.
 print(Message, Args) ->
     case application:get_env(elvis, no_output) of
         {ok, true} -> ok;


### PR DESCRIPTION
Change the sole call to `lager:info` into `elvis_utils:info`

This is the elvis_core parallel to inaka/elvis#411
