### PR TITLE
Bump elvis_core version from 0.3.4 to 0.3.5

### DIFF
--- a/src/elvis.app.src
+++ b/src/elvis.app.src
@@ -3,7 +3,7 @@
   [
    {pkg_name, elvis_core},
    {description, "Core library for the Erlang style reviewer"},
-   {vsn, "0.3.4"},
+   {vsn, "0.3.5"},
    {applications, [kernel, stdlib, lager, zipper, katana_code]},
    {modules,
     [


### PR DESCRIPTION
Bumping elvis_core version to 0.3.5

Could someone also publish a new package to HEX? I can then create a PR towards Elvis to use the latest package since elvis is still running on 0.3.2