### PR TITLE
Allow use of rebar_raw_resource in rebar3 -oriented projects

### DIFF
--- a/src/elvis_project.erl
+++ b/src/elvis_project.erl
@@ -157,6 +157,8 @@ is_rebar_master_dep({_AppName, {_SCM, _Location, "master"}}) ->
     true;
 is_rebar_master_dep({_AppName, {_SCM, _Location, {branch, "master"}}}) ->
     true;
+is_rebar_master_dep({AppName, {raw, DepResourceSpecification}}) ->
+    is_rebar_master_dep({AppName, DepResourceSpecification});
 %% Rebar2
 is_rebar_master_dep({_AppName, _Vsn, {_SCM, _Location, "master"}}) ->
     true;
@@ -182,8 +184,8 @@ is_rebar_not_git_dep({_AppName, {pkg, _OtherName}}, _Regex) ->
     false;
 is_rebar_not_git_dep({_AppName, {_SCM, Url, _Branch}}, Regex) ->
     nomatch == re:run(Url, Regex, []);
-is_rebar_not_git_dep({_AppName, {raw,  {git, Url, _Branch}}}, Regex) ->
-    nomatch == re:run(Url, Regex, []);
+is_rebar_not_git_dep({AppName, {raw,  DepResourceSpecification}}, Regex) ->
+    is_rebar_not_git_dep({AppName, DepResourceSpecification}, Regex);
 is_rebar_not_git_dep({_AppName, {_SCM, Url}}, Regex) ->
     nomatch == re:run(Url, Regex, []);
 is_rebar_not_git_dep({_AppName, _Vsn, {_SCM, Url}}, Regex) ->

--- a/src/elvis_project.erl
+++ b/src/elvis_project.erl
@@ -182,6 +182,8 @@ is_rebar_not_git_dep({_AppName, {pkg, _OtherName}}, _Regex) ->
     false;
 is_rebar_not_git_dep({_AppName, {_SCM, Url, _Branch}}, Regex) ->
     nomatch == re:run(Url, Regex, []);
+is_rebar_not_git_dep({_AppName, {raw,  {git, Url, _Branch}}}, Regex) ->
+    nomatch == re:run(Url, Regex, []);
 is_rebar_not_git_dep({_AppName, {_SCM, Url}}, Regex) ->
     nomatch == re:run(Url, Regex, []);
 is_rebar_not_git_dep({_AppName, _Vsn, {_SCM, Url}}, Regex) ->

--- a/test/examples/rebar.config.fail
+++ b/test/examples/rebar.config.fail
@@ -28,6 +28,7 @@
   {jiffy, "0.*", {git, "git@github.com:davisp/jiffy.git"}},
   {ibrowse, "4.*", {git, "https://github.com/cmullaparthi/ibrowse.git", "v4.1.1"}},
   {aleppo, "0.*", {git, "https://github.com/inaka/aleppo.git", "master"}},
+  {jsx, {raw, {git, "git@github.com:talentdeficit.git", {branch, "develop"}}}},
 
   {lager, {git, "git://github.com/basho/lager.git", "2.0.0"}},
   {getopt, {git, "git@github.com:jcomellas/getopt.git", {branch, "master"}}},
@@ -35,7 +36,8 @@
   {jiffy, {git, "https://github.com/davisp/jiffy.git", "0.11.3"}},
   {jiffy, {git, "git@github.com:davisp/jiffy.git"}},
   {ibrowse, {git, "https://github.com/cmullaparthi/ibrowse.git", "v4.1.1"}},
-  {aleppo, {git, "https://github.com/inaka/aleppo.git", "master"}}
+  {aleppo, {git, "https://github.com/inaka/aleppo.git", "master"}},
+  {jsx, {raw, {git, "https://github.com/talentdeficit.git", {branch, "master"}}}}
  ]
 }.
 {escript_name, "elvis"}.

--- a/test/examples/rebar3.config.success
+++ b/test/examples/rebar3.config.success
@@ -4,5 +4,6 @@
   {uuid, "1.7.0", {pkg, uuid_erl}},
   {meck, "0.8.2", {git, "https://github.com/basho/meck.git", {tag, "0.8.2"}}},
   {jiffy, {git, "https://github.com/davisp/jiffy.git"}},
-  recon
+  recon,
+  {jsx, {raw, {git, "https://github.com/talentdeficit.git", {branch, "develop"}}}}
  ]}.

--- a/test/project_SUITE.erl
+++ b/test/project_SUITE.erl
@@ -148,15 +148,15 @@ verify_git_for_deps_rebar(_Config) ->
     Filename = "rebar.config.fail",
     {ok, File} = elvis_test_utils:find_file(SrcDirs, Filename),
 
-    [_, _, _, _, _, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, #{}),
+    [_, _, _, _, _, _, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, #{}),
 
     RuleConfig =  #{ignore => [getopt]},
-    [_, _, _, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig),
+    [_, _, _, _, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig),
 
     RuleConfig1 =  #{ignore => [getopt, lager]},
-    [_, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig1),
+    [_, _, _] = elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig1),
 
-    RuleConfig2 =  #{ignore => [meck], regex => "git@.*"},
+    RuleConfig2 =  #{ignore => [meck, jsx], regex => "git@.*"},
     [_, _, _, _, _, _, _, _] =
         elvis_project:git_for_deps_rebar(ElvisConfig, File, RuleConfig2).
 
@@ -168,16 +168,16 @@ verify_protocol_for_deps_rebar(_Config) ->
     Filename = "rebar.config.fail",
     {ok, File} = elvis_test_utils:find_file(SrcDirs, Filename),
 
-    [_, _, _, _, _, _] = elvis_project:protocol_for_deps_rebar(ElvisConfig, File, #{}),
+    [_, _, _, _, _, _, _] = elvis_project:protocol_for_deps_rebar(ElvisConfig, File, #{}),
 
-    RuleConfig =  #{ignore => [getopt]},
+    RuleConfig =  #{ignore => [getopt, jsx]},
     [_, _, _, _] = elvis_project:protocol_for_deps_rebar(ElvisConfig, File, RuleConfig),
 
     RuleConfig1 =  #{ignore => [getopt, lager]},
-    [_, _] = elvis_project:protocol_for_deps_rebar(ElvisConfig, File, RuleConfig1),
+    [_, _, _] = elvis_project:protocol_for_deps_rebar(ElvisConfig, File, RuleConfig1),
 
     RuleConfig2 =  #{ignore => [meck], regex => "git@.*"},
-    [_, _, _, _, _, _, _, _] =
+    [_, _, _, _, _, _, _, _, _] =
         elvis_project:protocol_for_deps_rebar(ElvisConfig, File, RuleConfig2).
 
 -spec verify_hex_dep_rebar(config()) -> any().

--- a/test/project_SUITE.erl
+++ b/test/project_SUITE.erl
@@ -79,13 +79,16 @@ verify_no_deps_master_rebar(_Config) ->
     Filename = "rebar.config.fail",
     {ok, File} = elvis_test_utils:find_file(SrcDirs, Filename),
 
-    [_, _, _, _] = elvis_project:no_deps_master_rebar(ElvisConfig, File, #{}),
+    [_, _, _, _, _] = elvis_project:no_deps_master_rebar(ElvisConfig, File, #{}),
 
     RuleConfig =  #{ignore => [aleppo]},
-    [_, _] = elvis_project:no_deps_master_rebar(ElvisConfig, File, RuleConfig),
+    [_, _, _] = elvis_project:no_deps_master_rebar(ElvisConfig, File, RuleConfig),
 
     RuleConfig1 =  #{ignore => [aleppo, getopt]},
-    [] = elvis_project:no_deps_master_rebar(ElvisConfig, File, RuleConfig1).
+    [_] = elvis_project:no_deps_master_rebar(ElvisConfig, File, RuleConfig1),
+
+    RuleConfig2 =  #{ignore => [jsx]},
+    [_, _, _, _] = elvis_project:no_deps_master_rebar(ElvisConfig, File, RuleConfig2).
 
 
 -spec verify_git_for_deps_erlang_mk(config()) -> any().


### PR DESCRIPTION
I have this entry in `rebar.config`'s `deps`:

```erlang
{dep, {raw, {git, "https://github.com/dep.git", {branch, "develop"}}}}
```

While analyzing `rebar.config`, `elvis` (via `elvis_core`) exits with:

```erlang
# rebar.config [FAIL]
Error: 'badarg' while applying rule 'protocol_for_deps_rebar'.
===> Linting failed
```

That entry respects the format of rebar3 plugin [rebar_raw_resource](https://github.com/basho/rebar_raw_resource).