### PR TITLE
[Fix #450] Fix encoding issue for elvis_file:src/1

### DIFF
--- a/config/test.pass.config
+++ b/config/test.pass.config
@@ -5,7 +5,7 @@
     {config,
      [#{dirs => ["../../_build/test/lib/elvis/test/examples"],
         filter => "**.erl",
-        rules => [{elvis_style, line_length, #{limit => 800}]
+        rules => [{elvis_style, line_length, #{limit => 800}}]
        }]
     },
     {output_format, plain}

--- a/rebar.config
+++ b/rebar.config
@@ -77,10 +77,8 @@
                         , error_handling
                         ]}
            , {plt_apps, top_level_deps}
-           , {plt_extra_apps, []}
-           , {plt_location, local}
-           , {base_plt_apps, [stdlib, kernel]}
-           , {base_plt_location, global}]}.
+           , {plt_extra_apps, [kernel, stdlib]}
+           , {plt_location, local}]}.
 
 %% == Shell ==
 


### PR DESCRIPTION
- 	Add/fix missing curly brace closure within test configuration file
- 	Fix dialyzer error about missing callback info
> Addresses "Callback info about the gen_server behaviour is not available" dialyzer error.