### PR TITLE
treat FUNCTION_NAME as valid variable

### DIFF
--- a/src/elvis_rulesets.erl
+++ b/src/elvis_rulesets.erl
@@ -33,7 +33,7 @@ rules(erl_files) ->
   , {elvis_style, no_debug_call, #{ignore => [elvis, elvis_utils]}}
   , { elvis_style
     , variable_naming_convention
-    , #{regex => "^_?([A-Z][0-9a-zA-Z]*)$"}
+    , #{regex => "^_?([A-Z][0-9a-zA-Z]*)$|^FUNCTION_NAME$"}
     }
   , {elvis_style, no_nested_try_catch}
   ];


### PR DESCRIPTION
Embedded macros might not expand the FUNCTION_NAME macro and it will be
treated as variable. Let's accept it.

Fixes inaka/elvis#505