### PR TITLE
Support ignore for ignored variable used

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -364,20 +364,20 @@ invalid_dynamic_call(Config, Target, RuleConfig) ->
                             elvis_file:file(),
                             used_ignored_variable_config()) ->
     [elvis_result:item()].
-used_ignored_variable(Config, Target, _RuleConfig) ->
+used_ignored_variable(Config, Target, RuleConfig) ->
     IgnoreModules = maps:get(ignore, RuleConfig, []),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ResultFun = result_node_line_col_fun(?USED_IGNORED_VAR_MSG),
     ModuleName = elvis_code:module_name(Root),
-    
-    case lists:member(ModuleName, IgnoreModules) of 
+
+    case lists:member(ModuleName, IgnoreModules) of
         false ->
             case elvis_code:find(fun is_ignored_var/1, Root, #{mode => zipper}) of
                 [] ->
                     [];
                 UsedIgnoredVars ->
                     lists:map(ResultFun, UsedIgnoredVars)
-            end
+            end;
         true -> []
     end.
 

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -358,18 +358,27 @@ invalid_dynamic_call(Config, Target, RuleConfig) ->
         true -> []
     end.
 
+-type used_ignored_variable_config() :: #{ignore => [module()]}.
+
 -spec used_ignored_variable(elvis_config:config(),
                             elvis_file:file(),
-                            empty_rule_config()) ->
+                            used_ignored_variable_config()) ->
     [elvis_result:item()].
 used_ignored_variable(Config, Target, _RuleConfig) ->
+    IgnoreModules = maps:get(ignore, RuleConfig, []),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ResultFun = result_node_line_col_fun(?USED_IGNORED_VAR_MSG),
-    case elvis_code:find(fun is_ignored_var/1, Root, #{mode => zipper}) of
-        [] ->
-            [];
-        UsedIgnoredVars ->
-            lists:map(ResultFun, UsedIgnoredVars)
+    ModuleName = elvis_code:module_name(Root),
+    
+    case lists:member(ModuleName, IgnoreModules) of 
+        false ->
+            case elvis_code:find(fun is_ignored_var/1, Root, #{mode => zipper}) of
+                [] ->
+                    [];
+                UsedIgnoredVars ->
+                    lists:map(ResultFun, UsedIgnoredVars)
+            end
+        true -> []
     end.
 
 -spec no_behavior_info(elvis_config:config(),

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -358,7 +358,10 @@ verify_used_ignored_variable(_Config) ->
      #{line_num := 13},
      #{line_num := 17},
      #{line_num := 17}
-    ] = elvis_style:used_ignored_variable(ElvisConfig, File, #{}).
+    ] = elvis_style:used_ignored_variable(ElvisConfig, File, #{}),
+    [] = elvis_style:used_ignored_variable(ElvisConfig,
+                                           File,
+                                           #{ignore => [fail_used_ignored_variable]}).
 
 -spec verify_no_behavior_info(config()) -> any().
 verify_no_behavior_info(_Config) ->


### PR DESCRIPTION
This change adds the ability to add a list of ignored modules to the rule ignored_variable_used.

This is needed as elvis will fail on an ignored variable in  a eunit ?assertMatch macro.

```
    ?assertMatch({ok, {a_valid_message, _V}}, fut(Args))
```
Not ignoring the variable will cause the compiler to report a warning instead.
