### PR TITLE
Add parsable option in order to output results in the dialyzer-like format

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ list of items with the following structure `{Module, Function, RuleConfig}` or
 `disable` certain rules if you want to just by specifying the rule in the `rules`
 key and passing `disable` as its third parameter.
 
+`output_format` is used to configure the output format. Possible values are `colors`,
+`plain` and `parsable`. The latter could be use for the automated parsing and has a
+format very close to dialyzer in a form `FILE:LINE:RULE:MESSAGE`:
+
+```
+src/example.erl:1:god_modules:This module has too many functions (56). Consider breaking it into a number of modules.
+src/example_a.erl:341:no_debug_call:Remove the debug call to io:format/2 on line 341.
+src/example_a.erl:511:used_ignored_variable:Ignored variable is being used on line 511 and column 54.
+src/example_a.erl:1252:used_ignored_variable:Ignored variable is being used on line 1252 and column 21.
+```
+
 **IMPORTANT:** `disable` will only work if you also provided a `ruleset` as shown above.
 
 Let's say you like your files to have a maximum of 90 characters per line and

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -127,7 +127,7 @@ apply_rules(Config, File) ->
     {RulesResults, _, _} = lists:foldl(fun apply_rule/2, Acc, Rules),
 
     Results = elvis_result:new(file, File, RulesResults),
-    elvis_result:print(Results),
+    elvis_result:print_results(Results),
     Results.
 
 apply_rule({Module, Function}, {Result, Config, File}) ->

--- a/src/elvis_result.erl
+++ b/src/elvis_result.erl
@@ -8,7 +8,7 @@
          new/4,
          status/1,
          clean/1,
-         print/1
+         print_results/1
         ]).
 
 -export([
@@ -105,60 +105,64 @@ get_line_num(#{line_num := LineNum}) -> LineNum.
 
 %% Print
 
--spec print(item() | rule() | elvis_error() | [file()]) -> ok.
-print([]) ->
+-spec print_results(file()) -> ok.
+print_results(Results) ->
+    Format = application:get_env(elvis, output_format, colors),
+    print(Format, Results).
+
+-spec print(plain | colors | parsable, [file()] | file()) -> ok.
+print(_, []) ->
     ok;
-print([Result | Results]) ->
-    print(Result),
-    print(Results);
+print(Format, [Result | Results]) ->
+    print(Format, Result),
+    print(Format, Results);
 %% File
-print(#{file := File, rules := Rules}) ->
+print(Format, #{file := File, rules := Rules}) ->
     Path = elvis_file:path(File),
-    case application:get_env(elvis, parsable, false) of
-        false ->
+    case Format of
+        parsable -> ok;
+        _ ->
             case status(Rules) of
                 ok ->
                     elvis_utils:notice("# ~s [{{green-bold}}OK{{white-bold}}]", [Path]);
                 fail ->
                     elvis_utils:error("# ~s [{{red-bold}}FAIL{{white-bold}}]", [Path])
-            end;
-        true ->
-            ok
+            end
     end,
-    print_rules(Path, Rules);
-print(Error) ->
+    print_rules(Format, Path, Rules);
+print(_, Error) ->
     print_error(Error).
 
-print_rules(_File, []) ->
+print_rules(_Format, _File, []) ->
     ok;
-print_rules(File, [#{items := []} | Items]) ->
-    print_rules(File, Items);
-print_rules(File, [#{items := Items, name := Name} | EItems]) ->
-    case application:get_env(elvis, parsable, false) of
-        true -> ok;
-        false->
+print_rules(Format, File, [#{items := []} | Items]) ->
+    print_rules(Format, File, Items);
+print_rules(Format, File, [#{items := Items, name := Name} | EItems]) ->
+    case Format of
+        parsable -> ok;
+        _ ->
             elvis_utils:error("  - ~s", [atom_to_list(Name)])
     end,
-    print_item(File, Name, Items),
-    print_rules(File, EItems);
-print_rules(File, [Error | Items]) ->
+    print_item(Format, File, Name, Items),
+    print_rules(Format, File, EItems);
+print_rules(Format, File, [Error | Items]) ->
     print_error(Error),
-    print_rules(File, Items).
+    print_rules(Format, File, Items).
 
 %% Item
-print_item(File, Name, [#{message := Msg, line_num := Ln, info := Info} | Items]) ->
-    case application:get_env(elvis, parsable, false) of
-        true ->
+print_item(Format, File, Name, [#{message := Msg, line_num := Ln, info := Info} | Items]) ->
+    case Format of
+        parsable ->
             FMsg = io_lib:format(Msg, Info),
             io:format("~s:~p:~p:~s~n", [File, Ln, Name, FMsg]);
-        false->
+        _ ->
             elvis_utils:error("    - " ++ Msg, Info)
     end,
-    print_item(File, Name, Items);
-print_item(File, Name, [Error|Items]) ->
+    print_item(Format, File, Name, Items);
+print_item(Format, File, Name, [Error|Items]) ->
     print_error(Error),
-    print_item(File, Name, Items);
-print_item(_File, _Name, []) ->
+    print_item(Format, File, Name, Items);
+print_item(_Format, _File, _Name, []) ->
     ok.
 
 print_error(#{error_msg := Msg, info := Info}) ->


### PR DESCRIPTION
I added another way to format the output, by providing the parsable env variable, for producing the output, that reminds dialyzer output. (see rationale https://github.com/inaka/elvis/issues/497)

Example of the output:
```
src/example.erl:1:god_modules:This module has too many functions (56). Consider breaking it into a number of modules.
src/example_a.erl:341:no_debug_call:Remove the debug call to io:format/2 on line 341.
src/example_a.erl:511:used_ignored_variable:Ignored variable is being used on line 511 and column 54.
src/example_a.erl:1252:used_ignored_variable:Ignored variable is being used on line 1252 and column 21.
src/example_a.erl:1259:used_ignored_variable:Ignored variable is being used on line 1259 and column 21.
src/example_a.erl:1309:used_ignored_variable:Ignored variable is being used on line 1309 and column 17.
src/example_a.erl:1311:used_ignored_variable:Ignored variable is being used on line 1311 and column 17.
src/other.erl:1:god_modules:This module has too many functions (73). Consider breaking it into a number of modules.
src/other.erl:150:no_spec_with_records:The spec in line 150 uses a record, please define a type for the record and use that instead.

```