### PR TITLE
Prevent sub-folder files from being analyzed twice

### DIFF
--- a/src/elvis_file.erl
+++ b/src/elvis_file.erl
@@ -81,7 +81,7 @@ filter_files(Files, Dirs, Filter, IgnoreList) ->
     AppendFilter = fun(Dir) ->
                          case Dir of
                              "." -> Filter;
-                             Dir -> Dir ++ "/" ++ Filter
+                             Dir -> reduce_stars(Dir ++ "/" ++ Filter)
                          end
                    end,
     FullFilters = lists:map(AppendFilter, Dirs),
@@ -129,6 +129,9 @@ escape_all_chars(Glob) -> re:replace(Glob, ".", "[&]", [global]).
 replace_stars(Glob) -> re:replace(Glob, "[[][*][]]", ".*", [global]).
 
 replace_questions(Glob) -> re:replace(Glob, "[[][?][]]", ".", [global]).
+
+reduce_stars(DirAndFilter) ->
+    re:replace(DirAndFilter, "/\\*+/", "/", [global, {return, list}]).
 
 -spec find_encoding(Content::binary()) ->
   atom().

--- a/src/elvis_file.erl
+++ b/src/elvis_file.erl
@@ -103,7 +103,9 @@ filter_files(Files, Dirs, Filter, IgnoreList) ->
                 not lists:any(IsIgnored, IgnoreList)
         end,
     Found = lists:flatmap(FlatmapFun, Regexes),
-    lists:filter(IgnoreFun, Found).
+    % File src/sub/file.erl will match both src/ and src/sub/ folders. We can't have that!
+    FoundUnique = lists:usort(Found),
+    lists:filter(IgnoreFun, FoundUnique).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Private


### PR DESCRIPTION
This is what is happening to me...
I have an `elvis.config` file such as
```erlang
[{elvis, [
    {config, [
        #{ dirs => ["src",
                    "src/sub"],
           filter => "*.erl",
           ruleset => erl_files
    ]},
    {verbose, true}
]}].
```
When analyzing file `file.erl` inside folder `src/sub` it gets analyzed twice, since `elvis_core`'s internals match it with both `src/` and `src/sub/`.
The "solution" found was to un-duplicate these occurrences.