### PR TITLE
Support for no_call and no_common_caveats

### DIFF
--- a/test/examples/fail_no_call_classes.erl
+++ b/test/examples/fail_no_call_classes.erl
@@ -1,0 +1,16 @@
+-module(fail_no_call_classes).
+-export([fail/0]).
+
+-spec fail() -> any().
+fail() ->
+    _ = timer:send_after(0, fail_after),
+    _ = timer:send_after(0, self(), fail_after),
+
+    _ = timer:send_interval(0, fail_interval),
+    _ = timer:send_interval(0, self(), fail_interval),
+
+    _ = erlang:size({1,2,3}),
+    _ = erlang:size(<<"fail_size">>),
+
+    _ = erlang:tuple_size({1,2,3}),
+    _ = erlang:byte_size(<<"ok_size">>).


### PR DESCRIPTION
A discussed in https://github.com/inaka/elvis/issues/484

I haven't update the docs as yet, but it all has tests and is dialyzer clean.

There is one issue at present, which is that the existing elvis_core code does not recognise calls to size as actually being calls to erlang:size so the test file, somewhat artificially has calls in it to erlang:size (whereas 99% of my code certainly does not usually use the erlang: prefix for this).

Perhaps one to talk through.