### PR TITLE
Handle Hex deps with package name

### DIFF
--- a/src/elvis_project.erl
+++ b/src/elvis_project.erl
@@ -166,6 +166,11 @@ is_rebar_master_dep(_) ->
     false.
 is_rebar_hex_dep(_AppName) when is_atom(_AppName) ->
     true;
+is_rebar_hex_dep({_AppName, _Vsn, {pkg, _PackageName}})
+  when is_atom(_AppName),
+       is_list(_Vsn),
+       is_atom(_PackageName) ->
+    true;
 is_rebar_hex_dep({_AppName, _Vsn})
   when is_atom(_AppName),
        is_list(_Vsn) ->

--- a/test/examples/rebar3.config.success
+++ b/test/examples/rebar3.config.success
@@ -1,6 +1,7 @@
 {deps,
  [
   {lager, "2.1.1"},
+  {uuid, "1.7.0", {pkg, uuid_erl}},
   {meck, "0.8.2", {git, "https://github.com/basho/meck.git", {tag, "0.8.2"}}},
   {jiffy, {git, "https://github.com/davisp/jiffy.git"}},
   recon


### PR DESCRIPTION
Adds support for hex dependencies that specify a package name, like:

`{uuid, "1.7.0", {pkg, uuid_erl}}`