### PR TITLE
Decrease chance of error and improve maintenance

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 {profiles, [
   {test, [
     {deps, [ {mixer,       "1.0.1", {pkg, inaka_mixer}}
-           , {meck,        "0.8.11"}
+           , {meck,        "0.9.0"}
            , {xref_runner, "1.1.1"}
     ]}
   ]}

--- a/src/elvis_rulesets.erl
+++ b/src/elvis_rulesets.erl
@@ -4,42 +4,31 @@
 
 -spec rules(Group::atom()) -> list().
 rules(erl_files) ->
-  [ {elvis_style, line_length, #{limit => 100, skip_comments => false}}
-  , {elvis_style, no_tabs}
-  , {elvis_style, no_trailing_whitespace, #{ignore_empty_lines => false}}
-  , {elvis_style, macro_names, #{regex => "^([A-Z][A-Z_0-9]+)$", ignore => []}}
-  , {elvis_style, macro_module_names}
-  , { elvis_style
-    , operator_spaces
-    , #{rules => [{right, ","}, {right, "++"}, {left, "++"}]}
-    }
-  , {elvis_style, nesting_level, #{level => 4, ignore => []}}
-  , {elvis_style, god_modules, #{limit => 25, ignore => []}}
-  , {elvis_style, no_if_expression}
-  , {elvis_style, invalid_dynamic_call, #{ignore => []}}
-  , {elvis_style, used_ignored_variable, #{ignore => []}}
-  , {elvis_style, no_behavior_info}
-  , { elvis_style
-    , module_naming_convention
-    , #{regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$", ignore => []}
-    }
-  , { elvis_style
-    , function_naming_convention
-    , #{regex => "^([a-z][a-z0-9]*_?)*$", ignore => []}
-    }
-  , {elvis_style, state_record_and_type}
-  , {elvis_style, no_spec_with_records}
-  , {elvis_style, dont_repeat_yourself, #{min_complexity => 10}}
-  , {elvis_style, no_debug_call, #{ignore => []}}
-  , { elvis_style
-    , variable_naming_convention
-    , #{regex => "^_?([A-Z][0-9a-zA-Z]*)$", ignore => []}
-    }
-  , {elvis_style, no_nested_try_catch, #{ignore => []}}
-  , {elvis_style, atom_naming_convention, #{regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$",
-                                            enclosed_atoms => ".*",
-                                            ignore => []}}
-  ];
+    lists:map(
+        fun (Rule) ->
+            {elvis_style, Rule, elvis_style:default(Rule)}
+        end,
+        [ line_length
+        , no_tabs
+        , no_trailing_whitespace
+        , macro_names
+        , macro_module_names
+        , operator_spaces
+        , nesting_level
+        , god_modules
+        , no_if_expression
+        , invalid_dynamic_call
+        , used_ignored_variable
+        , no_behavior_info
+        , module_naming_convention
+        , function_naming_convention
+        , state_record_and_type
+        , no_spec_with_records
+        , dont_repeat_yourself
+        , no_debug_call
+        , variable_naming_convention
+        , no_nested_try_catch
+        , atom_naming_convention ]);
 rules(makefiles) ->
   [ {elvis_project, no_deps_master_erlang_mk, #{ignore => []}}
   , {elvis_project, protocol_for_deps_erlang_mk, #{ignore => []}}

--- a/src/elvis_rulesets.erl
+++ b/src/elvis_rulesets.erl
@@ -31,13 +31,26 @@ rules(erl_files) ->
         , atom_naming_convention
         ]);
 rules(makefiles) ->
-  [ {elvis_project, no_deps_master_erlang_mk, #{ignore => []}}
-  , {elvis_project, protocol_for_deps_erlang_mk, #{ignore => []}}
-  ];
+    lists:map(
+        fun (Rule) ->
+            {elvis_project, Rule, elvis_project:default(Rule)}
+        end,
+        [ no_deps_master_erlang_mk
+        , protocol_for_deps_erlang_mk
+        ]);
 rules(rebar_config) ->
-  [ {elvis_project, no_deps_master_rebar, #{ignore => []}}
-  , {elvis_project, protocol_for_deps_rebar, #{ignore => []}}
-  ];
+    lists:map(
+        fun (Rule) ->
+            {elvis_project, Rule, elvis_project:default(Rule)}
+        end,
+        [ no_deps_master_rebar
+        , protocol_for_deps_rebar
+        ]);
 rules(elvis_config) ->
-  [{elvis_project, old_configuration_format}];
+    lists:map(
+        fun (Rule) ->
+            {elvis_project, Rule, elvis_project:default(Rule)}
+        end,
+        [ old_configuration_format
+        ]);
 rules(_Group) -> [].

--- a/src/elvis_rulesets.erl
+++ b/src/elvis_rulesets.erl
@@ -28,7 +28,8 @@ rules(erl_files) ->
         , no_debug_call
         , variable_naming_convention
         , no_nested_try_catch
-        , atom_naming_convention ]);
+        , atom_naming_convention
+        ]);
 rules(makefiles) ->
   [ {elvis_project, no_deps_master_erlang_mk, #{ignore => []}}
   , {elvis_project, protocol_for_deps_erlang_mk, #{ignore => []}}

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -318,8 +318,8 @@ default(atom_naming_convention) ->
                                  function_naming_convention_config()) ->
     [elvis_result:item()].
 function_naming_convention(Config, Target, RuleConfig) ->
-    Regex = option(regex, RuleConfig, function_naming_convention),
-    Ignores = option(ignore, RuleConfig, function_naming_convention),
+    Regex = option(regex, RuleConfig, ?FUNCTION_NAME),
+    Ignores = option(ignore, RuleConfig, ?FUNCTION_NAME),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
     IgnoredFuns = lists:filtermap(
@@ -357,8 +357,8 @@ errors_for_function_names(Regex, [FunctionName | RemainingFuncNames]) ->
                                  variable_naming_convention_config()) ->
     [elvis_result:item()].
 variable_naming_convention(Config, Target, RuleConfig) ->
-    IgnoreModules = option(ignore, RuleConfig, variable_naming_convention),
-    Regex = option(regex, RuleConfig, variable_naming_convention),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    Regex = option(regex, RuleConfig, ?FUNCTION_NAME),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
     case lists:member(ModuleName, IgnoreModules) of
@@ -381,8 +381,8 @@ variable_naming_convention(Config, Target, RuleConfig) ->
                   line_length_config()) ->
     [elvis_result:item()].
 line_length(_Config, Target, RuleConfig) ->
-    Limit = option(limit, RuleConfig, line_length),
-    SkipComments = option(skip_comments, RuleConfig, line_length),
+    Limit = option(limit, RuleConfig, ?FUNCTION_NAME),
+    SkipComments = option(skip_comments, RuleConfig, ?FUNCTION_NAME),
     {Src, #{encoding := Encoding}} = elvis_file:src(Target),
     Args = [Limit, SkipComments, Encoding],
     elvis_utils:check_lines(Src, fun check_line_length/3, Args).
@@ -409,7 +409,11 @@ no_spaces(_Config, Target, _RuleConfig) ->
     [elvis_result:item()].
 no_trailing_whitespace(_Config, Target, RuleConfig) ->
     {Src, _} = elvis_file:src(Target),
-    elvis_utils:check_lines(Src, fun check_no_trailing_whitespace/3,
+    IgnoreEmptyLines = option(ignore_empty_lines, RuleConfig, ?FUNCTION_NAME),
+    elvis_utils:check_lines(Src,
+                            fun(Src1, Fun, _Args) ->
+                                check_no_trailing_whitespace(Src1, Fun, IgnoreEmptyLines)
+                            end,
                             RuleConfig).
 
 -type macro_names_config() :: #{regex => string(),
@@ -421,12 +425,12 @@ no_trailing_whitespace(_Config, Target, RuleConfig) ->
                   macro_names_config()) ->
     [elvis_result:item()].
 macro_names(Config, Target, RuleConfig) ->
-    IgnoreModules = option(ignore, RuleConfig, macro_names),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
     {Root, _File} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
     case lists:member(ModuleName, IgnoreModules) of
         false ->
-            Regexp = option(regex, RuleConfig, macro_names),
+            Regexp = option(regex, RuleConfig, ?FUNCTION_NAME),
             MacroNodes = elvis_code:find(fun is_macro_define_node/1, Root,
                                          #{traverse => all, mode => node}),
             check_macro_names(Regexp, MacroNodes, _ResultsIn = []);
@@ -451,7 +455,7 @@ macro_module_names(Config, Target, _RuleConfig) ->
                       operator_spaces_config()) ->
     [elvis_result:item()].
 operator_spaces(Config, Target, RuleConfig) ->
-    Rules = option(rules, RuleConfig, operator_spaces),
+    Rules = option(rules, RuleConfig, ?FUNCTION_NAME),
     {Src, #{encoding := Encoding}} = elvis_file:src(Target),
     {Root, _} = elvis_file:parse_tree(Config, Target),
 
@@ -488,8 +492,8 @@ is_punctuation_token(Node) ->
                     nesting_level_config()) ->
     [elvis_result:item()].
 nesting_level(Config, Target, RuleConfig) ->
-    Level = option(level, RuleConfig, nesting_level),
-    IgnoreModules = option(ignore, RuleConfig, nesting_level),
+    Level = option(level, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -509,8 +513,8 @@ nesting_level(Config, Target, RuleConfig) ->
                   god_modules_config()) ->
     [elvis_result:item()].
 god_modules(Config, Target, RuleConfig) ->
-    Limit = option(limit, RuleConfig, god_modules),
-    IgnoreModules = option(ignore, RuleConfig, god_modules),
+    Limit = option(limit, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -552,7 +556,7 @@ no_if_expression(Config, Target, _RuleConfig) ->
                            invalid_dynamic_call_config()) ->
     [elvis_result:item()].
 invalid_dynamic_call(Config, Target, RuleConfig) ->
-    IgnoreModules = option(ignore, RuleConfig, invalid_dynamic_call),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
 
@@ -575,7 +579,7 @@ invalid_dynamic_call(Config, Target, RuleConfig) ->
                             used_ignored_variable_config()) ->
     [elvis_result:item()].
 used_ignored_variable(Config, Target, RuleConfig) ->
-    IgnoreModules = option(ignore, RuleConfig, used_ignored_variable),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ResultFun = result_node_line_col_fun(?USED_IGNORED_VAR_MSG),
     ModuleName = elvis_code:module_name(Root),
@@ -629,8 +633,8 @@ no_behavior_info(Config, Target, _RuleConfig) ->
                                module_naming_convention_config()) ->
     [elvis_result:item()].
 module_naming_convention(Config, Target, RuleConfig) ->
-    Regex = option(regex, RuleConfig, module_naming_convention),
-    IgnoreModules = option(ignore, RuleConfig, module_naming_convention),
+    Regex = option(regex, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -694,8 +698,8 @@ no_spec_with_records(Config, Target, _RuleConfig) ->
                            dont_repeat_yourself_config()) ->
     [elvis_result:item()].
 dont_repeat_yourself(Config, Target, RuleConfig) ->
-    MinComplexity = option(min_complexity, RuleConfig, dont_repeat_yourself),
-    IgnoreModules = option(ignore, RuleConfig, dont_repeat_yourself),
+    MinComplexity = option(min_complexity, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -729,10 +733,10 @@ dont_repeat_yourself(Config, Target, RuleConfig) ->
                         max_module_length_config()) ->
     [elvis_result:item()].
 max_module_length(Config, Target, RuleConfig) ->
-    MaxLength = option(max_length, RuleConfig, max_module_length),
-    IgnoreModules = option(ignore, RuleConfig, max_module_length),
-    CountComments = option(count_comments, RuleConfig, max_module_length),
-    CountWhitespace = option(count_whitespace, RuleConfig, max_module_length),
+    MaxLength = option(max_length, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    CountComments = option(count_comments, RuleConfig, ?FUNCTION_NAME),
+    CountWhitespace = option(count_whitespace, RuleConfig, ?FUNCTION_NAME),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     {Src, _} = elvis_file:src(Target),
@@ -767,10 +771,10 @@ max_module_length(Config, Target, RuleConfig) ->
                           max_function_length_config()) ->
     [elvis_result:item()].
 max_function_length(Config, Target, RuleConfig) ->
-    IgnoreFunctions = option(ignore_functions, RuleConfig, max_function_length),
-    MaxLength = option(max_length, RuleConfig, max_function_length),
-    CountComments = option(count_comments, RuleConfig, max_function_length),
-    CountWhitespace = option(count_whitespace, RuleConfig, max_function_length),
+    IgnoreFunctions = option(ignore_functions, RuleConfig, ?FUNCTION_NAME),
+    MaxLength = option(max_length, RuleConfig, ?FUNCTION_NAME),
+    CountComments = option(count_comments, RuleConfig, ?FUNCTION_NAME),
+    CountWhitespace = option(count_whitespace, RuleConfig, ?FUNCTION_NAME),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     {Src, _} = elvis_file:src(Target),
@@ -829,8 +833,9 @@ max_function_length(Config, Target, RuleConfig) ->
               no_call_config()) ->
     [elvis_result:item()].
 no_call(Config, Target, RuleConfig) ->
-    DefaultFns = option(no_call_functions, RuleConfig, no_call),
-    no_call_common(Config, Target, RuleConfig, no_call, DefaultFns, ?NO_CALL_MSG).
+    DefaultFns = option(no_call_functions, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    no_call_common(Config, Target, IgnoreModules, DefaultFns, ?NO_CALL_MSG).
 
 
 -type no_debug_call_config() :: #{debug_functions => [function_spec()],
@@ -841,8 +846,9 @@ no_call(Config, Target, RuleConfig) ->
                     no_debug_call_config()) ->
     [elvis_result:item()].
 no_debug_call(Config, Target, RuleConfig) ->
-    DefaultFns = option(debug_functions, RuleConfig, no_debug_call),
-    no_call_common(Config, Target, RuleConfig, no_debug_call, DefaultFns, ?NO_DEBUG_CALL_MSG).
+    DefaultFns = option(debug_functions, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    no_call_common(Config, Target, IgnoreModules, DefaultFns, ?NO_DEBUG_CALL_MSG).
 
 
 -type no_common_caveats_call_config() :: #{caveat_functions => [function_spec()],
@@ -854,9 +860,9 @@ no_debug_call(Config, Target, RuleConfig) ->
     [elvis_result:item()].
 
 no_common_caveats_call(Config, Target, RuleConfig) ->
-    DefaultFns = option(caveat_functions, RuleConfig, no_common_caveats_call),
-    no_call_common(Config, Target, RuleConfig, no_common_caveats_call, DefaultFns,
-                   ?NO_COMMON_CAVEATS_CALL_MSG).
+    DefaultFns = option(caveat_functions, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    no_call_common(Config, Target, IgnoreModules, DefaultFns, ?NO_COMMON_CAVEATS_CALL_MSG).
 
 -spec node_line_limits(ktn_code:tree_node())->
     {Min :: integer(), Max :: integer()}.
@@ -883,7 +889,7 @@ node_line_limits(FunctionNode) ->
     [elvis_result:item()].
 no_nested_try_catch(Config, Target, RuleConfig) ->
     {Root, _} = elvis_file:parse_tree(Config, Target),
-    IgnoreModules = option(ignore, RuleConfig, no_nested_try_catch),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
     case lists:member(elvis_code:module_name(Root), IgnoreModules) of
         false -> Predicate = fun(Node) -> ktn_code:type(Node) == 'try' end,
                  ResultFun = result_node_line_fun(?NO_NESTED_TRY_CATCH),
@@ -908,12 +914,12 @@ no_nested_try_catch(Config, Target, RuleConfig) ->
 atom_naming_convention(Config, Target, RuleConfig) ->
     {Root, _File} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
-    IgnoreModules = option(ignore, RuleConfig, atom_naming_convention),
+    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
     case lists:member(ModuleName, IgnoreModules) of
         false ->
-            Regex = option(regex, RuleConfig, atom_naming_convention),
+            Regex = option(regex, RuleConfig, ?FUNCTION_NAME),
             RegexEnclosed
-                = enclosed_atoms_regex_or_same(option(enclosed_atoms, RuleConfig, atom_naming_convention), Regex),
+                = enclosed_atoms_regex_or_same(option(enclosed_atoms, RuleConfig, ?FUNCTION_NAME), Regex),
             AtomNodes = elvis_code:find(fun is_atom_node/1, Root, #{traverse => all, mode => node}),
             check_atom_names(Regex, RegexEnclosed, AtomNodes, []);
         true ->
@@ -1086,10 +1092,9 @@ check_no_spaces(Line, Num, _Args) ->
 
 %% No Trailing Whitespace
 
--spec check_no_trailing_whitespace(binary(), integer(), map()) ->
+-spec check_no_trailing_whitespace(binary(), integer(), boolean()) ->
     no_result | {ok, elvis_result:item()}.
-check_no_trailing_whitespace(Line, Num, RuleConfig) ->
-    IgnoreEmptyLines = option(ignore_empty_lines, RuleConfig, no_trailing_whitespace),
+check_no_trailing_whitespace(Line, Num, IgnoreEmptyLines) ->
     Regex =
         case IgnoreEmptyLines of
             %% Lookbehind assertion: http://erlang.org/doc/man/re.html#sect17
@@ -1503,19 +1508,14 @@ is_children(Parent, Node) ->
     [] =/= zipper:filter(fun(Child) -> Child == Node end, Zipper).
 
 %% No call
--type no_call_configs() :: no_call_config()
-                         | no_debug_call_config()
-                         | no_common_caveats_call_config().
 -spec no_call_common(elvis_config:config(),
                      elvis_file:file(),
-                     no_call_configs(),
-                     atom(),
+                     [module()],
                      [function_spec()],
                      string()
                     ) ->
     [elvis_result:item()].
-no_call_common(Config, Target, RuleConfig, Rule, NoCallFuns, Msg) ->
-    IgnoreModules = option(ignore, RuleConfig, Rule),
+no_call_common(Config, Target, IgnoreModules, NoCallFuns, Msg) ->
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
 

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1546,4 +1546,14 @@ check_nested_try_catchs(ResultFun, TryExp) ->
            Rule :: atom(),
            OptionValue :: term().
 option(OptionName, RuleConfig, Rule) ->
-    maps:get(OptionName, RuleConfig, maps:get(OptionName, default(Rule))).
+    maybe_default_option(maps:get(OptionName, RuleConfig, undefined), OptionName, Rule).
+
+-spec maybe_default_option(UserDefinedOptionValue, OptionName, Rule) -> OptionValue
+      when UserDefinedOptionValue :: undefined | term(),
+           OptionName :: atom(),
+           Rule :: atom(),
+           OptionValue :: term().
+maybe_default_option(undefined = _UserDefinedOptionValue, OptionName, Rule) ->
+    maps:get(OptionName, default(Rule));
+maybe_default_option(UserDefinedOptionValue, _OptionName, _Rule) ->
+    UserDefinedOptionValue.

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -156,7 +156,10 @@ default(macro_module_names) ->
     #{};
 
 default(operator_spaces) ->
-    #{ rules => [{right, ","}, {right, "++"}, {left, "++"}]
+    #{ rules => [ {right, ","}
+                , {right, "++"}
+                , {left, "++"}
+                ]
      };
 
 default(nesting_level) ->
@@ -237,7 +240,8 @@ default(no_debug_call) ->
      , debug_functions => [ {ct, pal}
                           , {ct, print}
                           , {io, format, 1}
-                          , {io, format, 2}]
+                          , {io, format, 2}
+                          ]
      };
 
 default(no_common_caveats_call) ->
@@ -246,13 +250,15 @@ default(no_common_caveats_call) ->
                            , {timer, send_after, 3}
                            , {timer, send_interval, 2}
                            , {timer, send_interval, 3}
-                           , {erlang, size, 1}]
+                           , {erlang, size, 1}
+                           ]
      };
 
 default(atom_naming_convention) ->
     #{ ignore => []
      , regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$"
-     , enclosed_atoms => ".*" }.
+     , enclosed_atoms => ".*"
+     }.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Rules

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1,6 +1,7 @@
 -module(elvis_style).
 
 -export([
+         default/1,
          function_naming_convention/3,
          variable_naming_convention/3,
          line_length/3,
@@ -130,6 +131,168 @@
         "defined by the regular expression '~p'.").
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Default values
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec default(Rule :: atom(), OptionName :: atom()) -> DefaultOptionValue :: term().
+default(line_length, limit) -> 100;
+default(line_length, skip_comments) -> false;
+default(no_trailing_whitespace, ignore_empty_lines) -> false;
+default(macro_names, ignore) -> [];
+default(macro_names, regex) -> "^([A-Z][A-Z_0-9]+)$";
+default(atom_naming_convention, ignore) -> [];
+default(atom_naming_convention, regex) -> "^([a-z][a-z0-9]*_?)*(_SUITE)?$";
+default(atom_naming_convention, enclosed_atoms) -> ".*";
+default(operator_spaces, rules) -> [{right, ","}, {right, "++"}, {left, "++"}];
+default(nesting_level, level) -> 4;
+default(nesting_level, ignore) -> [];
+default(god_modules, limit) -> 25;
+default(god_modules, ignore) -> [];
+default(no_nested_try_catch, ignore) -> [];
+default(invalid_dynamic_call, ignore) -> [];
+default(used_ignored_variable, ignore) -> [];
+default(function_naming_convention, regex) -> "^([a-z][a-z0-9]*_?)*(_SUITE)?$";
+default(function_naming_convention, ignore) -> [];
+default(variable_naming_convention, regex) -> "^_?([A-Z][0-9a-zA-Z]*)$";
+default(variable_naming_convention, ignore) -> [];
+default(module_naming_convention, regex) -> "^([a-z][a-z0-9]*_?)*(_SUITE)?$";
+default(module_naming_convention, ignore) -> [];
+default(dont_repeat_yourself, min_complexity) -> 10;
+default(dont_repeat_yourself, ignore) -> [];
+default(max_module_length, max_length) -> 500;
+default(max_module_length, ignore) -> [];
+default(max_module_length, count_comments) -> false;
+default(max_module_length, count_whitespace) -> false;
+default(max_function_length, max_length) -> 30;
+default(max_function_length, count_comments) -> false;
+default(max_function_length, count_whitespace) -> false;
+default(max_function_length, ignore_functions) -> [];
+default(no_call, ignore) -> [];
+default(no_call, no_call_functions) -> [];
+default(no_debug_call, ignore) -> [];
+default(no_debug_call, debug_functions) -> [ {ct, pal}
+                                           , {ct, print}
+                                           , {io, format, 1}
+                                           , {io, format, 2}];
+default(no_common_caveats_call, ignore) -> [];
+default(no_common_caveats_call, caveat_functions) -> [ {timer, send_after, 2}
+                                                     , {timer, send_after, 3}
+                                                     , {timer, send_interval, 2}
+                                                     , {timer, send_interval, 3}
+                                                     , {erlang, size, 1}].
+
+-spec default(Rule :: atom()) -> DefaultRuleConfig :: term().
+default(line_length) ->
+    #{ limit => default(line_length, limit)
+     , skip_comments => default(line_length, skip_comments)
+     };
+
+default(no_tabs) ->
+    #{};
+
+default(no_trailing_whitespace) ->
+    #{ ignore_empty_lines => default(no_trailing_whitespace, ignore_empty_lines)
+     };
+
+default(macro_names) ->
+    #{ ignore => default(macro_names, ignore)
+     , regex => default(macro_names, regex)
+     };
+
+default(macro_module_names) ->
+    #{};
+
+default(operator_spaces) ->
+    #{ rules => default(operator_spaces, rules)
+     };
+
+default(nesting_level) ->
+    #{ level => default(nesting_level, level)
+     , ignore => default(nesting_level, ignore)
+     };
+
+default(god_modules) ->
+    #{ limit => default(god_modules, limit)
+     , ignore => default(god_modules, ignore)
+     };
+
+default(no_if_expression) ->
+    #{};
+
+default(no_nested_try_catch) ->
+    #{ ignore => default(no_nested_try_catch, ignore)
+     };
+
+default(invalid_dynamic_call) ->
+    #{ ignore => default(invalid_dynamic_call, ignore)
+     };
+
+default(used_ignored_variable) ->
+    #{ ignore => default(used_ignored_variable, ignore)
+     };
+
+default(no_behavior_info) ->
+    #{};
+
+default(function_naming_convention) ->
+    #{ regex => default(function_naming_convention, regex)
+     , ignore => default(function_naming_convention, ignore)
+     };
+
+default(variable_naming_convention) ->
+    #{ regex => default(variable_naming_convention, regex)
+     , ignore => default(variable_naming_convention, ignore)
+     };
+
+default(module_naming_convention) ->
+    #{ regex => default(module_naming_convention, regex)
+     , ignore => default(module_naming_convention, ignore)
+     };
+
+default(state_record_and_type) ->
+    #{};
+
+default(no_spec_with_records) ->
+    #{};
+
+default(dont_repeat_yourself) ->
+    #{ min_complexity => default(dont_repeat_yourself, min_complexity)
+     , ignore => default(dont_repeat_yourself, ignore)
+     };
+
+default(max_module_length) ->
+    #{ max_length => default(max_module_length, max_length)
+     , ignore => default(max_module_length, ignore)
+     , count_comments => default(max_module_length, count_comments)
+     , count_whitespace => default(max_module_length, count_whitespace)
+     };
+
+default(max_function_length) ->
+    #{ max_length => default(max_function_length, max_length)
+     , count_comments => default(max_function_length, count_comments)
+     , count_whitespace => default(max_function_length, count_whitespace)
+     , ignore_functions => default(max_function_length, ignore_functions)
+     };
+
+default(no_call) ->
+    #{ ignore => default(no_call, ignore)
+     , no_call_functions => default(no_call, no_call_functions)
+     };
+
+default(no_debug_call) ->
+    #{ ignore => default(no_debug_call, ignore)
+     , debug_functions => default(no_debug_call, debug_functions)
+     };
+
+default(no_common_caveats_call) ->
+    #{ ignore => default(no_common_caveats_call, ignore)
+     , caveat_functions => default(no_common_caveats_call, caveat_functions)
+     };
+
+default(atom_naming_convention) ->
+    #{}.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Rules
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -155,8 +318,8 @@
                                  function_naming_convention_config()) ->
     [elvis_result:item()].
 function_naming_convention(Config, Target, RuleConfig) ->
-    Regex = maps:get(regex, RuleConfig, ".*"),
-    Ignores = maps:get(ignore, RuleConfig, []),
+    Regex = option(regex, RuleConfig, function_naming_convention),
+    Ignores = option(ignore, RuleConfig, function_naming_convention),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
     IgnoredFuns = lists:filtermap(
@@ -194,8 +357,8 @@ errors_for_function_names(Regex, [FunctionName | RemainingFuncNames]) ->
                                  variable_naming_convention_config()) ->
     [elvis_result:item()].
 variable_naming_convention(Config, Target, RuleConfig) ->
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
-    Regex = maps:get(regex, RuleConfig, ".*"),
+    IgnoreModules = option(ignore, RuleConfig, variable_naming_convention),
+    Regex = option(regex, RuleConfig, variable_naming_convention),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
     case lists:member(ModuleName, IgnoreModules) of
@@ -218,8 +381,8 @@ variable_naming_convention(Config, Target, RuleConfig) ->
                   line_length_config()) ->
     [elvis_result:item()].
 line_length(_Config, Target, RuleConfig) ->
-    Limit = maps:get(limit, RuleConfig, 80),
-    SkipComments = maps:get(skip_comments, RuleConfig, false),
+    Limit = option(limit, RuleConfig, line_length),
+    SkipComments = option(skip_comments, RuleConfig, line_length),
     {Src, #{encoding := Encoding}} = elvis_file:src(Target),
     Args = [Limit, SkipComments, Encoding],
     elvis_utils:check_lines(Src, fun check_line_length/3, Args).
@@ -258,12 +421,12 @@ no_trailing_whitespace(_Config, Target, RuleConfig) ->
                   macro_names_config()) ->
     [elvis_result:item()].
 macro_names(Config, Target, RuleConfig) ->
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
+    IgnoreModules = option(ignore, RuleConfig, macro_names),
     {Root, _File} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
     case lists:member(ModuleName, IgnoreModules) of
         false ->
-            Regexp = maps:get(regex, RuleConfig, "^([A-Z][A-Z_0-9]+)$"),
+            Regexp = option(regex, RuleConfig, macro_names),
             MacroNodes = elvis_code:find(fun is_macro_define_node/1, Root,
                                          #{traverse => all, mode => node}),
             check_macro_names(Regexp, MacroNodes, _ResultsIn = []);
@@ -288,7 +451,7 @@ macro_module_names(Config, Target, _RuleConfig) ->
                       operator_spaces_config()) ->
     [elvis_result:item()].
 operator_spaces(Config, Target, RuleConfig) ->
-    Rules = maps:get(rules, RuleConfig, []),
+    Rules = option(rules, RuleConfig, operator_spaces),
     {Src, #{encoding := Encoding}} = elvis_file:src(Target),
     {Root, _} = elvis_file:parse_tree(Config, Target),
 
@@ -325,8 +488,8 @@ is_punctuation_token(Node) ->
                     nesting_level_config()) ->
     [elvis_result:item()].
 nesting_level(Config, Target, RuleConfig) ->
-    Level = maps:get(level, RuleConfig, 4),
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
+    Level = option(level, RuleConfig, nesting_level),
+    IgnoreModules = option(ignore, RuleConfig, nesting_level),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -346,8 +509,8 @@ nesting_level(Config, Target, RuleConfig) ->
                   god_modules_config()) ->
     [elvis_result:item()].
 god_modules(Config, Target, RuleConfig) ->
-    Limit = maps:get(limit, RuleConfig, 25),
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
+    Limit = option(limit, RuleConfig, god_modules),
+    IgnoreModules = option(ignore, RuleConfig, god_modules),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -389,7 +552,7 @@ no_if_expression(Config, Target, _RuleConfig) ->
                            invalid_dynamic_call_config()) ->
     [elvis_result:item()].
 invalid_dynamic_call(Config, Target, RuleConfig) ->
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
+    IgnoreModules = option(ignore, RuleConfig, invalid_dynamic_call),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
 
@@ -412,7 +575,7 @@ invalid_dynamic_call(Config, Target, RuleConfig) ->
                             used_ignored_variable_config()) ->
     [elvis_result:item()].
 used_ignored_variable(Config, Target, RuleConfig) ->
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
+    IgnoreModules = option(ignore, RuleConfig, used_ignored_variable),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ResultFun = result_node_line_col_fun(?USED_IGNORED_VAR_MSG),
     ModuleName = elvis_code:module_name(Root),
@@ -466,8 +629,8 @@ no_behavior_info(Config, Target, _RuleConfig) ->
                                module_naming_convention_config()) ->
     [elvis_result:item()].
 module_naming_convention(Config, Target, RuleConfig) ->
-    Regex = maps:get(regex, RuleConfig, ".*"),
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
+    Regex = option(regex, RuleConfig, module_naming_convention),
+    IgnoreModules = option(ignore, RuleConfig, module_naming_convention),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -531,8 +694,8 @@ no_spec_with_records(Config, Target, _RuleConfig) ->
                            dont_repeat_yourself_config()) ->
     [elvis_result:item()].
 dont_repeat_yourself(Config, Target, RuleConfig) ->
-    MinComplexity = maps:get(min_complexity, RuleConfig, 5),
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
+    MinComplexity = option(min_complexity, RuleConfig, dont_repeat_yourself),
+    IgnoreModules = option(ignore, RuleConfig, dont_repeat_yourself),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -566,10 +729,10 @@ dont_repeat_yourself(Config, Target, RuleConfig) ->
                         max_module_length_config()) ->
     [elvis_result:item()].
 max_module_length(Config, Target, RuleConfig) ->
-    MaxLength = maps:get(max_length, RuleConfig, 500),
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
-    CountComments = maps:get(count_comments, RuleConfig, false),
-    CountWhitespace = maps:get(count_whitespace, RuleConfig, false),
+    MaxLength = option(max_length, RuleConfig, max_module_length),
+    IgnoreModules = option(ignore, RuleConfig, max_module_length),
+    CountComments = option(count_comments, RuleConfig, max_module_length),
+    CountWhitespace = option(count_whitespace, RuleConfig, max_module_length),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     {Src, _} = elvis_file:src(Target),
@@ -604,10 +767,10 @@ max_module_length(Config, Target, RuleConfig) ->
                           max_function_length_config()) ->
     [elvis_result:item()].
 max_function_length(Config, Target, RuleConfig) ->
-    IgnoreFunctions = maps:get(ignore_functions, RuleConfig, []),
-    MaxLength = maps:get(max_length, RuleConfig, 30),
-    CountComments = maps:get(count_comments, RuleConfig, false),
-    CountWhitespace = maps:get(count_whitespace, RuleConfig, false),
+    IgnoreFunctions = option(ignore_functions, RuleConfig, max_function_length),
+    MaxLength = option(max_length, RuleConfig, max_function_length),
+    CountComments = option(count_comments, RuleConfig, max_function_length),
+    CountWhitespace = option(count_whitespace, RuleConfig, max_function_length),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     {Src, _} = elvis_file:src(Target),
@@ -666,8 +829,8 @@ max_function_length(Config, Target, RuleConfig) ->
               no_call_config()) ->
     [elvis_result:item()].
 no_call(Config, Target, RuleConfig) ->
-    DefaultFns = [],
-    no_call_common(Config, Target, RuleConfig, no_call_functions, DefaultFns, ?NO_CALL_MSG).
+    DefaultFns = option(no_call_functions, RuleConfig, no_call),
+    no_call_common(Config, Target, RuleConfig, no_call, DefaultFns, ?NO_CALL_MSG).
 
 
 -type no_debug_call_config() :: #{debug_functions => [function_spec()],
@@ -678,12 +841,8 @@ no_call(Config, Target, RuleConfig) ->
                     no_debug_call_config()) ->
     [elvis_result:item()].
 no_debug_call(Config, Target, RuleConfig) ->
-    DefaultFns = [{ct, pal},
-                  {ct, print},
-                  {io, format, 1},
-                  {io, format, 2}
-                 ],
-    no_call_common(Config, Target, RuleConfig, debug_functions, DefaultFns, ?NO_DEBUG_CALL_MSG).
+    DefaultFns = option(debug_functions, RuleConfig, no_debug_call),
+    no_call_common(Config, Target, RuleConfig, no_debug_call, DefaultFns, ?NO_DEBUG_CALL_MSG).
 
 
 -type no_common_caveats_call_config() :: #{caveat_functions => [function_spec()],
@@ -695,13 +854,8 @@ no_debug_call(Config, Target, RuleConfig) ->
     [elvis_result:item()].
 
 no_common_caveats_call(Config, Target, RuleConfig) ->
-    DefaultFns = [{timer, send_after, 2},
-                  {timer, send_after, 3},
-                  {timer, send_interval, 2},
-                  {timer, send_interval, 3},
-                  {erlang, size, 1}
-                 ],
-    no_call_common(Config, Target, RuleConfig, caveat_functions, DefaultFns,
+    DefaultFns = option(caveat_functions, RuleConfig, no_common_caveats_call),
+    no_call_common(Config, Target, RuleConfig, no_common_caveats_call, DefaultFns,
                    ?NO_COMMON_CAVEATS_CALL_MSG).
 
 -spec node_line_limits(ktn_code:tree_node())->
@@ -729,7 +883,7 @@ node_line_limits(FunctionNode) ->
     [elvis_result:item()].
 no_nested_try_catch(Config, Target, RuleConfig) ->
     {Root, _} = elvis_file:parse_tree(Config, Target),
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
+    IgnoreModules = option(ignore, RuleConfig, no_nested_try_catch),
     case lists:member(elvis_code:module_name(Root), IgnoreModules) of
         false -> Predicate = fun(Node) -> ktn_code:type(Node) == 'try' end,
                  ResultFun = result_node_line_fun(?NO_NESTED_TRY_CATCH),
@@ -754,12 +908,12 @@ no_nested_try_catch(Config, Target, RuleConfig) ->
 atom_naming_convention(Config, Target, RuleConfig) ->
     {Root, _File} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
+    IgnoreModules = option(ignore, RuleConfig, atom_naming_convention),
     case lists:member(ModuleName, IgnoreModules) of
         false ->
-            Regex = maps:get(regex, RuleConfig, "^([a-z][a-z0-9]*_?)*(_SUITE)?$"),
+            Regex = option(regex, RuleConfig, atom_naming_convention),
             RegexEnclosed
-                = enclosed_atoms_regex_or_same(maps:get(enclosed_atoms, RuleConfig, ".*"), Regex),
+                = enclosed_atoms_regex_or_same(option(enclosed_atoms, RuleConfig, atom_naming_convention), Regex),
             AtomNodes = elvis_code:find(fun is_atom_node/1, Root, #{traverse => all, mode => node}),
             check_atom_names(Regex, RegexEnclosed, AtomNodes, []);
         true ->
@@ -935,11 +1089,12 @@ check_no_spaces(Line, Num, _Args) ->
 -spec check_no_trailing_whitespace(binary(), integer(), map()) ->
     no_result | {ok, elvis_result:item()}.
 check_no_trailing_whitespace(Line, Num, RuleConfig) ->
+    IgnoreEmptyLines = option(ignore_empty_lines, RuleConfig, no_trailing_whitespace),
     Regex =
-        case RuleConfig of
+        case IgnoreEmptyLines of
             %% Lookbehind assertion: http://erlang.org/doc/man/re.html#sect17
-            #{ignore_empty_lines := true} -> "(?<=\\S)\\s+$";
-            _AnythingElse                 -> "\\s+$"
+            true -> "(?<=\\S)\\s+$";
+            false -> "\\s+$"
         end,
 
     case re:run(Line, Regex) of
@@ -1359,11 +1514,10 @@ is_children(Parent, Node) ->
                      string()
                     ) ->
     [elvis_result:item()].
-no_call_common(Config, Target, RuleConfig, ConfigKey, DefaultNoCallFns, Msg) ->
-    IgnoreModules = maps:get(ignore, RuleConfig, []),
+no_call_common(Config, Target, RuleConfig, Rule, NoCallFuns, Msg) ->
+    IgnoreModules = option(ignore, RuleConfig, Rule),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
-    NoCallFuns = maps:get(ConfigKey, RuleConfig, DefaultNoCallFns),
 
     case lists:member(ModuleName, IgnoreModules) of
         false ->
@@ -1413,3 +1567,15 @@ check_nested_try_catchs(ResultFun, TryExp) ->
                              false
                     end,
                     elvis_code:find(Predicate, TryExp)).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Internal Function Definitions
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec option(OptionName, RuleConfig, Rule) -> OptionValue
+      when OptionName :: atom(),
+           RuleConfig :: map(),
+           Rule :: atom(),
+           OptionValue :: term().
+option(OptionName, RuleConfig, Rule) ->
+    maps:get(OptionName, RuleConfig, default(Rule, OptionName)).

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -286,8 +286,8 @@ default(atom_naming_convention) ->
                                  function_naming_convention_config()) ->
     [elvis_result:item()].
 function_naming_convention(Config, Target, RuleConfig) ->
-    Regex = option(regex, RuleConfig, ?FUNCTION_NAME),
-    Ignores = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    Regex = option(regex, RuleConfig, function_naming_convention),
+    Ignores = option(ignore, RuleConfig, function_naming_convention),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
     IgnoredFuns = lists:filtermap(
@@ -325,8 +325,8 @@ errors_for_function_names(Regex, [FunctionName | RemainingFuncNames]) ->
                                  variable_naming_convention_config()) ->
     [elvis_result:item()].
 variable_naming_convention(Config, Target, RuleConfig) ->
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
-    Regex = option(regex, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, variable_naming_convention),
+    Regex = option(regex, RuleConfig, variable_naming_convention),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
     case lists:member(ModuleName, IgnoreModules) of
@@ -349,8 +349,8 @@ variable_naming_convention(Config, Target, RuleConfig) ->
                   line_length_config()) ->
     [elvis_result:item()].
 line_length(_Config, Target, RuleConfig) ->
-    Limit = option(limit, RuleConfig, ?FUNCTION_NAME),
-    SkipComments = option(skip_comments, RuleConfig, ?FUNCTION_NAME),
+    Limit = option(limit, RuleConfig, line_length),
+    SkipComments = option(skip_comments, RuleConfig, line_length),
     {Src, #{encoding := Encoding}} = elvis_file:src(Target),
     Args = [Limit, SkipComments, Encoding],
     elvis_utils:check_lines(Src, fun check_line_length/3, Args).
@@ -377,7 +377,7 @@ no_spaces(_Config, Target, _RuleConfig) ->
     [elvis_result:item()].
 no_trailing_whitespace(_Config, Target, RuleConfig) ->
     {Src, _} = elvis_file:src(Target),
-    IgnoreEmptyLines = option(ignore_empty_lines, RuleConfig, ?FUNCTION_NAME),
+    IgnoreEmptyLines = option(ignore_empty_lines, RuleConfig, no_trailing_whitespace),
     elvis_utils:check_lines(Src,
                             fun(Src1, Fun, _Args) ->
                                 check_no_trailing_whitespace(Src1, Fun, IgnoreEmptyLines)
@@ -393,12 +393,12 @@ no_trailing_whitespace(_Config, Target, RuleConfig) ->
                   macro_names_config()) ->
     [elvis_result:item()].
 macro_names(Config, Target, RuleConfig) ->
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, macro_names),
     {Root, _File} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
     case lists:member(ModuleName, IgnoreModules) of
         false ->
-            Regexp = option(regex, RuleConfig, ?FUNCTION_NAME),
+            Regexp = option(regex, RuleConfig, macro_names),
             MacroNodes = elvis_code:find(fun is_macro_define_node/1, Root,
                                          #{traverse => all, mode => node}),
             check_macro_names(Regexp, MacroNodes, _ResultsIn = []);
@@ -423,7 +423,7 @@ macro_module_names(Config, Target, _RuleConfig) ->
                       operator_spaces_config()) ->
     [elvis_result:item()].
 operator_spaces(Config, Target, RuleConfig) ->
-    Rules = option(rules, RuleConfig, ?FUNCTION_NAME),
+    Rules = option(rules, RuleConfig, operator_spaces),
     {Src, #{encoding := Encoding}} = elvis_file:src(Target),
     {Root, _} = elvis_file:parse_tree(Config, Target),
 
@@ -460,8 +460,8 @@ is_punctuation_token(Node) ->
                     nesting_level_config()) ->
     [elvis_result:item()].
 nesting_level(Config, Target, RuleConfig) ->
-    Level = option(level, RuleConfig, ?FUNCTION_NAME),
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    Level = option(level, RuleConfig, nesting_level),
+    IgnoreModules = option(ignore, RuleConfig, nesting_level),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -481,8 +481,8 @@ nesting_level(Config, Target, RuleConfig) ->
                   god_modules_config()) ->
     [elvis_result:item()].
 god_modules(Config, Target, RuleConfig) ->
-    Limit = option(limit, RuleConfig, ?FUNCTION_NAME),
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    Limit = option(limit, RuleConfig, god_modules),
+    IgnoreModules = option(ignore, RuleConfig, god_modules),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -524,7 +524,7 @@ no_if_expression(Config, Target, _RuleConfig) ->
                            invalid_dynamic_call_config()) ->
     [elvis_result:item()].
 invalid_dynamic_call(Config, Target, RuleConfig) ->
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, invalid_dynamic_call),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
 
@@ -547,7 +547,7 @@ invalid_dynamic_call(Config, Target, RuleConfig) ->
                             used_ignored_variable_config()) ->
     [elvis_result:item()].
 used_ignored_variable(Config, Target, RuleConfig) ->
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, used_ignored_variable),
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ResultFun = result_node_line_col_fun(?USED_IGNORED_VAR_MSG),
     ModuleName = elvis_code:module_name(Root),
@@ -601,8 +601,8 @@ no_behavior_info(Config, Target, _RuleConfig) ->
                                module_naming_convention_config()) ->
     [elvis_result:item()].
 module_naming_convention(Config, Target, RuleConfig) ->
-    Regex = option(regex, RuleConfig, ?FUNCTION_NAME),
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    Regex = option(regex, RuleConfig, module_naming_convention),
+    IgnoreModules = option(ignore, RuleConfig, module_naming_convention),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -666,8 +666,8 @@ no_spec_with_records(Config, Target, _RuleConfig) ->
                            dont_repeat_yourself_config()) ->
     [elvis_result:item()].
 dont_repeat_yourself(Config, Target, RuleConfig) ->
-    MinComplexity = option(min_complexity, RuleConfig, ?FUNCTION_NAME),
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    MinComplexity = option(min_complexity, RuleConfig, dont_repeat_yourself),
+    IgnoreModules = option(ignore, RuleConfig, dont_repeat_yourself),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
@@ -701,10 +701,10 @@ dont_repeat_yourself(Config, Target, RuleConfig) ->
                         max_module_length_config()) ->
     [elvis_result:item()].
 max_module_length(Config, Target, RuleConfig) ->
-    MaxLength = option(max_length, RuleConfig, ?FUNCTION_NAME),
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
-    CountComments = option(count_comments, RuleConfig, ?FUNCTION_NAME),
-    CountWhitespace = option(count_whitespace, RuleConfig, ?FUNCTION_NAME),
+    MaxLength = option(max_length, RuleConfig, max_module_length),
+    IgnoreModules = option(ignore, RuleConfig, max_module_length),
+    CountComments = option(count_comments, RuleConfig, max_module_length),
+    CountWhitespace = option(count_whitespace, RuleConfig, max_module_length),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     {Src, _} = elvis_file:src(Target),
@@ -739,10 +739,10 @@ max_module_length(Config, Target, RuleConfig) ->
                           max_function_length_config()) ->
     [elvis_result:item()].
 max_function_length(Config, Target, RuleConfig) ->
-    IgnoreFunctions = option(ignore_functions, RuleConfig, ?FUNCTION_NAME),
-    MaxLength = option(max_length, RuleConfig, ?FUNCTION_NAME),
-    CountComments = option(count_comments, RuleConfig, ?FUNCTION_NAME),
-    CountWhitespace = option(count_whitespace, RuleConfig, ?FUNCTION_NAME),
+    IgnoreFunctions = option(ignore_functions, RuleConfig, max_function_length),
+    MaxLength = option(max_length, RuleConfig, max_function_length),
+    CountComments = option(count_comments, RuleConfig, max_function_length),
+    CountWhitespace = option(count_whitespace, RuleConfig, max_function_length),
 
     {Root, _} = elvis_file:parse_tree(Config, Target),
     {Src, _} = elvis_file:src(Target),
@@ -801,8 +801,8 @@ max_function_length(Config, Target, RuleConfig) ->
               no_call_config()) ->
     [elvis_result:item()].
 no_call(Config, Target, RuleConfig) ->
-    DefaultFns = option(no_call_functions, RuleConfig, ?FUNCTION_NAME),
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    DefaultFns = option(no_call_functions, RuleConfig, no_call),
+    IgnoreModules = option(ignore, RuleConfig, no_call),
     no_call_common(Config, Target, IgnoreModules, DefaultFns, ?NO_CALL_MSG).
 
 
@@ -814,8 +814,8 @@ no_call(Config, Target, RuleConfig) ->
                     no_debug_call_config()) ->
     [elvis_result:item()].
 no_debug_call(Config, Target, RuleConfig) ->
-    DefaultFns = option(debug_functions, RuleConfig, ?FUNCTION_NAME),
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    DefaultFns = option(debug_functions, RuleConfig, no_debug_call),
+    IgnoreModules = option(ignore, RuleConfig, no_debug_call),
     no_call_common(Config, Target, IgnoreModules, DefaultFns, ?NO_DEBUG_CALL_MSG).
 
 
@@ -828,8 +828,8 @@ no_debug_call(Config, Target, RuleConfig) ->
     [elvis_result:item()].
 
 no_common_caveats_call(Config, Target, RuleConfig) ->
-    DefaultFns = option(caveat_functions, RuleConfig, ?FUNCTION_NAME),
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    DefaultFns = option(caveat_functions, RuleConfig, no_common_caveats_call),
+    IgnoreModules = option(ignore, RuleConfig, no_common_caveats_call),
     no_call_common(Config, Target, IgnoreModules, DefaultFns, ?NO_COMMON_CAVEATS_CALL_MSG).
 
 -spec node_line_limits(ktn_code:tree_node())->
@@ -857,7 +857,7 @@ node_line_limits(FunctionNode) ->
     [elvis_result:item()].
 no_nested_try_catch(Config, Target, RuleConfig) ->
     {Root, _} = elvis_file:parse_tree(Config, Target),
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, no_nested_try_catch),
     case lists:member(elvis_code:module_name(Root), IgnoreModules) of
         false -> Predicate = fun(Node) -> ktn_code:type(Node) == 'try' end,
                  ResultFun = result_node_line_fun(?NO_NESTED_TRY_CATCH),
@@ -882,12 +882,12 @@ no_nested_try_catch(Config, Target, RuleConfig) ->
 atom_naming_convention(Config, Target, RuleConfig) ->
     {Root, _File} = elvis_file:parse_tree(Config, Target),
     ModuleName = elvis_code:module_name(Root),
-    IgnoreModules = option(ignore, RuleConfig, ?FUNCTION_NAME),
+    IgnoreModules = option(ignore, RuleConfig, atom_naming_convention),
     case lists:member(ModuleName, IgnoreModules) of
         false ->
-            Regex = option(regex, RuleConfig, ?FUNCTION_NAME),
+            Regex = option(regex, RuleConfig, atom_naming_convention),
             RegexEnclosed
-                = enclosed_atoms_regex_or_same(option(enclosed_atoms, RuleConfig, ?FUNCTION_NAME), Regex),
+                = enclosed_atoms_regex_or_same(option(enclosed_atoms, RuleConfig, atom_naming_convention), Regex),
             AtomNodes = elvis_code:find(fun is_atom_node/1, Root, #{traverse => all, mode => node}),
             check_atom_names(Regex, RegexEnclosed, AtomNodes, []);
         true ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -134,119 +134,72 @@
 %% Default values
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec default(Rule :: atom(), OptionName :: atom()) -> DefaultOptionValue :: term().
-default(line_length, limit) -> 100;
-default(line_length, skip_comments) -> false;
-default(no_trailing_whitespace, ignore_empty_lines) -> false;
-default(macro_names, ignore) -> [];
-default(macro_names, regex) -> "^([A-Z][A-Z_0-9]+)$";
-default(atom_naming_convention, ignore) -> [];
-default(atom_naming_convention, regex) -> "^([a-z][a-z0-9]*_?)*(_SUITE)?$";
-default(atom_naming_convention, enclosed_atoms) -> ".*";
-default(operator_spaces, rules) -> [{right, ","}, {right, "++"}, {left, "++"}];
-default(nesting_level, level) -> 4;
-default(nesting_level, ignore) -> [];
-default(god_modules, limit) -> 25;
-default(god_modules, ignore) -> [];
-default(no_nested_try_catch, ignore) -> [];
-default(invalid_dynamic_call, ignore) -> [];
-default(used_ignored_variable, ignore) -> [];
-default(function_naming_convention, regex) -> "^([a-z][a-z0-9]*_?)*(_SUITE)?$";
-default(function_naming_convention, ignore) -> [];
-default(variable_naming_convention, regex) -> "^_?([A-Z][0-9a-zA-Z]*)$";
-default(variable_naming_convention, ignore) -> [];
-default(module_naming_convention, regex) -> "^([a-z][a-z0-9]*_?)*(_SUITE)?$";
-default(module_naming_convention, ignore) -> [];
-default(dont_repeat_yourself, min_complexity) -> 10;
-default(dont_repeat_yourself, ignore) -> [];
-default(max_module_length, max_length) -> 500;
-default(max_module_length, ignore) -> [];
-default(max_module_length, count_comments) -> false;
-default(max_module_length, count_whitespace) -> false;
-default(max_function_length, max_length) -> 30;
-default(max_function_length, count_comments) -> false;
-default(max_function_length, count_whitespace) -> false;
-default(max_function_length, ignore_functions) -> [];
-default(no_call, ignore) -> [];
-default(no_call, no_call_functions) -> [];
-default(no_debug_call, ignore) -> [];
-default(no_debug_call, debug_functions) -> [ {ct, pal}
-                                           , {ct, print}
-                                           , {io, format, 1}
-                                           , {io, format, 2}];
-default(no_common_caveats_call, ignore) -> [];
-default(no_common_caveats_call, caveat_functions) -> [ {timer, send_after, 2}
-                                                     , {timer, send_after, 3}
-                                                     , {timer, send_interval, 2}
-                                                     , {timer, send_interval, 3}
-                                                     , {erlang, size, 1}].
-
 -spec default(Rule :: atom()) -> DefaultRuleConfig :: term().
 default(line_length) ->
-    #{ limit => default(line_length, limit)
-     , skip_comments => default(line_length, skip_comments)
+    #{ limit => 100
+     , skip_comments => false
      };
 
 default(no_tabs) ->
     #{};
 
 default(no_trailing_whitespace) ->
-    #{ ignore_empty_lines => default(no_trailing_whitespace, ignore_empty_lines)
+    #{ ignore_empty_lines => false
      };
 
 default(macro_names) ->
-    #{ ignore => default(macro_names, ignore)
-     , regex => default(macro_names, regex)
+    #{ ignore => []
+     , regex => "^([A-Z][A-Z_0-9]+)$"
      };
 
 default(macro_module_names) ->
     #{};
 
 default(operator_spaces) ->
-    #{ rules => default(operator_spaces, rules)
+    #{ rules => [{right, ","}, {right, "++"}, {left, "++"}]
      };
 
 default(nesting_level) ->
-    #{ level => default(nesting_level, level)
-     , ignore => default(nesting_level, ignore)
+    #{ level => 4
+     , ignore => []
      };
 
 default(god_modules) ->
-    #{ limit => default(god_modules, limit)
-     , ignore => default(god_modules, ignore)
+    #{ limit => 25
+     , ignore => []
      };
 
 default(no_if_expression) ->
     #{};
 
 default(no_nested_try_catch) ->
-    #{ ignore => default(no_nested_try_catch, ignore)
+    #{ ignore => []
      };
 
 default(invalid_dynamic_call) ->
-    #{ ignore => default(invalid_dynamic_call, ignore)
+    #{ ignore => []
      };
 
 default(used_ignored_variable) ->
-    #{ ignore => default(used_ignored_variable, ignore)
+    #{ ignore => []
      };
 
 default(no_behavior_info) ->
     #{};
 
 default(function_naming_convention) ->
-    #{ regex => default(function_naming_convention, regex)
-     , ignore => default(function_naming_convention, ignore)
+    #{ regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$"
+     , ignore => []
      };
 
 default(variable_naming_convention) ->
-    #{ regex => default(variable_naming_convention, regex)
-     , ignore => default(variable_naming_convention, ignore)
+    #{ regex => "^_?([A-Z][0-9a-zA-Z]*)$"
+     , ignore => []
      };
 
 default(module_naming_convention) ->
-    #{ regex => default(module_naming_convention, regex)
-     , ignore => default(module_naming_convention, ignore)
+    #{ regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$"
+     , ignore => []
      };
 
 default(state_record_and_type) ->
@@ -256,41 +209,50 @@ default(no_spec_with_records) ->
     #{};
 
 default(dont_repeat_yourself) ->
-    #{ min_complexity => default(dont_repeat_yourself, min_complexity)
-     , ignore => default(dont_repeat_yourself, ignore)
+    #{ min_complexity => 10
+     , ignore => []
      };
 
 default(max_module_length) ->
-    #{ max_length => default(max_module_length, max_length)
-     , ignore => default(max_module_length, ignore)
-     , count_comments => default(max_module_length, count_comments)
-     , count_whitespace => default(max_module_length, count_whitespace)
+    #{ max_length => 500
+     , ignore => []
+     , count_comments => false
+     , count_whitespace => false
      };
 
 default(max_function_length) ->
-    #{ max_length => default(max_function_length, max_length)
-     , count_comments => default(max_function_length, count_comments)
-     , count_whitespace => default(max_function_length, count_whitespace)
-     , ignore_functions => default(max_function_length, ignore_functions)
+    #{ max_length => 30
+     , count_comments => false
+     , count_whitespace => false
+     , ignore_functions => []
      };
 
 default(no_call) ->
-    #{ ignore => default(no_call, ignore)
-     , no_call_functions => default(no_call, no_call_functions)
+    #{ ignore => []
+     , no_call_functions => []
      };
 
 default(no_debug_call) ->
-    #{ ignore => default(no_debug_call, ignore)
-     , debug_functions => default(no_debug_call, debug_functions)
+    #{ ignore => []
+     , debug_functions => [ {ct, pal}
+                          , {ct, print}
+                          , {io, format, 1}
+                          , {io, format, 2}]
      };
 
 default(no_common_caveats_call) ->
-    #{ ignore => default(no_common_caveats_call, ignore)
-     , caveat_functions => default(no_common_caveats_call, caveat_functions)
+    #{ ignore => []
+     , caveat_functions => [ {timer, send_after, 2}
+                           , {timer, send_after, 3}
+                           , {timer, send_interval, 2}
+                           , {timer, send_interval, 3}
+                           , {erlang, size, 1}]
      };
 
 default(atom_naming_convention) ->
-    #{}.
+    #{ ignore => []
+     , regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$"
+     , enclosed_atoms => ".*" }.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Rules
@@ -1578,4 +1540,4 @@ check_nested_try_catchs(ResultFun, TryExp) ->
            Rule :: atom(),
            OptionValue :: term().
 option(OptionName, RuleConfig, Rule) ->
-    maps:get(OptionName, RuleConfig, default(Rule, OptionName)).
+    maps:get(OptionName, RuleConfig, maps:get(OptionName, default(Rule))).

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -277,7 +277,7 @@ verify_operator_spaces(_Config) ->
     File = "fail_operator_spaces.erl",
     {ok, Path} = elvis_test_utils:find_file(SrcDirs, File),
 
-    [] = elvis_style:operator_spaces(ElvisConfig, Path, #{}),
+    [] = elvis_style:operator_spaces(ElvisConfig, Path, #{rules=>[]}),
 
     RuleConfig = #{rules => [{right, ","}]},
     [_, _, _] = elvis_style:operator_spaces(ElvisConfig, Path, RuleConfig),
@@ -307,7 +307,7 @@ verify_operator_spaces_latin1(_Config) ->
     File = "fail_operator_spaces_latin1.erl",
     {ok, Path} = elvis_test_utils:find_file(SrcDirs, File),
 
-    [] = elvis_style:operator_spaces(ElvisConfig, Path, #{}),
+    [] = elvis_style:operator_spaces(ElvisConfig, Path, #{rules => []}),
 
     AppendOptions = #{rules => [{right, "++"}, {left, "++"}]},
     [_, _] = elvis_style:operator_spaces(ElvisConfig, Path, AppendOptions).


### PR DESCRIPTION
I found different defaults in `elvis_style` and `elvis_rulesets`, and in those cases the public Wiki won.

[Fix inaka/elvis#525].