### PR TITLE
Allow {Module, Function} ignores in function_naming_convention/3

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -162,30 +162,30 @@ function_naming_convention(Config, Target, RuleConfig) ->
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
     IgnoredFuns = lists:filtermap(
-                    fun({_ModuleName, Function}) -> {true, Function};
+                    fun({Mod, Function}) when Mod =:= ModuleName -> {true, Function};
                        (_) -> false
                     end, Ignores),
     case lists:member(ModuleName, Ignores) of
-      true -> [];
+        true -> [];
         false ->
-        FunctionNames0 = elvis_code:function_names(Root),
-        FunctionNames = lists:filter(
-                          fun(FunctionNames) ->
-                                  not lists:member(FunctionNames, IgnoredFuns)
-                          end, FunctionNames0),
-        errors_for_function_names(Regex, FunctionNames)
+            FunctionNames0 = elvis_code:function_names(Root),
+            FunctionNames = lists:filter(
+                              fun(FunctionNames) ->
+                                      not lists:member(FunctionNames, IgnoredFuns)
+                              end, FunctionNames0),
+            errors_for_function_names(Regex, FunctionNames)
     end.
 
 errors_for_function_names(_Regex, []) -> [];
-errors_for_function_names(Regex, [FunctionName | Rem]) ->
+errors_for_function_names(Regex, [FunctionName | RemainingFuncNames]) ->
     FunctionNameStr = atom_to_list(FunctionName),
     case re:run(FunctionNameStr, Regex) of
         nomatch ->
             Msg = ?FUNCTION_NAMING_CONVENTION_MSG,
             Info = [FunctionNameStr, Regex],
             Result = elvis_result:new(item, Msg, Info, 1),
-            [Result | errors_for_function_names(Regex, Rem)];
-        {match, _} -> errors_for_function_names(Regex, Rem)
+            [Result | errors_for_function_names(Regex, RemainingFuncNames)];
+        {match, _} -> errors_for_function_names(Regex, RemainingFuncNames)
     end.
 
 -type variable_naming_convention_config() :: #{regex => string(),

--- a/test/examples/fail_function_naming_convention_ignored_function.erl
+++ b/test/examples/fail_function_naming_convention_ignored_function.erl
@@ -1,0 +1,18 @@
+-module(fail_function_naming_convention_ignored_function).
+
+-dialyzer({nowarn_function, bad_names_inside/0}).
+
+-export([bad_names_inside/0]).
+
+%% Function names must use only lowercase characters.
+%% Words in function names must be separated with _.
+
+%% Cf. https://github.com/inaka/erlang_guidelines#function-names
+
+bad_names_inside() ->
+    camelCase(should, fail).
+
+%% Private / hidden functions still checked
+
+camelCase(Should, Fail) ->
+    [Should, Fail].

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -112,6 +112,20 @@ verify_function_naming_convention(_Config) ->
                               , {fail_function_naming_convention, 'no_predicates?'}
                               ]
                    },
+    [_EmailError] = elvis_style:function_naming_convention(ElvisConfig, FileFail, RuleConfig3),
+
+    RuleConfig4 = #{regex => "^([a-z][a-z0-9]*_?)*$",
+                    ignore => [ {fail_function_naming_convention, camelCase}
+                              , {fail_function_naming_convention, 'ALL_CAPS'}
+                              , {fail_function_naming_convention, 'Initial_cap'}
+                              , {fail_function_naming_convention, 'ok-for-lisp'}
+                              , {fail_function_naming_convention, 'no_predicates?'}
+                              , {fail_function_naming_convention, user@location}
+                              ]
+                   },
+    [] = elvis_style:function_naming_convention(ElvisConfig, FilePass, RuleConfig3),
+    IgnoredFail = "fail_function_naming_convention_ignored_function.erl",
+    {ok, FileFail} = elvis_test_utils:find_file(SrcDirs, PathFail),
     [_EmailError] = elvis_style:function_naming_convention(ElvisConfig, FileFail, RuleConfig3).
 
 -spec verify_variable_naming_convention(config()) -> any().

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -102,7 +102,17 @@ verify_function_naming_convention(_Config) ->
 
     {ok, FileFail} = elvis_test_utils:find_file(SrcDirs, PathFail),
     [] =
-      elvis_style:function_naming_convention(ElvisConfig, FilePass, RuleConfig2).
+        elvis_style:function_naming_convention(ElvisConfig, FilePass, RuleConfig2),
+
+    RuleConfig3 = #{regex => "^([a-z][a-z0-9]*_?)*$",
+                    ignore => [ {fail_function_naming_convention, camelCase}
+                              , {fail_function_naming_convention, 'ALL_CAPS'}
+                              , {fail_function_naming_convention, 'Initial_cap'}
+                              , {fail_function_naming_convention, 'ok-for-lisp'}
+                              , {fail_function_naming_convention, 'no_predicates?'}
+                              ]
+                   },
+    [_EmailError] = elvis_style:function_naming_convention(ElvisConfig, FileFail, RuleConfig3).
 
 -spec verify_variable_naming_convention(config()) -> any().
 verify_variable_naming_convention(_Config) ->


### PR DESCRIPTION
I'm slowly trying to modify as many rules as possible to accept a `{Module, Function}` or even `{Module, Function, Arity}` ignore. See: https://github.com/inaka/elvis/issues/488 for a discussion that I had with @elbrujohalcon regarding this. 

Rather than creating a big bang PR that fixes it in many places, I'd like to start small and fix one of the easiest ones to implement this for: function_naming_convention/3

I'm apparently able to update the Wiki (which seems a bit strange...?). Once approved and merged, I'll follow up with a PR in https://github.com/inaka/elvis/blob/master/rebar.config and edit the Wiki 