### PR TITLE
[Fix #468] Add include_dirs/1 to elvis_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![Stories in Ready](https://badge.waffle.io/inaka/elvis.png?label=ready&title=Ready)](https://waffle.io/inaka/elvis)
-
-# elvis-core [![Build Status](https://travis-ci.org/inaka/elvis_core.svg?branch=master)](https://travis-ci.org/inaka/elvis_core)
+# elvis-core [![Build Status](https://travis-ci.org/inaka/elvis_core.svg?branch=master)](https://travis-ci.org/inaka/elvis_core) [![Stories in Ready](https://badge.waffle.io/inaka/elvis.png?label=ready&title=Ready)](https://waffle.io/inaka/elvis)
 
 Erlang style reviewer core library.
 
@@ -151,15 +149,30 @@ also you like to use tabs instead of spaces, so you need to override `erl_files`
 `ruleset` default `rules` as follows:
 
 ```erlang
-...
 #{dirs => ["src"],
   filter => "*.erl",
   rules => [{elvis_style, line_length, #{limit => 90}}, %% change default line_length limit from 100 to 90
             {elvis_style, no_tabs, disable}], %% disable no_tabs rule
   ruleset => erl_files
 },
-...
 ```
+
+You can also `ignore` modules at a _check level_ or at a _ruleset (group of checks) level_:
+- at check level by setting the ignore parameter in the rule you want to skip, e.g:
+  ```erlang
+  {elvis_style, no_debug_call, #{ignore => [elvis, elvis_utils]}}
+  ```
+  There we are telling elvis to **ignore** _elvis_ and _elvis_utils_ modules when running `no_debug_call` check.
+
+- at ruleset level by setting the **ignore** group level option for the group you want to skip, e.g:
+  ```erlang
+  #{dirs => ["src"],
+    filter => "*.erl",
+    ruleset => erl_files,
+    ignore => [module1, module4]
+   }
+  ```
+  With this configuration, none of the checks for [erl_files](https://github.com/inaka/elvis_core/blob/master/src/elvis_rulesets.erl#L6-L34) would be applied to `module1.erl` and `module4.erl` files.
 
 The implementation of a rule is just a function that takes 3 arguments: `elvis`'s
 `config` entry from its [configuration](#configuration); the file to be

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ in the root directory:
    [
     {config,
      [#{dirs => ["src"],
+        include_dirs => ["include"],
         filter => "*.erl",
         ruleset => erl_files
        },
@@ -129,6 +130,9 @@ in the root directory:
  }
 ].
 ```
+
+The `include_dirs` key is just a list of folders (`[string()]`) where to search for
+header files.
 
 The `dirs` key is a list that indicates where `elvis` should look for the
 files that match `filter`, which will be run through each of the default rules

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -8,6 +8,7 @@
          normalize/1,
          %% Geters
          dirs/1,
+         include_dirs/1,
          ignore/1,
          filter/1,
          files/1,
@@ -27,6 +28,7 @@
 -define(DEFAULT_CONFIG_PATH, "./elvis.config").
 -define(DEFAULT_REBAR_CONFIG_PATH, "./rebar.config").
 -define(DEFAULT_FILTER, "*.erl").
+-define(DEFAULT_INCLUDE_DIRS, ["include"]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Public
@@ -115,6 +117,15 @@ dirs(_RuleGroup = #{dirs := Dirs}) ->
     Dirs;
 dirs(#{}) ->
     [].
+
+% Only get `include_dirs' value for erl files RuleGroup, discard other ones.
+-spec include_dirs(Config::config() | map()) -> [string()].
+include_dirs(Config) when is_list(Config) ->
+    lists:flatmap(fun include_dirs/1, Config);
+include_dirs(_RuleGroup = #{include_dirs := IDirs})->
+    IDirs;
+include_dirs(_) ->
+    ?DEFAULT_INCLUDE_DIRS.
 
 -spec ignore(config() | map()) -> [string()].
 ignore(Config) when is_list(Config) ->

--- a/src/elvis_file.erl
+++ b/src/elvis_file.erl
@@ -112,7 +112,7 @@ filter_files(Files, Dirs, Filter, IgnoreList) ->
 -spec resolve_parse_tree(map(), string(), binary()) ->
     undefined | ktn_code:tree_node().
 resolve_parse_tree(Config, ".erl", Content) ->
-    ktn_code:parse_tree(Config, Content);
+    ktn_code:parse_tree(elvis_config:include_dirs(Config), Content);
 resolve_parse_tree(_, _, _) ->
     undefined.
 

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -16,14 +16,15 @@
          rock_with_old_config/1,
          rock_with_rebar_default_config/1,
          rock_this/1,
-         rock_this_not_skipping_files/1,
-         rock_this_skipping_files/1,
          rock_without_colors/1,
          rock_with_no_output_has_no_output/1,
          rock_with_errors_has_output/1,
          rock_without_errors_has_no_output/1,
          rock_without_errors_and_with_verbose_has_output/1,
          rock_with_rule_groups/1,
+         rock_this_skipping_files/1,
+         rock_this_not_skipping_files/1,
+         rock_with_include_dirs/1,
          %% Util & Config
          throw_configuration/1,
          find_file_and_check_src/1,
@@ -271,6 +272,7 @@ rock_with_rule_groups(_Config) ->
            throw:{invalid_config, _} -> fail
        end.
 
+-spec rock_this_skipping_files(Config::config()) -> ok.
 rock_this_skipping_files(_Config) ->
     meck:new(elvis_file, [passthrough]),
     Dirs = ["../../_build/test/lib/elvis/test/examples"],
@@ -280,8 +282,10 @@ rock_this_skipping_files(_Config) ->
     ElvisConfig = elvis_config:load_file(ConfigPath),
     ok = elvis_core:rock_this(Path, ElvisConfig),
     0 = meck:num_calls(elvis_file, load_file_data, '_'),
-    meck:unload(elvis_file).
+    meck:unload(elvis_file),
+    ok.
 
+-spec rock_this_not_skipping_files(Config::config()) -> ok.
 rock_this_not_skipping_files(_Config) ->
     meck:new(elvis_file, [passthrough]),
     Dirs = ["../../_build/test/lib/elvis/test/examples"],
@@ -291,7 +295,61 @@ rock_this_not_skipping_files(_Config) ->
     ElvisConfig = elvis_config:load_file(ConfigPath),
     ok = elvis_core:rock_this(Path, ElvisConfig),
     1 = meck:num_calls(elvis_file, load_file_data, '_'),
-    meck:unload(elvis_file).
+    meck:unload(elvis_file),
+    ok.
+
+-spec rock_with_include_dirs(Config::config()) -> ok.
+rock_with_include_dirs(_Config) ->
+    meck:new(ktn_code, [unstick]),
+    Dirs = ["../../test/examples"],
+    Filter = "small.erl",
+    _ = application:set_env(elvis, verbose, true),
+
+    % Default `include_dirs' value is used when not provided
+    meck:expect(ktn_code,
+                parse_tree,
+                fun(IDirs = ["include"], Content) ->
+                    meck:passthrough([IDirs, Content]);
+                   (_, _) ->
+                    % Received include dirs are different than expected
+                    throw({error, badmatch})
+                end),
+    DefaultConf = [#{dirs => Dirs, filter => Filter, ruleset => erl_files}],
+    % We don't care about checks results
+    _ = elvis_core:rock(DefaultConf),
+    true = meck:validate(ktn_code),
+
+    % Given `include_dirs' are used when provided
+    CustomIDirs = ["path/to/include1", "path/to/include2"],
+    meck:expect(ktn_code,
+                parse_tree,
+                fun(IDirs, Content) ->
+                  case IDirs of
+                    CustomIDirs ->
+                      meck:passthrough([IDirs, Content]);
+                    _ ->
+                      % Received include dirs are different than expected
+                      throw({error, badmatch})
+                  end
+                end),
+    CustomConf = #{dirs => Dirs,
+                   include_dirs => CustomIDirs,
+                   filter => Filter,
+                   ruleset => erl_files},
+    % We don't care about checks results
+    _ = elvis_core:rock([CustomConf]),
+    true = meck:validate(ktn_code),
+
+    % It must fail when the received include_dirs value is different
+    % than expected.
+    _ = elvis_core:rock([CustomConf#{include_dirs => ["unknown/path"]}]),
+    false = meck:validate(ktn_code),
+
+    % Clean up environment
+    _ = application:set_env(elvis, verbose, false),
+    _ = meck:unload(ktn_code),
+    ok.
+
 
 %%%%%%%%%%%%%%%
 %%% Utils


### PR DESCRIPTION
Also:
- Fix call to ktn_code:parse_tree/2
- [Fix inaka/elvis/issues/357] Document group and check level ignore
