### PR TITLE
Add rule to disallow using seqbind

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -23,7 +23,8 @@
          max_module_length/3,
          max_function_length/3,
          no_debug_call/3,
-         no_nested_try_catch/3
+         no_nested_try_catch/3,
+         no_seqbind/3
         ]).
 
 -define(LINE_LENGTH_MSG, "Line ~p is too long: ~s.").
@@ -113,6 +114,9 @@
 
 -define(NO_NESTED_TRY_CATCH,
         "Nested try...catch block starting at line ~p.").
+
+-define(NO_SEQBIND,
+        "Declaration of seqbind at line ~p.").
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Rules
@@ -1182,3 +1186,25 @@ check_nested_try_catchs(ResultFun, TryExp) ->
                              false
                     end,
                     elvis_code:find(Predicate, TryExp)).
+
+
+
+%% Disallow `-compile({parse_trans, seqbind})`
+no_seqbind(Config, Target, _RuleConfig) ->
+    {Root, _} = elvis_file:parse_tree(Config, Target),
+    ResultFun = result_node_line_fun(?NO_SEQBIND),
+    SeqbindDecls = elvis_code:find(fun is_seqbind_declaration/1, Root),
+    lists:map(ResultFun, SeqbindDecls).
+
+
+is_seqbind_declaration(Node) ->
+    case ktn_code:type(Node) of
+        compile -> declares_seqbind(ktn_code:attr(value, Node));
+        _ -> false
+    end.
+
+
+declares_seqbind(Decls) when is_list(Decls) ->
+    lists:keyfind(parse_transform, 1, Decls) =:= {parse_transform, seqbind};
+declares_seqbind(Singleton) ->
+    Singleton =:= {parse_transform, seqbind}.


### PR DESCRIPTION
seqbind [1] is a parse transform for Erlang that allows the programmer
to assign to "the same variable" multiples times, e.g.,

```erlang
X@ = 10,
X@ = X@ + 1.
```

Although this transform can be useful at times, even its author
recommends using it sparingly since it obscures the functional nature of
Erlang, and can look quite ugly.

This commit adds an elvis_style rule to detect when a module declares
its intention to use seqbind.

[1] https://github.com/spawngrid/seqbind