### PR TITLE
[inaka/elvis#425] Rename application to elvis_core

### DIFF
--- a/config/elvis.config
+++ b/config/elvis.config
@@ -3,7 +3,7 @@
    elvis,
    [
     {config,
-     [#{dirs => ["src"],
+     [#{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
         filter => "*.erl",
         ruleset => erl_files
        },

--- a/config/rebar.config
+++ b/config/rebar.config
@@ -8,7 +8,7 @@
 {elvis,
  [
   {config,
-   [#{dirs => ["../../_build/test/lib/elvis/test/examples"],
+   [#{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
       filter => "**.erl",
       rules => [{elvis_style, line_length, #{limit => 135}}]
      }

--- a/config/test.config
+++ b/config/test.config
@@ -1,9 +1,9 @@
 [
  {
-   elvis,
+   elvis_core,
    [
     {config,
-     [#{dirs => ["../../_build/test/lib/elvis/test/examples"],
+     [#{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
         filter => "**.erl",
         rules => [{elvis_style, line_length, #{limit => 80,
                                                skip_comments => false}},

--- a/config/test.pass.config
+++ b/config/test.pass.config
@@ -3,7 +3,7 @@
    elvis,
    [
     {config,
-     [#{dirs => ["../../_build/test/lib/elvis/test/examples"],
+     [#{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
         filter => "**.erl",
         rules => [{elvis_style, line_length, #{limit => 800}}]
        }]
@@ -12,4 +12,3 @@
    ]
  }
 ].
-

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -1,8 +1,7 @@
 -module(elvis_config).
 
--export([ default/0
-        , load_file/1
-        , load/1
+-export([ from_rebar/1
+        , from_file/1
         , validate/1
         , normalize/1
           %% Geters
@@ -21,45 +20,33 @@
 
 -type config() :: [map()].
 
--define(DEFAULT_CONFIG_PATH, "./elvis.config").
--define(DEFAULT_REBAR_CONFIG_PATH, "./rebar.config").
 -define(DEFAULT_FILTER, "*.erl").
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Public
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec default() -> config().
-default() ->
-    case file:consult(?DEFAULT_CONFIG_PATH) of
-        {ok, [Config]} ->
-            load(Config);
-        {error, enoent} ->
-            case file:consult(?DEFAULT_REBAR_CONFIG_PATH) of
-                {ok, Config} ->
-                    load(Config);
-                {error, enoent} ->
-                    Config = application:get_env(elvis_core, config, []),
-                    ensure_config_list(Config);
-                {error, Reason} ->
-                    throw(Reason)
-            end;
+-spec from_rebar(string()) -> config().
+from_rebar(Path) ->
+    case file:consult(Path) of
+        {ok, Config} ->
+            load(elvis, Config);
         {error, Reason} ->
             throw(Reason)
     end.
 
--spec load_file(string()) -> config().
-load_file(Path) ->
+-spec from_file(string()) -> config().
+from_file(Path) ->
     case file:consult(Path) of
         {ok, [Config]} ->
-            load(Config);
+            load(elvis, Config);
         {error, Reason} ->
             throw(Reason)
     end.
 
--spec load(term()) -> config().
-load(AppConfig) ->
-    ElvisConfig = proplists:get_value(elvis, AppConfig, []),
+-spec load(atom(), term()) -> config().
+load(Key, AppConfig) ->
+    ElvisConfig = proplists:get_value(Key, AppConfig, []),
     Config =  proplists:get_value(config, ElvisConfig, []),
     ensure_config_list(Config).
 

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -1,34 +1,29 @@
 -module(elvis_config).
 
--export([
-         default/0,
-         load_file/1,
-         load/1,
-         validate/1,
-         normalize/1,
-         %% Geters
-         dirs/1,
-         include_dirs/1,
-         ignore/1,
-         filter/1,
-         files/1,
-         rules/1,
-         %% Files
-         resolve_files/1,
-         resolve_files/2,
-         apply_to_files/2
+-export([ default/0
+        , load_file/1
+        , load/1
+        , validate/1
+        , normalize/1
+          %% Geters
+        , dirs/1
+        , ignore/1
+        , filter/1
+        , files/1
+        , rules/1
+          %% Files
+        , resolve_files/1
+        , resolve_files/2
+        , apply_to_files/2
         ]).
 
--export_type([
-              config/0
-             ]).
+-export_type([config/0]).
 
 -type config() :: [map()].
 
 -define(DEFAULT_CONFIG_PATH, "./elvis.config").
 -define(DEFAULT_REBAR_CONFIG_PATH, "./rebar.config").
 -define(DEFAULT_FILTER, "*.erl").
--define(DEFAULT_INCLUDE_DIRS, ["include"]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Public
@@ -117,15 +112,6 @@ dirs(_RuleGroup = #{dirs := Dirs}) ->
     Dirs;
 dirs(#{}) ->
     [].
-
-% Only get `include_dirs' value for erl files RuleGroup, discard other ones.
--spec include_dirs(Config::config() | map()) -> [string()].
-include_dirs(Config) when is_list(Config) ->
-    lists:flatmap(fun include_dirs/1, Config);
-include_dirs(_RuleGroup = #{include_dirs := IDirs})->
-    IDirs;
-include_dirs(_) ->
-    ?DEFAULT_INCLUDE_DIRS.
 
 -spec ignore(config() | map()) -> [string()].
 ignore(Config) when is_list(Config) ->

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -44,7 +44,7 @@ default() ->
                 {ok, Config} ->
                     load(Config);
                 {error, enoent} ->
-                    Config = application:get_env(elvis, config, []),
+                    Config = application:get_env(elvis_core, config, []),
                     ensure_config_list(Config);
                 {error, Reason} ->
                     throw(Reason)

--- a/src/elvis_core.app.src
+++ b/src/elvis_core.app.src
@@ -1,5 +1,5 @@
 {
-  application, elvis,
+  application, elvis_core,
   [
    {pkg_name, elvis_core},
    {description, "Core library for the Erlang style reviewer"},

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -14,8 +14,6 @@
 %% for internal use only
 -export([do_rock/2]).
 
--define(APP_NAME, "elvis").
-
 -type source_filename() :: nonempty_string().
 -type target() :: source_filename() | module().
 
@@ -26,7 +24,7 @@
 %% @doc Used when starting the application on the shell.
 -spec start() -> ok.
 start() ->
-    {ok, _} = application:ensure_all_started(elvis),
+    {ok, _} = application:ensure_all_started(elvis_core),
     ok.
 
 %%% Rock Command
@@ -85,7 +83,7 @@ rock_this(Path, Config) ->
 %% @private
 -spec do_parallel_rock(map()) -> ok | {fail, [elvis_result:file() | elvis_result:rule()]}.
 do_parallel_rock(Config0) ->
-    Parallel = application:get_env(elvis, parallel, 1),
+    Parallel = application:get_env(elvis_core, parallel, 1),
     Config = elvis_config:resolve_files(Config0),
     Files = elvis_config:files(Config),
 

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -2,11 +2,8 @@
 
 %% Public API
 
--export([
-         rock/0,
-         rock/1,
-         rock_this/1,
-         rock_this/2
+-export([ rock/1
+        , rock_this/2
         ]).
 
 -export([start/0]).
@@ -29,23 +26,12 @@ start() ->
 
 %%% Rock Command
 
--spec rock() -> ok | {fail, [elvis_result:file()]}.
-rock() ->
-    Config = elvis_config:default(),
-    rock(Config).
-
 -spec rock(elvis_config:config()) -> ok | {fail, [elvis_result:file()]}.
 rock(Config) ->
     ok = elvis_config:validate(Config),
     NewConfig = elvis_config:normalize(Config),
     Results = lists:map(fun do_parallel_rock/1, NewConfig),
     lists:foldl(fun combine_results/2, ok, Results).
-
--spec rock_this(target()) ->
-    ok | {fail, [elvis_result:file() | elvis_result:rule()]}.
-rock_this(Target) ->
-    Config = elvis_config:default(),
-    rock_this(Target, Config).
 
 -spec rock_this(target(), elvis_config:config()) ->
     ok | {fail, [elvis_result:file() | elvis_result:rule()]}.

--- a/src/elvis_result.erl
+++ b/src/elvis_result.erl
@@ -107,7 +107,7 @@ get_line_num(#{line_num := LineNum}) -> LineNum.
 
 -spec print_results(file()) -> ok.
 print_results(Results) ->
-    Format = application:get_env(elvis, output_format, colors),
+    Format = application:get_env(elvis_core, output_format, colors),
     print(Format, Results).
 
 -spec print(plain | colors | parsable, [file()] | file()) -> ok.

--- a/src/elvis_utils.erl
+++ b/src/elvis_utils.erl
@@ -164,14 +164,14 @@ error_prn(Message, Args) ->
 
 -spec print_info(string(), [term()]) -> ok.
 print_info(Message, Args) ->
-    case application:get_env(elvis, verbose) of
+    case application:get_env(elvis_core, verbose) of
         {ok, true} -> print(Message, Args);
         _ -> ok
     end.
 
 -spec print(string(), [term()]) -> ok.
 print(Message, Args) ->
-    case application:get_env(elvis, no_output) of
+    case application:get_env(elvis_core, no_output) of
         {ok, true} -> ok;
         _ ->
             Output = io_lib:format(Message, Args),
@@ -190,7 +190,7 @@ parse_colors(Message) ->
                "white-bold" => "\e[1;37m",
                "reset" => "\e[0m"},
     Opts = [global, {return, list}],
-    case application:get_env(elvis, output_format, colors) of
+    case application:get_env(elvis_core, output_format, colors) of
         P when P =:= plain orelse
                P =:= parsable ->
             re:replace(Message, "{{.*?}}", "", Opts);

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -58,12 +58,12 @@ all() ->
 
 -spec init_per_suite(config()) -> config().
 init_per_suite(Config) ->
-    {ok, _} = application:ensure_all_started(elvis),
+    {ok, _} = application:ensure_all_started(elvis_core),
     Config.
 
 -spec end_per_suite(config()) -> config().
 end_per_suite(Config) ->
-    ok = application:stop(elvis),
+    ok = application:stop(elvis_core),
     Config.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -195,8 +195,8 @@ rock_without_colors(_Config) ->
 
 -spec rock_with_parsable(config()) -> ok.
 rock_with_parsable(_Config) ->
-    {ok, Default} = application:get_env(elvis, output_format),
-    application:set_env(elvis, output_format, parsable),
+    {ok, Default} = application:get_env(elvis_core, output_format),
+    application:set_env(elvis_core, output_format, parsable),
     ConfigPath = "../../config/test.config",
     ElvisConfig = elvis_config:load_file(ConfigPath),
     Fun = fun() -> elvis_core:rock(ElvisConfig) end,
@@ -208,17 +208,17 @@ rock_with_parsable(_Config) ->
              _:{badmatch, []} ->
                  ct:fail("Unexpected result ~p")
          after
-             application:set_env(elvis, output_format, Default)
+             application:set_env(elvis_core, output_format, Default)
          end.
 
 -spec rock_with_no_output_has_no_output(config()) -> ok.
 rock_with_no_output_has_no_output(_Config) ->
-    application:set_env(elvis, no_output, true),
+    application:set_env(elvis_core, no_output, true),
     ConfigPath = "../../config/test.config",
     ElvisConfig = elvis_config:load_file(ConfigPath),
     Fun = fun() -> elvis_core:rock(ElvisConfig) end,
     [] = check_no_line_output(Fun),
-    application:unset_env(elvis, no_output),
+    application:unset_env(elvis_core, no_output),
     ok.
 
 -spec rock_with_errors_has_output(config()) -> ok.
@@ -240,13 +240,13 @@ rock_without_errors_has_no_output(_Config) ->
 
 -spec rock_without_errors_and_with_verbose_has_output(config()) -> ok.
 rock_without_errors_and_with_verbose_has_output(_Config) ->
-    application:set_env(elvis, verbose, true),
+    application:set_env(elvis_core, verbose, true),
     ConfigPath = "../../config/test.pass.config",
     ElvisConfig = elvis_config:load_file(ConfigPath),
     Fun = fun() -> elvis_core:rock(ElvisConfig) end,
     Expected = "OK",
     [_|_] = check_some_line_output(Fun, Expected, fun matches_regex/2),
-    application:unset_env(elvis, verbose),
+    application:unset_env(elvis_core, verbose),
     ok.
 
 -spec rock_with_rule_groups(Config::config()) -> ok.

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -122,8 +122,10 @@ rock_with_list_config(_Config) ->
 
 -spec rock_with_file_config(config()) -> ok.
 rock_with_file_config(_Config) ->
-    Fun = fun() -> elvis_core:rock() end,
-    Expected = "# \\.\\./\\.\\./_build/test/lib/elvis/test/" ++
+    ConfigPath = "../../config/elvis.config",
+    ElvisConfig = elvis_config:from_file(ConfigPath),
+    Fun = fun() -> elvis_core:rock(ElvisConfig) end,
+    Expected = "# \\.\\./\\.\\./_build/test/lib/elvis_core/test/" ++
                "examples/.*\\.erl.*FAIL",
     [_ | _] = check_some_line_output(Fun, Expected, fun matches_regex/2),
     ok.
@@ -131,7 +133,7 @@ rock_with_file_config(_Config) ->
 -spec rock_with_old_config(config()) -> ok.
 rock_with_old_config(_Config) ->
     ConfigPath = "../../config/old/elvis.config",
-    ElvisConfig = elvis_config:load_file(ConfigPath),
+    ElvisConfig = elvis_config:from_file(ConfigPath),
     ok = try
              ok = elvis_core:rock(ElvisConfig)
          catch
@@ -139,7 +141,7 @@ rock_with_old_config(_Config) ->
          end,
 
     ConfigPath1 = "../../config/old/elvis-test.config",
-    ElvisConfig1 = elvis_config:load_file(ConfigPath1),
+    ElvisConfig1 = elvis_config:from_file(ConfigPath1),
     ok = try
              ok = elvis_core:rock(ElvisConfig1)
          catch
@@ -147,7 +149,7 @@ rock_with_old_config(_Config) ->
          end,
 
     ConfigPath2 = "../../config/old/elvis-test-rule-config-list.config",
-    ElvisConfig2 = elvis_config:load_file(ConfigPath2),
+    ElvisConfig2 = elvis_config:from_file(ConfigPath2),
     ok = try
              ok = elvis_core:rock(ElvisConfig2)
          catch
@@ -157,8 +159,9 @@ rock_with_old_config(_Config) ->
 -spec rock_with_rebar_default_config(config()) -> ok.
 rock_with_rebar_default_config(_Config) ->
     {ok, _} = file:copy("../../config/rebar.config", "rebar.config"),
+    ElvisConfig = elvis_config:from_rebar("rebar.config"),
     [#{name := line_length}] = try
-        {fail, Results} = elvis_core:rock(),
+        {fail, Results} = elvis_core:rock(ElvisConfig),
         [Rule || #{rules := [Rule]} <- Results]
     after
         file:delete("rebar.config")
@@ -167,24 +170,24 @@ rock_with_rebar_default_config(_Config) ->
 
 -spec rock_this(config()) -> ok.
 rock_this(_Config) ->
-    ok = elvis_core:rock_this(elvis_core),
+    ElvisConfig = elvis_test_utils:config(),
+    ok = elvis_core:rock_this(elvis_core, ElvisConfig),
 
     ok = try
-             {fail, _} = elvis_core:rock_this("bla.erl")
+             {fail, _} = elvis_core:rock_this("bla.erl", ElvisConfig)
          catch
              _:{enoent, "bla.erl"} -> ok
          end,
 
     Path =
-        "../../_build/test/lib/elvis/test/examples/fail_line_length.erl",
-    {fail, _} = elvis_core:rock_this(Path),
+        "../../_build/test/lib/elvis_core/test/examples/fail_line_length.erl",
+    {fail, _} = elvis_core:rock_this(Path, ElvisConfig),
 
     ok.
 
 -spec rock_without_colors(config()) -> ok.
 rock_without_colors(_Config) ->
-    ConfigPath = "../../config/test.config",
-    ElvisConfig = elvis_config:load_file(ConfigPath),
+    ElvisConfig = elvis_test_utils:config(),
     Fun = fun() -> elvis_core:rock(ElvisConfig) end,
     Expected = "\\e.*?m",
     ok = try check_some_line_output(Fun, Expected, fun matches_regex/2) of
@@ -197,8 +200,7 @@ rock_without_colors(_Config) ->
 rock_with_parsable(_Config) ->
     {ok, Default} = application:get_env(elvis_core, output_format),
     application:set_env(elvis_core, output_format, parsable),
-    ConfigPath = "../../config/test.config",
-    ElvisConfig = elvis_config:load_file(ConfigPath),
+    ElvisConfig = elvis_test_utils:config(),
     Fun = fun() -> elvis_core:rock(ElvisConfig) end,
     Expected = ".*\\.erl:\\d:[a-zA-Z0-9_]+:.*",
     ok = try check_some_line_output(Fun, Expected, fun matches_regex/2) of
@@ -214,8 +216,7 @@ rock_with_parsable(_Config) ->
 -spec rock_with_no_output_has_no_output(config()) -> ok.
 rock_with_no_output_has_no_output(_Config) ->
     application:set_env(elvis_core, no_output, true),
-    ConfigPath = "../../config/test.config",
-    ElvisConfig = elvis_config:load_file(ConfigPath),
+    ElvisConfig = elvis_test_utils:config(),
     Fun = fun() -> elvis_core:rock(ElvisConfig) end,
     [] = check_no_line_output(Fun),
     application:unset_env(elvis_core, no_output),
@@ -223,8 +224,7 @@ rock_with_no_output_has_no_output(_Config) ->
 
 -spec rock_with_errors_has_output(config()) -> ok.
 rock_with_errors_has_output(_Config) ->
-    ConfigPath = "../../config/test.config",
-    ElvisConfig = elvis_config:load_file(ConfigPath),
+    ElvisConfig = elvis_test_utils:config(),
     Fun = fun() -> elvis_core:rock(ElvisConfig) end,
     Expected = "FAIL",
     [_|_] = check_some_line_output(Fun, Expected, fun matches_regex/2),
@@ -233,7 +233,7 @@ rock_with_errors_has_output(_Config) ->
 -spec rock_without_errors_has_no_output(config()) -> ok.
 rock_without_errors_has_no_output(_Config) ->
     ConfigPath = "../../config/test.pass.config",
-    ElvisConfig = elvis_config:load_file(ConfigPath),
+    ElvisConfig = elvis_config:from_file(ConfigPath),
     Fun = fun() -> elvis_core:rock(ElvisConfig) end,
     [] = check_no_line_output(Fun),
     ok.
@@ -241,8 +241,7 @@ rock_without_errors_has_no_output(_Config) ->
 -spec rock_without_errors_and_with_verbose_has_output(config()) -> ok.
 rock_without_errors_and_with_verbose_has_output(_Config) ->
     application:set_env(elvis_core, verbose, true),
-    ConfigPath = "../../config/test.pass.config",
-    ElvisConfig = elvis_config:load_file(ConfigPath),
+    ElvisConfig = elvis_test_utils:config(),
     Fun = fun() -> elvis_core:rock(ElvisConfig) end,
     Expected = "OK",
     [_|_] = check_some_line_output(Fun, Expected, fun matches_regex/2),
@@ -296,11 +295,11 @@ rock_with_rule_groups(_Config) ->
 -spec rock_this_skipping_files(Config::config()) -> ok.
 rock_this_skipping_files(_Config) ->
     meck:new(elvis_file, [passthrough]),
-    Dirs = ["../../_build/test/lib/elvis/test/examples"],
+    Dirs = ["../../_build/test/lib/elvis_core/test/examples"],
     [File] = elvis_file:find_files(Dirs, "small.erl"),
     Path = elvis_file:path(File),
     ConfigPath = "../../config/elvis-test-pa.config",
-    ElvisConfig = elvis_config:load_file(ConfigPath),
+    ElvisConfig = elvis_config:from_file(ConfigPath),
     ok = elvis_core:rock_this(Path, ElvisConfig),
     0 = meck:num_calls(elvis_file, load_file_data, '_'),
     meck:unload(elvis_file),
@@ -309,11 +308,10 @@ rock_this_skipping_files(_Config) ->
 -spec rock_this_not_skipping_files(Config::config()) -> ok.
 rock_this_not_skipping_files(_Config) ->
     meck:new(elvis_file, [passthrough]),
-    Dirs = ["../../_build/test/lib/elvis/test/examples"],
+    Dirs = ["../../_build/test/lib/elvis_core/test/examples"],
     [File] = elvis_file:find_files(Dirs, "small.erl"),
     Path = elvis_file:path(File),
-    ConfigPath = "../../config/test.config",
-    ElvisConfig = elvis_config:load_file(ConfigPath),
+    ElvisConfig = elvis_test_utils:config(),
     ok = elvis_core:rock_this(Path, ElvisConfig),
     1 = meck:num_calls(elvis_file, load_file_data, '_'),
     meck:unload(elvis_file),
@@ -327,7 +325,7 @@ throw_configuration(_Config) ->
     Filename = "./elvis.config",
     ok = file:write_file(Filename, <<"-">>),
     ok = try
-             _ = elvis_config:default(),
+             _ = elvis_config:from_file(Filename),
              fail
          catch
              throw:_ -> ok

--- a/test/elvis_meta_SUITE.erl
+++ b/test/elvis_meta_SUITE.erl
@@ -11,7 +11,7 @@ all() -> [dialyzer, xref].
 
 -spec dialyzer(config()) -> {comment, []}.
 dialyzer(_Config) ->
-  BaseDir = code:lib_dir(elvis),
+  BaseDir = code:lib_dir(elvis_core),
   DefaultRebar3PltLoc = filename:join(BaseDir, "../../../default"),
   Plts = filelib:wildcard(filename:join(DefaultRebar3PltLoc, "*_plt")),
   Dirs = [filename:join(BaseDir, Dir) || Dir <- ["ebin", "test"]],
@@ -29,7 +29,7 @@ dialyzer(_Config) ->
 
 -spec xref(config()) -> {comment, []}.
 xref(_Config) ->
-  BaseDir = code:lib_dir(elvis),
+  BaseDir = code:lib_dir(elvis_core),
   Dirs = [filename:join(BaseDir, Dir) || Dir <- ["ebin", "test"]],
   XrefConfig = #{ dirs => Dirs
                 , xref_defaults =>

--- a/test/elvis_test_utils.erl
+++ b/test/elvis_test_utils.erl
@@ -1,8 +1,12 @@
 -module(elvis_test_utils).
 
--export([
-         find_file/2
+-export([ config/0
+        , find_file/2
         ]).
+
+-spec config() -> elvis_config:config().
+config() ->
+  application:get_env(elvis_core, config, []).
 
 -spec find_file([string()], string()) ->
     {ok, elvis_file:file()} | {error, enoent}.

--- a/test/project_SUITE.erl
+++ b/test/project_SUITE.erl
@@ -53,7 +53,7 @@ end_per_suite(Config) ->
 
 -spec verify_no_deps_master_erlang_mk(config()) -> any().
 verify_no_deps_master_erlang_mk(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Filename = "Makefile.fail",
@@ -73,7 +73,7 @@ verify_no_deps_master_erlang_mk(_Config) ->
 
 -spec verify_no_deps_master_rebar(config()) -> any().
 verify_no_deps_master_rebar(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Filename = "rebar.config.fail",
@@ -90,7 +90,7 @@ verify_no_deps_master_rebar(_Config) ->
 
 -spec verify_git_for_deps_erlang_mk(config()) -> any().
 verify_git_for_deps_erlang_mk(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Filename = "Makefile.fail",
@@ -116,7 +116,7 @@ verify_git_for_deps_erlang_mk(_Config) ->
 
 -spec verify_protocol_for_deps_erlang_mk(config()) -> any().
 verify_protocol_for_deps_erlang_mk(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Filename = "Makefile.fail",
@@ -142,7 +142,7 @@ verify_protocol_for_deps_erlang_mk(_Config) ->
 
 -spec verify_git_for_deps_rebar(config()) -> any().
 verify_git_for_deps_rebar(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Filename = "rebar.config.fail",
@@ -162,7 +162,7 @@ verify_git_for_deps_rebar(_Config) ->
 
 -spec verify_protocol_for_deps_rebar(config()) -> any().
 verify_protocol_for_deps_rebar(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Filename = "rebar.config.fail",
@@ -182,7 +182,7 @@ verify_protocol_for_deps_rebar(_Config) ->
 
 -spec verify_hex_dep_rebar(config()) -> any().
 verify_hex_dep_rebar(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Filename = "rebar3.config.success",
@@ -192,7 +192,7 @@ verify_hex_dep_rebar(_Config) ->
 
 -spec verify_old_config_format(config()) -> any().
 verify_old_config_format(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     PathFail = "fail.elvis.config",

--- a/test/project_SUITE.erl
+++ b/test/project_SUITE.erl
@@ -39,12 +39,12 @@ all() ->
 
 -spec init_per_suite(config()) -> config().
 init_per_suite(Config) ->
-    ok = application:start(elvis),
+    ok = application:start(elvis_core),
     Config.
 
 -spec end_per_suite(config()) -> config().
 end_per_suite(Config) ->
-    ok = application:stop(elvis),
+    ok = application:stop(elvis_core),
     Config.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -80,7 +80,7 @@ end_per_suite(Config) ->
 
 -spec verify_function_naming_convention(config()) -> any().
 verify_function_naming_convention(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     RuleConfig = #{regex => "^([a-z][a-z0-9]*_?)*$"},
@@ -106,7 +106,7 @@ verify_function_naming_convention(_Config) ->
 
 -spec verify_variable_naming_convention(config()) -> any().
 verify_variable_naming_convention(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     RuleConfig = #{regex => "^_?([A-Z][0-9a-zA-Z]*)$"},
@@ -130,7 +130,7 @@ verify_variable_naming_convention(_Config) ->
 
 -spec verify_line_length_rule(config()) -> any().
 verify_line_length_rule(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     File = "fail_line_length.erl",
@@ -154,7 +154,7 @@ verify_line_length_rule(_Config) ->
 
 -spec verify_line_length_rule_latin1(config()) -> any().
 verify_line_length_rule_latin1(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     File = "fail_line_length_latin1.erl",
@@ -167,7 +167,7 @@ verify_line_length_rule_latin1(_Config) ->
 
 -spec verify_unicode_line_length_rule(config()) -> any().
 verify_unicode_line_length_rule(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Pass = "pass_unicode_comments.erl",
@@ -178,7 +178,7 @@ verify_unicode_line_length_rule(_Config) ->
 
 -spec verify_no_tabs_rule(config()) -> any().
 verify_no_tabs_rule(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     File = "fail_no_tabs.erl",
@@ -188,7 +188,7 @@ verify_no_tabs_rule(_Config) ->
 
 -spec verify_no_spaces_rule(config()) -> any().
 verify_no_spaces_rule(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     File = "fail_no_spaces.erl",
@@ -198,7 +198,7 @@ verify_no_spaces_rule(_Config) ->
 
 -spec verify_no_trailing_whitespace_rule(config()) -> any().
 verify_no_trailing_whitespace_rule(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     File = "fail_no_trailing_whitespace.erl",
@@ -217,7 +217,7 @@ do_verify_no_trailing_whitespace(Path, Config, RuleConfig, ExpectedNumItems) ->
 
 -spec verify_macro_names_rule(config()) -> any().
 verify_macro_names_rule(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     File = "fail_macro_names.erl",
@@ -227,7 +227,7 @@ verify_macro_names_rule(_Config) ->
 
 -spec verify_macro_module_names(config()) -> any().
 verify_macro_module_names(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     File = "fail_macro_module_names.erl",
@@ -237,7 +237,7 @@ verify_macro_module_names(_Config) ->
 
 -spec verify_operator_spaces(config()) -> any().
 verify_operator_spaces(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     File = "fail_operator_spaces.erl",
@@ -267,7 +267,7 @@ verify_operator_spaces(_Config) ->
 
 -spec verify_operator_spaces_latin1(config()) -> any().
 verify_operator_spaces_latin1(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     File = "fail_operator_spaces_latin1.erl",
@@ -281,7 +281,7 @@ verify_operator_spaces_latin1(_Config) ->
 
 -spec verify_nesting_level(config()) -> any().
 verify_nesting_level(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Path = "fail_nesting_level.erl",
@@ -302,7 +302,7 @@ verify_nesting_level(_Config) ->
 
 -spec verify_god_modules(config()) -> any().
 verify_god_modules(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Path = "fail_god_modules.erl",
@@ -314,7 +314,7 @@ verify_god_modules(_Config) ->
 
 -spec verify_no_if_expression(config()) -> any().
 verify_no_if_expression(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Path = "fail_no_if_expression.erl",
@@ -327,7 +327,7 @@ verify_no_if_expression(_Config) ->
 
 -spec verify_invalid_dynamic_call(config()) -> any().
 verify_invalid_dynamic_call(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     PathPass = "pass_invalid_dynamic_call.erl",
@@ -350,7 +350,7 @@ verify_invalid_dynamic_call(_Config) ->
 
 -spec verify_used_ignored_variable(config()) -> any().
 verify_used_ignored_variable(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Path = "fail_used_ignored_variable.erl",
@@ -367,7 +367,7 @@ verify_used_ignored_variable(_Config) ->
 
 -spec verify_no_behavior_info(config()) -> any().
 verify_no_behavior_info(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     Path = "fail_no_behavior_info.erl",
@@ -379,7 +379,7 @@ verify_no_behavior_info(_Config) ->
 
 -spec verify_module_naming_convention(config()) -> any().
 verify_module_naming_convention(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     RuleConfig = #{regex => "^([a-z][a-z0-9]*_?)*$",
@@ -404,7 +404,7 @@ verify_module_naming_convention(_Config) ->
 
 -spec verify_state_record_and_type(config()) -> any().
 verify_state_record_and_type(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     PathPass = "pass_state_record_and_type.erl",
@@ -421,7 +421,7 @@ verify_state_record_and_type(_Config) ->
 
 -spec verify_no_spec_with_records(config()) -> any().
 verify_no_spec_with_records(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     PathFail = "fail_no_spec_with_records.erl",
@@ -434,7 +434,7 @@ verify_no_spec_with_records(_Config) ->
 
 -spec verify_dont_repeat_yourself(config()) -> any().
 verify_dont_repeat_yourself(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     PathFail = "fail_dont_repeat_yourself.erl",
@@ -456,7 +456,7 @@ verify_dont_repeat_yourself(_Config) ->
 
 -spec verify_max_module_length(config()) -> any().
 verify_max_module_length(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
     PathFail = "fail_max_module_length.erl",
     {ok, FileFail} = elvis_test_utils:find_file(SrcDirs, PathFail),
@@ -502,7 +502,7 @@ verify_max_module_length(_Config) ->
 
 -spec verify_max_function_length(config()) -> any().
 verify_max_function_length(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     PathFail = "fail_max_function_length.erl",
@@ -565,7 +565,7 @@ verify_max_function_length(_Config) ->
 
 -spec verify_no_debug_call(config()) -> any().
 verify_no_debug_call(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     PathFail = "fail_no_debug_call.erl",
@@ -601,7 +601,7 @@ verify_no_call(_Config) ->
 
 -spec verify_no_call_flavours(atom(), fun(), atom(), non_neg_integer()) -> any().
 verify_no_call_flavours(RuleName, RuleFun, RuleConfigMapKey, ExpectedDefaultRuleMatchCount) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
     PathFail = "fail_no_call_classes.erl",
@@ -629,7 +629,7 @@ verify_no_call_flavours(RuleName, RuleFun, RuleConfigMapKey, ExpectedDefaultRule
 
 -spec verify_no_nested_try_catch(config()) -> any().
 verify_no_nested_try_catch(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
 
     SrcDirs = elvis_config:dirs(ElvisConfig),
 
@@ -647,7 +647,7 @@ verify_no_nested_try_catch(_Config) ->
 
 -spec verify_no_seqbind(config()) -> any().
 verify_no_seqbind(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = ["../../test/examples"],
     File = "fail_no_seqbind.erl",
     {ok, Path} = elvis_test_utils:find_file(SrcDirs, File),
@@ -659,7 +659,7 @@ verify_no_seqbind(_Config) ->
 
 -spec verify_no_useless_seqbind(config()) -> any().
 verify_no_useless_seqbind(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     SrcDirs = ["../../test/examples"],
     {ok, PassPath} = elvis_test_utils:find_file(SrcDirs, "pass_no_useless_seqbind.erl"),
     {ok, FailPath} = elvis_test_utils:find_file(SrcDirs, "fail_no_useless_seqbind.erl"),
@@ -668,7 +668,7 @@ verify_no_useless_seqbind(_Config) ->
 
 -spec results_are_ordered_by_line(config()) -> true.
 results_are_ordered_by_line(_Config) ->
-    ElvisConfig = elvis_config:default(),
+    ElvisConfig = elvis_test_utils:config(),
     {fail, Results} = elvis_core:rock(ElvisConfig),
     true = lists:all(fun(X) -> X end, is_item_line_sort(Results)).
 

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -63,12 +63,12 @@ all() ->
 
 -spec init_per_suite(config()) -> config().
 init_per_suite(Config) ->
-    _ = application:ensure_all_started(elvis),
+    _ = application:ensure_all_started(elvis_core),
     Config.
 
 -spec end_per_suite(config()) -> config().
 end_per_suite(Config) ->
-    ok = application:stop(elvis),
+    ok = application:stop(elvis_core),
     Config.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
This PR removes the functions from the `elvis_core` module that automagically find the configuration. Only the functions that require the configuration to be provided explicitly remain. This will enable users (like the elvis CLI) to be more specific and evident regarding what configuration is being used.

inaka/elvis#425