### PR TITLE
Rock in parallel

### DIFF
--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -98,7 +98,7 @@ do_parallel_rock(Config0) ->
                               [], [Config], Files, Parallel),
     elvis_result_status(Results).
 
--spec do_rock(elvis_result:file(), elvis_config:config()) -> {ok, elvis_result:file()}.
+-spec do_rock(elvis_file:file(), map() | [map()]) -> {ok, elvis_result:file()}.
 do_rock(File, Config) ->
     LoadedFile = load_file_data(Config, File),
     Results = apply_rules(Config, LoadedFile),

--- a/src/elvis_result.erl
+++ b/src/elvis_result.erl
@@ -12,7 +12,7 @@
         ]).
 
 -export([
-         get_file/1,
+         get_path/1,
          get_rules/1,
          get_name/1,
          get_items/1,
@@ -45,7 +45,7 @@
          }.
 -type file() ::
         #{
-           file => elvis_file:file(),
+           file => string(),
            rules => [rule()]
          }.
 -type elvis_error() ::
@@ -68,8 +68,8 @@ new(item, Msg, Info) ->
     new(item, Msg, Info, 0);
 new(rule, Name, Results) ->
     #{name => Name, items => Results};
-new(file, File, Rules) ->
-    #{file => File, rules => Rules};
+new(file, #{path := Path}, Rules) ->
+    #{file => Path, rules => Rules};
 new(error, Msg, Info) ->
     #{error_msg => Msg, info => Info}.
 
@@ -81,8 +81,8 @@ new(item, Msg, Info, LineNum) ->
 
 %% Getters
 
--spec get_file(file()) -> elvis_file:file().
-get_file(#{file := File}) -> File.
+-spec get_path(file()) -> string().
+get_path(#{file := File}) -> File.
 
 -spec get_rules(file()) -> [rule()].
 get_rules(#{rules := Rules}) -> Rules.
@@ -117,8 +117,7 @@ print(Format, [Result | Results]) ->
     print(Format, Result),
     print(Format, Results);
 %% File
-print(Format, #{file := File, rules := Rules}) ->
-    Path = elvis_file:path(File),
+print(Format, #{file := Path, rules := Rules}) ->
     case Format of
         parsable -> ok;
         _ ->
@@ -193,12 +192,9 @@ clean([], Result) ->
     lists:reverse(Result);
 clean([#{rules := []} | Files], Result) ->
     clean(Files, Result);
-clean([File = #{rules := Rules, file := FileInfo} | Files], Result) ->
+clean([File = #{rules := Rules} | Files], Result) ->
     CleanRules = clean(Rules),
-    FileInfo1 = maps:remove(content, FileInfo),
-    FileInfo2 = maps:remove(parse_tree, FileInfo1),
-    NewFile = File#{rules => CleanRules,
-                    file => FileInfo2},
+    NewFile = File#{rules => CleanRules},
     clean(Files, [NewFile | Result]);
 clean([#{items := []} | Rules], Result) ->
     clean(Rules, Result);

--- a/src/elvis_task.erl
+++ b/src/elvis_task.erl
@@ -12,7 +12,7 @@
                                       Acc :: term()),
                  InitialAcc :: term(),
                  ExtraArgs :: list(),
-                 JonItemList :: list(),
+                 JoinItemList :: list(),
                  Concurrency :: non_neg_integer()) ->
                         {ok, FinalAcc :: term()} | {error, term()}.
 chunk_fold({M,F} = FunWork, FunAcc, InitialAcc, ExtraArgs, List, ChunkSize)
@@ -53,6 +53,7 @@ start_worker(FunWork, ExtraArgs, Arg) ->
     Key = spawn_monitor(fun() -> do_work(Parent, FunWork, ExtraArgs, Arg) end),
     Key.
 
+-spec do_work(pid(), {module(), atom()}, list(), term()) -> no_return().
 do_work(Parent, {M,F}, ExtraArgs, Arg) ->
     try erlang:apply(M, F, [Arg | ExtraArgs]) of
         {ok, Results} ->
@@ -88,7 +89,7 @@ accumulate(AccF, AccR, Res, AccG) ->
         {ok, AccR1} = AccF(Res, AccR),
         AccR1
     catch T:E ->
-            cleanup(AccG),
+            _ = cleanup(AccG),
             throw({T,E})
     end.
 
@@ -107,7 +108,7 @@ gather(Timeout, AccG) ->
                 {ok, Res0} ->
                     {AccG1, Res0};
                 {error, {T,E}} ->
-                    cleanup(AccG1),
+                    _ = cleanup(AccG1),
                     throw({T,E})
             end
     after Timeout ->

--- a/src/elvis_task.erl
+++ b/src/elvis_task.erl
@@ -1,0 +1,115 @@
+-module(elvis_task).
+
+-export([chunk_fold/6]).
+
+%% @doc chunk_fold evaluates apply(Module, Function, [Elem|ExtrArgs]) for
+%% every element Elem in JobItemList in parallel with max concurrcy factor
+%% equal to Concurrency. On succesfull evaluation FunAcc function is called
+%% with the result of succesfull execution as a first parametr and accumulator
+%% as a second parametr.
+-spec chunk_fold(FunWork :: {Module :: module(), Function :: atom()},
+                 FunAcc :: fun((NewElem :: term(), Acc :: term()) ->
+                                      Acc :: term()),
+                 InitialAcc :: term(),
+                 ExtraArgs :: list(),
+                 JonItemList :: list(),
+                 Concurrency :: non_neg_integer()) ->
+                        {ok, FinalAcc :: term()} | {error, term()}.
+chunk_fold({M,F} = FunWork, FunAcc, InitialAcc, ExtraArgs, List, ChunkSize)
+ when is_atom(M), is_atom(F),
+      is_function(FunAcc, 2),
+      is_list(ExtraArgs), is_list(List),
+      is_integer(ChunkSize) andalso ChunkSize > 0
+      ->
+    try
+        Term = do_in_parallel(FunWork, FunAcc, ExtraArgs, List,
+                              _MaxW = ChunkSize, _RemainW = ChunkSize,
+                              InitialAcc, []),
+        {ok, Term}
+    catch throw:{T,E} ->
+            {error, {T, E}}
+    end.
+
+do_in_parallel(_FunWork, FunAcc, _ExtraArgs, [], _MaxW, _RemainW, AccR, AccG) ->
+    gather_all_results(FunAcc, AccR, AccG);
+do_in_parallel(FunWork, FunAcc, ExtraArgs, List, MaxW, 0, AccR, AccG) ->
+    {AccR1, AccG1, N} = gather_results(FunAcc, AccR, AccG),
+    do_in_parallel(FunWork, FunAcc, ExtraArgs, List,
+                      MaxW, erlang:min(N, MaxW), AccR1, AccG1);
+do_in_parallel(FunWork, FunAcc, ExtraArgs, List, MaxW, RemainW, AccR, AccG) ->
+    {WorkToBeDone, WorkRemain} =
+        try lists:split(RemainW, List) of
+            Res -> Res
+        catch error:badarg -> {List, []}
+        end,
+
+    WrkRefs = [start_worker(FunWork, ExtraArgs, WorkPiece)
+              || WorkPiece <- WorkToBeDone],
+    do_in_parallel(FunWork, FunAcc, ExtraArgs, WorkRemain, MaxW, 0,
+                      AccR, WrkRefs ++ AccG).
+
+start_worker(FunWork, ExtraArgs, Arg) ->
+    Parent = self(),
+    Key = spawn_monitor(fun() -> do_work(Parent, FunWork, ExtraArgs, Arg) end),
+    Key.
+
+do_work(Parent, {M,F}, ExtraArgs, Arg) ->
+    try erlang:apply(M, F, [Arg | ExtraArgs]) of
+        {ok, Results} ->
+            exit({Parent, {ok, Results}});
+        Unexpected ->
+            Error = {error, {badreturn, Unexpected}},
+            exit({Parent, {error, Error}})
+    catch T:E ->
+            exit({Parent, {error, {T,E}}})
+    end.
+
+gather_all_results(AccF, AccR, Remain) ->
+    {AccR1, _, _} = gather_results0(AccF, AccR, Remain, 0, infinity),
+    AccR1.
+
+gather_results(AccF, AccR, AccG) ->
+    {AccG1, Res} = gather(infinity, AccG),
+    AccR1 = accumulate(AccF, AccR, Res, AccG1),
+    gather_results0(AccF, AccR1, AccG1, 1, 0).
+
+gather_results0(_AccF, AccR, [], N, _Timeout) ->
+    {AccR, [], N};
+gather_results0(AccF, AccR, AccG, N, Timeout) ->
+    case gather(Timeout, AccG) of
+        timeout -> {AccR, AccG, N};
+        {AccG1, Res} ->
+            AccR1 = accumulate(AccF, AccR, Res, AccG1),
+            gather_results0(AccF, AccR1, AccG1, N + 1, Timeout)
+    end.
+
+accumulate(AccF, AccR, Res, AccG) ->
+    try
+        {ok, AccR1} = AccF(Res, AccR),
+        AccR1
+    catch T:E ->
+            cleanup(AccG),
+            throw({T,E})
+    end.
+
+cleanup(AccG) ->
+    [ begin
+          erlang:demonitor(MRef, [flush]),
+          erlang:exit(Pid, kill)
+      end || {Pid, MRef} <- AccG ].
+
+gather(Timeout, AccG) ->
+    Self = self(),
+    receive
+        {'DOWN', _MonRef, process, Pid, {Self, Res}} ->
+            AccG1 = lists:keydelete(Pid, 1, AccG),
+            case Res of
+                {ok, Res0} ->
+                    {AccG1, Res0};
+                {error, {T,E}} ->
+                    cleanup(AccG1),
+                    throw({T,E})
+            end
+    after Timeout ->
+            timeout
+    end.

--- a/src/elvis_utils.erl
+++ b/src/elvis_utils.erl
@@ -191,7 +191,8 @@ parse_colors(Message) ->
                "reset" => "\e[0m"},
     Opts = [global, {return, list}],
     case application:get_env(elvis, output_format, colors) of
-        plain ->
+        P when P =:= plain orelse
+               P =:= parsable ->
             re:replace(Message, "{{.*?}}", "", Opts);
         colors ->
             Fun = fun(Key, Acc) ->

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -444,8 +444,8 @@ chunk_fold(_Config) ->
 
 
 -spec chunk_fold_task(integer(), integer()) -> {ok, integer()}.
-chunk_fold_task(Elem, Miltiplier) ->
-    {ok, Elem * Miltiplier}.
+chunk_fold_task(Elem, Multiplier) ->
+    {ok, Elem * Multiplier}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Private


### PR DESCRIPTION
Implement parallel processing of the files. Option 'parallel'
takes pos integer as a number of processes allowed to run in
parallel, default to 1, to keep current behaviour.
    
Drop most of the file section from the result, and split loading
phase to reduce memory consumption and speed up gathering of the
results.

Some results, based on the https://github.com/basho/riak_core.git
Config:
```
$ cat elvis.config 
[
 {
   elvis,
   [
    {config,
     [#{dirs => ["src"],
        include_dirs => ["include"],
        filter => "*.erl",
        ruleset => erl_files
       }
     ]
    },
    %% Optional to select the output format, the default is colors
    {output_format, parsable}
   ]
 }
].
```
1) Before the change (current master):
```
riak_core$ time ../elvis/_build/default/bin/elvis rock > elvis.log

real	0m30.834s
user	0m30.711s
sys	0m1.371s
```
2) After the change, single process version:
```
riak_core$ time ../elvis/_build/default/bin/elvis rock > elvis.log

real	0m10.907s
user	0m11.523s
sys	0m0.257s
```
3) After the change, auto option (4 procs)
```
riak_core$ time ../elvis/_build/default/bin/elvis -p auto rock > elvis.log

real	0m5.933s
user	0m20.865s
sys	0m0.321s
```

