### PR TITLE
add verbosity config option, output only errors unless set

### DIFF
--- a/config/test.pass.config
+++ b/config/test.pass.config
@@ -1,0 +1,15 @@
+[ % this check passes
+ {
+   elvis,
+   [
+    {config,
+     [#{dirs => ["../../_build/test/lib/elvis/test/examples"],
+        filter => "**.erl",
+        rules => [{elvis_style, line_length, #{limit => 800}]
+       }]
+    },
+    {output_format, plain}
+   ]
+ }
+].
+

--- a/src/elvis_result.erl
+++ b/src/elvis_result.erl
@@ -1,5 +1,7 @@
 -module(elvis_result).
 
+-compile({no_auto_import, [error/2]}).
+
 %% API
 -export([
          new/3,
@@ -112,22 +114,22 @@ print([Result | Results]) ->
 %% File
 print(#{file := File, rules := Rules}) ->
     Path = elvis_file:path(File),
-    Status = case status(Rules) of
-                 ok -> "{{green-bold}}OK";
-                 fail -> "{{red-bold}}FAIL"
-             end,
-
-    elvis_utils:notice("# ~s [~s{{white-bold}}]", [Path, Status]),
+    case status(Rules) of
+        ok ->
+          elvis_utils:notice("# ~s [{{green-bold}}OK{{white-bold}}]", [Path]);
+        fail ->
+          elvis_utils:error("# ~s [{{red-bold}}FAIL{{white-bold}}]", [Path])
+    end,
     print(Rules);
 %% Rule
 print(#{items := []}) ->
     ok;
 print(#{name := Name, items := Items}) ->
-    elvis_utils:notice("  - ~s", [atom_to_list(Name)]),
+    elvis_utils:error("  - ~s", [atom_to_list(Name)]),
     print(Items);
 %% Item
 print(#{message := Msg, info := Info}) ->
-    elvis_utils:notice("    - " ++ Msg, Info);
+    elvis_utils:error("    - " ++ Msg, Info);
 %% Error
 print(#{error_msg := Msg, info := Info}) ->
     elvis_utils:error_prn(Msg, Info).

--- a/src/elvis_utils.erl
+++ b/src/elvis_utils.erl
@@ -1,5 +1,7 @@
 -module(elvis_utils).
 
+-compile({no_auto_import, [error/2]}).
+
 -export([
          %% Rules
          check_lines/3,
@@ -16,6 +18,8 @@
          info/2,
          notice/1,
          notice/2,
+         error/1,
+         error/2,
          error_prn/1,
          error_prn/2,
          parse_colors/1
@@ -129,7 +133,7 @@ info(Message) ->
 -spec info(string(), [term()]) -> ok.
 info(Message, Args) ->
     ColoredMessage = Message ++ "{{reset}}~n",
-    print(ColoredMessage, Args).
+    print_info(ColoredMessage, Args).
 
 -spec notice(string()) -> ok.
 notice(Message) ->
@@ -138,8 +142,16 @@ notice(Message) ->
 -spec notice(string(), [term()]) -> ok.
 notice(Message, Args) ->
     ColoredMessage = "{{white-bold}}" ++ Message ++ "{{reset}}~n",
-    print(ColoredMessage, Args).
+    print_info(ColoredMessage, Args).
 
+-spec error(string()) -> ok.
+error(Message) ->
+    error(Message, []).
+
+-spec error(string(), [term()]) -> ok.
+error(Message, Args) ->
+    ColoredMessage = "{{white-bold}}" ++ Message ++ "{{reset}}~n",
+    print(ColoredMessage, Args).
 
 -spec error_prn(string()) -> ok.
 error_prn(Message) ->
@@ -149,6 +161,13 @@ error_prn(Message) ->
 error_prn(Message, Args) ->
     ColoredMessage = "{{red}}Error: {{reset}}" ++ Message ++ "{{reset}}~n",
     print(ColoredMessage, Args).
+
+-spec print_info(string(), [term()]) -> ok.
+print_info(Message, Args) ->
+    case application:get_env(elvis, verbose) of
+        {ok, true} -> print(Message, Args);
+        _ -> ok
+    end.
 
 -spec print(string(), [term()]) -> ok.
 print(Message, Args) ->


### PR DESCRIPTION
`elvis_utils:print_info` will be suppressed when `verbose` is _not_ set. `elvis_utils:error` can only be suppressed by setting `no_output`.