### PR TITLE
Allow module-level configuration via attribute `-elvis(_)`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ script:
   - rebar3 --version
   - erl -version
   - rebar3 test
+  - rebar3 escriptize
+  - _build/default/bin/elvis_core

--- a/config/test.config
+++ b/config/test.config
@@ -28,21 +28,25 @@
                   },
                   {elvis_style, state_record_and_type},
                   {elvis_style, no_spec_with_records}
-                 ]
+                 ],
+        ruleset => erl_files
        },
       #{dirs => ["../../"],
         filter => "Makefile",
         rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => []}},
-                  {elvis_project, protocol_for_deps_erlang_mk, #{ignore => []}}]
+                  {elvis_project, protocol_for_deps_erlang_mk, #{ignore => []}}],
+        ruleset => makefiles
        },
       #{dirs => ["../../"],
         filter => "rebar.config",
         rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}},
-                  {elvis_project, protocol_for_deps_rebar, #{ignore => []}}]
+                  {elvis_project, protocol_for_deps_rebar, #{ignore => []}}],
+        ruleset => rebar_config
        },
       #{dirs => ["../../"],
         filter => "elvis.config",
-        rules => [{elvis_project, old_configuration_format}]
+        rules => [{elvis_project, old_configuration_format}],
+        ruleset => elvis_config
        }
      ]
     },

--- a/config/test.config
+++ b/config/test.config
@@ -7,45 +7,21 @@
         filter => "**.erl",
         rules => [{elvis_style, line_length, #{limit => 80,
                                                skip_comments => false}},
-                  {elvis_style, no_tabs},
-                  {elvis_style, no_trailing_whitespace},
-                  {elvis_style, macro_names},
-                  {elvis_style, macro_module_names},
-                  {elvis_style, operator_spaces, #{rules => [{right, ","},
-                                                             {right, "++"},
-                                                             {left, "++"}]}},
                   {elvis_style, nesting_level, #{level => 3}},
-                  {elvis_style, god_modules, #{limit => 25}},
-                  {elvis_style, no_if_expression},
-                  {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
-                  {elvis_style, used_ignored_variable},
-                  {elvis_style, no_behavior_info},
-                  {
-                    elvis_style,
-                    module_naming_convention,
-                    #{regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$",
-                      ignore => []}
-                  },
-                  {elvis_style, state_record_and_type},
-                  {elvis_style, no_spec_with_records}
+                  {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}}
                  ],
         ruleset => erl_files
        },
       #{dirs => ["../../"],
         filter => "Makefile",
-        rules => [{elvis_project, no_deps_master_erlang_mk, #{ignore => []}},
-                  {elvis_project, protocol_for_deps_erlang_mk, #{ignore => []}}],
         ruleset => makefiles
        },
       #{dirs => ["../../"],
         filter => "rebar.config",
-        rules => [{elvis_project, no_deps_master_rebar, #{ignore => []}},
-                  {elvis_project, protocol_for_deps_rebar, #{ignore => []}}],
         ruleset => rebar_config
        },
       #{dirs => ["../../"],
         filter => "elvis.config",
-        rules => [{elvis_project, old_configuration_format}],
         ruleset => elvis_config
        }
      ]

--- a/elvis.config
+++ b/elvis.config
@@ -7,7 +7,8 @@
         filter => "*.erl",
         rules => [{elvis_style, invalid_dynamic_call, #{ignore => [elvis_core]}},
                   {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
-                  {elvis_style, no_debug_call, #{ignore => [elvis_result, elvis_utils]}}],
+                  {elvis_style, no_debug_call, #{ignore => [elvis_result, elvis_utils]}},
+                  {elvis_style, god_modules, #{ignore => [elvis_style]}}],
         ruleset => erl_files
        },
       #{dirs => ["."],

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -118,15 +118,15 @@ filter(_RuleGroup = #{filter := Filter}) ->
 filter(#{}) ->
     ?DEFAULT_FILTER.
 
--spec files(RuleGroup::config() | map()) -> [elvis_file:file()] | undefined.
+-spec files(RuleGroup::config() | map()) -> [elvis_file:file()].
 files(RuleGroup) when is_list(RuleGroup) ->
     lists:map(fun files/1, RuleGroup);
 files(_RuleGroup = #{files := Files}) ->
     Files;
 files(#{}) ->
-    undefined.
+    [].
 
--spec rules(Rules::config() | map()) -> [string()] | undefined.
+-spec rules(Rules::config() | map()) -> list().
 rules(Rules) when is_list(Rules) ->
     lists:map(fun rules/1, Rules);
 rules(#{rules := UserRules, ruleset := RuleSet}) ->
@@ -136,7 +136,7 @@ rules(#{rules := Rules}) -> Rules;
 rules(#{ruleset := RuleSet}) ->
     elvis_rulesets:rules(RuleSet);
 rules(#{}) ->
-    undefined.
+    [].
 
 %% @doc Takes a configuration and a list of files, filtering some
 %%      of them according to the 'filter' key, or if not specified

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -126,7 +126,7 @@ files(_RuleGroup = #{files := Files}) ->
 files(#{}) ->
     [].
 
--spec rules(Rules::config() | map()) -> list().
+-spec rules(Rules::config() | map()) -> [elvis_core:rule()].
 rules(Rules) when is_list(Rules) ->
     lists:map(fun rules/1, Rules);
 rules(#{rules := UserRules, ruleset := RuleSet}) ->
@@ -190,7 +190,7 @@ ignore_to_regexp(A) when is_atom(A) ->
     "/" ++ atom_to_list(A) ++ "\\.erl$".
 
 %% @doc Merge user rules (override) with elvis default rules.
--spec merge_rules(UserRules::list(), DefaultRules::list()) -> list().
+-spec merge_rules(UserRules::list(), DefaultRules::list()) -> [elvis_core:rule()].
 merge_rules(UserRules, DefaultRules) ->
     UnduplicatedRules =
         % Drops repeated rules
@@ -216,7 +216,7 @@ merge_rules(UserRules, DefaultRules) ->
         ),
     UnduplicatedRules ++ OverrideRules.
 
--spec is_rule_override(FileName::atom(), RuleName::atom(), UserRules::list()) ->
+-spec is_rule_override(FileName::atom(), RuleName::atom(), UserRules::[elvis_core:rule()]) ->
     boolean().
 is_rule_override(FileName, RuleName, UserRules) ->
     lists:any(

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -14,6 +14,8 @@
         , resolve_files/1
         , resolve_files/2
         , apply_to_files/2
+          %% Rules
+        , merge_rules/2
         ]).
 
 -export_type([config/0]).

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -106,7 +106,7 @@ load_file_data(Config, File) ->
     end.
 
 %% @private
--spec main([]) -> ok.
+-spec main([]) -> ok | {fail, [elvis_result:file()]}.
 main([]) ->
     ok = application:load(elvis_core),
     rock(elvis_config:from_file("elvis.config")).

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -158,7 +158,7 @@ is_elvis_attr(Node) ->
 elvis_attr_rules([] = _ElvisAttrs) ->
     undefined;
 elvis_attr_rules(ElvisAttrs) ->
-    [ktn_code:attr(value, ElvisAttr) || ElvisAttr <- ElvisAttrs].
+    [Rule || ElvisAttr <- ElvisAttrs, Rule <- ktn_code:attr(value, ElvisAttr)].
 
 apply_rule({Module, Function}, {Result, Config, File}) ->
     apply_rule({Module, Function, #{}}, {Result, Config, File});

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -11,6 +11,9 @@
 %% for internal use only
 -export([do_rock/2]).
 
+%% for eating what we cook
+-export([main/1]).
+
 -type source_filename() :: nonempty_string().
 -type target() :: source_filename() | module().
 
@@ -101,6 +104,12 @@ load_file_data(Config, File) ->
             elvis_utils:error_prn(Msg, [Reason, Path]),
             File
     end.
+
+%% @private
+-spec main([]) -> ok.
+main([]) ->
+    ok = application:load(elvis_core),
+    rock(elvis_config:from_file("elvis.config")).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Private

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -17,6 +17,10 @@
 -type source_filename() :: nonempty_string().
 -type target() :: source_filename() | module().
 
+-type rule() :: {Module :: module(), Function :: atom(), Options :: #{ atom() => term() }}
+              | {Module :: module(), Function :: atom()}.
+-export_type([rule/0]).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Public API
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -85,14 +89,14 @@ do_parallel_rock(Config0) ->
                               [], [Config], Files, Parallel),
     elvis_result_status(Results).
 
--spec do_rock(elvis_file:file(), map() | [map()]) -> {ok, elvis_result:file()}.
+-spec do_rock(elvis_file:file(), elvis_config:config() | map()) -> {ok, elvis_result:file()}.
 do_rock(File, Config) ->
     LoadedFile = load_file_data(Config, File),
     Results = apply_rules(Config, LoadedFile),
     {ok, Results}.
 
 %% @private
--spec load_file_data(map() | [map()], elvis_file:file()) -> elvis_file:file().
+-spec load_file_data(elvis_config:config() | map(), elvis_file:file()) -> elvis_file:file().
 load_file_data(Config, File) ->
     Path = elvis_file:path(File),
     elvis_utils:info("Loading ~s", [Path]),
@@ -130,7 +134,7 @@ apply_rules_and_print(Config, File) ->
     elvis_result:print_results(Results),
     Results.
 
--spec apply_rules(map(), File::elvis_file:file()) ->
+-spec apply_rules(elvis_config:config() | map(), File::elvis_file:file()) ->
     elvis_result:file().
 apply_rules(Config, File) ->
     Rules = elvis_config:rules(Config),

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -158,12 +158,7 @@ is_elvis_attr(Node) ->
 elvis_attr_rules([] = _ElvisAttrs) ->
     undefined;
 elvis_attr_rules(ElvisAttrs) ->
-    lists:foldl(
-        fun (ElvisAttr, ModuleLevelRules) ->
-            ModuleLevelRules ++ ktn_code:attr(value, ElvisAttr)
-        end,
-        [],
-        ElvisAttrs).
+    [ktn_code:attr(value, ElvisAttr) || ElvisAttr <- ElvisAttrs].
 
 apply_rule({Module, Function}, {Result, Config, File}) ->
     apply_rule({Module, Function, #{}}, {Result, Config, File});

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -11,7 +11,7 @@
 %% for internal use only
 -export([do_rock/2]).
 
-%% for eating what we cook
+%% for eating our own dogfood
 -export([main/1]).
 
 -type source_filename() :: nonempty_string().

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -141,17 +141,7 @@ merge_rules(ElvisAttrRules, undefined = _ElvisConfigRules) ->
 merge_rules(undefined = _ElvisAttrRules, ElvisConfigRules) ->
     ElvisConfigRules;
 merge_rules(ElvisAttrRules, ElvisConfigRules) ->
-    lists:filter(
-        fun (ElvisConfigRule) ->
-            not(lists:any(
-                    fun (ElvisAttrRule) ->
-                        {erlang:element(1, ElvisAttrRule), erlang:element(2, ElvisAttrRule)}
-                            =:=
-                        {erlang:element(1, ElvisConfigRule), erlang:element(2, ElvisConfigRule)}
-                    end,
-                    ElvisAttrRules))
-        end,
-        ElvisConfigRules) ++ ElvisAttrRules.
+    elvis_config:merge_rules(ElvisAttrRules, ElvisConfigRules).
 
 is_elvis_attr(Node) ->
     ktn_code:type(Node) =:= elvis.
@@ -161,15 +151,10 @@ elvis_attr_rules([] = _ElvisAttrs) ->
 elvis_attr_rules(ElvisAttrs) ->
     lists:foldl(
         fun (ElvisAttr, ModuleLevelRules) ->
-            ModuleLevelRules ++ try_attr_rules(ktn_code:attr(value, ElvisAttr))
+            ModuleLevelRules ++ ktn_code:attr(value, ElvisAttr)
         end,
         [],
         ElvisAttrs).
-
-try_attr_rules(ModuleLevelRules) when is_map(ModuleLevelRules) ->
-    maps:get(module, ModuleLevelRules, []);
-try_attr_rules(_ModuleLevelRules) ->
-    [].
 
 apply_rule({Module, Function}, {Result, Config, File}) ->
     apply_rule({Module, Function, #{}}, {Result, Config, File});

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -148,8 +148,6 @@ merge_rules({file, ParseTree}, ElvisConfigRules) ->
     ElvisAttrs = elvis_code:find(fun is_elvis_attr/1, ParseTree,
                                  #{ traverse => content, mode => node }),
     ElvisAttrRules = elvis_attr_rules(ElvisAttrs),
-    merge_rules(ElvisAttrRules, ElvisConfigRules);
-merge_rules(ElvisAttrRules, ElvisConfigRules) ->
     elvis_config:merge_rules(ElvisAttrRules, ElvisConfigRules).
 
 is_elvis_attr(Node) ->

--- a/src/elvis_file.erl
+++ b/src/elvis_file.erl
@@ -60,7 +60,7 @@ parse_tree(_Config, File) ->
     throw({invalid_file, File}).
 
 %% @doc Loads and adds all related file data.
--spec load_file_data(map(), file()) -> file().
+-spec load_file_data(elvis_config:config() | map(), file()) -> file().
 load_file_data(Config, File0 = #{path := _Path}) ->
     {_, File1} = src(File0),
     {_, File2} = parse_tree(Config, File1),

--- a/src/elvis_rulesets.erl
+++ b/src/elvis_rulesets.erl
@@ -2,7 +2,7 @@
 
 -export([rules/1]).
 
--spec rules(Group::atom()) -> list().
+-spec rules(Group::atom()) -> [elvis_core:rule()].
 rules(erl_files) ->
     lists:map(
         fun (Rule) ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -887,7 +887,10 @@ atom_naming_convention(Config, Target, RuleConfig) ->
         false ->
             Regex = option(regex, RuleConfig, atom_naming_convention),
             RegexEnclosed
-                = enclosed_atoms_regex_or_same(option(enclosed_atoms, RuleConfig, atom_naming_convention), Regex),
+                = enclosed_atoms_regex_or_same(option(enclosed_atoms,
+                                                      RuleConfig,
+                                                      atom_naming_convention),
+                                               Regex),
             AtomNodes = elvis_code:find(fun is_atom_node/1, Root, #{traverse => all, mode => node}),
             check_atom_names(Regex, RegexEnclosed, AtomNodes, []);
         true ->

--- a/test/elvis_test_utils.erl
+++ b/test/elvis_test_utils.erl
@@ -1,12 +1,18 @@
 -module(elvis_test_utils).
 
 -export([ config/0
+        , config/1
         , find_file/2
         ]).
 
 -spec config() -> elvis_config:config().
 config() ->
   application:get_env(elvis_core, config, []).
+
+-spec config(Ruleset :: atom()) -> elvis_config:config().
+config(Ruleset) ->
+  RulesetCfgs = application:get_env(elvis_core, config, []),
+  [Cfg || Cfg <- RulesetCfgs, maps:find(ruleset, Cfg) =:= {ok, Ruleset}].
 
 -spec find_file([string()], string()) ->
     {ok, elvis_file:file()} | {error, enoent}.

--- a/test/elvis_test_utils.erl
+++ b/test/elvis_test_utils.erl
@@ -12,7 +12,7 @@ config() ->
 -spec config(Ruleset :: atom()) -> elvis_config:config().
 config(Ruleset) ->
   RulesetCfgs = application:get_env(elvis_core, config, []),
-  [Cfg || Cfg <- RulesetCfgs, maps:find(ruleset, Cfg) =:= {ok, Ruleset}].
+  [Cfg || #{ruleset := R} = Cfg <- RulesetCfgs, R =:= Ruleset].
 
 -spec find_file([string()], string()) ->
     {ok, elvis_file:file()} | {error, enoent}.

--- a/test/examples/pass_atom_naming_convention_elvis_attr.erl
+++ b/test/examples/pass_atom_naming_convention_elvis_attr.erl
@@ -1,0 +1,19 @@
+-module(pass_atom_naming_convention_elvis_attr).
+
+-export([for_test/0]).
+
+-elvis([{elvis_style, atom_naming_convention, #{ regex => "^[a-zA-Z\_]+$",
+                                                 enclosed_atoms => "^[a-zA-Z\_0-9' \-\\\\]+$" }},
+        {elvis_style, line_length, #{limit => 100}}]).
+
+for_test() ->
+    this_is_not_an_OK_atom,
+    'and_neither-is_this',
+    'or_THIS',
+    '1_of_us_is_wrong',
+    '\' this nasty atom\'',
+    '\'',
+    '\'\'',
+    '\'startswithbacktick',
+    'backtick\'inside',
+    'backtick at the end\''.

--- a/test/examples/pass_dont_repeat_yourself_elvis_attr.erl
+++ b/test/examples/pass_dont_repeat_yourself_elvis_attr.erl
@@ -1,0 +1,29 @@
+-module(pass_dont_repeat_yourself_elvis_attr).
+
+-export([
+         repeated_complexity_5/2,
+         repeated_complexity_10/2
+        ]).
+
+-elvis([{elvis_style, dont_repeat_yourself, #{min_complexity => 13}},
+        {elvis_style, no_debug_call, disable},
+        {elvis_style, function_naming_convention, #{regex => "^[a-z_0-9]+$"}}]).
+
+repeated_complexity_5(X, Y) ->
+    Z = X ++ [ok],
+    W = Y ++ [ok],
+    Z ++ W ++ [ok].
+
+-spec repeated_complexity_10(any(), any()) -> fun((...) -> any()).
+repeated_complexity_10(X, Y) ->
+    Z = case X of
+            Y -> io:format("Y");
+            _ -> <<"ok">>
+        end,
+
+    W = case Z of
+            X -> io:format("Y");
+            _ -> <<"ok">>
+        end,
+
+    fun(_) -> W end.

--- a/test/examples/pass_function_naming_convention_elvis_attr.erl
+++ b/test/examples/pass_function_naming_convention_elvis_attr.erl
@@ -1,0 +1,42 @@
+-module(pass_function_naming_convention_elvis_attr).
+
+-dialyzer({nowarn_function, bad_names_inside/0}).
+
+-export([bad_names_inside/0]).
+
+-elvis([{elvis_style, function_naming_convention, #{regex => "^[a-z\_A-Z'\-\?@]+$"}}]).
+-elvis([{elvis_style, line_length, #{limit => 88}}]).
+-elvis([{elvis_style, atom_naming_convention, #{regex => ".*"}}]).
+
+%% Function names must use only lowercase characters.
+%% Words in function names must be separated with _.
+
+%% Cf. https://github.com/inaka/erlang_guidelines#function-names
+
+bad_names_inside() ->
+    camelCase(should, fail),
+    'ALL_CAPS'(should, fail),
+    'Initial_cap'(should, fail),
+    'ok-for-lisp'(should, fail),
+    'no_predicates?'(should, fail),
+    user@location(should, fail).
+
+%% Private / hidden functions still checked
+
+camelCase(Should, Fail) ->
+    [Should, Fail].
+
+'ALL_CAPS'(Should, Fail) ->
+    [Should, Fail].
+
+'Initial_cap'(Should, Fail) ->
+    [Should, Fail].
+
+'ok-for-lisp'(Should, Fail) ->
+    [Should, Fail].
+
+'no_predicates?'(Should, Fail) ->
+    [Should, Fail].
+
+user@location(Should, Fail) ->
+    [Should, Fail].

--- a/test/examples/pass_god_modules_elvis_attr.erl
+++ b/test/examples/pass_god_modules_elvis_attr.erl
@@ -1,0 +1,60 @@
+-module(pass_god_modules_elvis_attr).
+
+-elvis([{elvis_style, god_modules, #{limit => 26}}]).
+-elvis([{elvis_style, function_naming_convention, #{regex => "^[a-z0-9_]+$"}}]).
+
+-export([
+         function_1/0,
+         function_2/0,
+         function_3/0,
+         function_4/0,
+         function_5/0,
+         function_6/0,
+         function_7/0,
+         function_8/0,
+         function_9/0,
+         function_10/0,
+         function_11/0,
+         function_12/0,
+         function_13/0,
+         function_14/0,
+         function_15/0,
+         function_16/0,
+         function_17/0,
+         function_18/0,
+         function_19/0,
+         function_20/0,
+         function_21/0,
+         function_22/0,
+         function_23/0,
+         function_24/0,
+         function_25/0,
+         function_26/0
+        ]).
+
+function_1() -> ok.
+function_2() -> ok.
+function_3() -> ok.
+function_4() -> ok.
+function_5() -> ok.
+function_6() -> ok.
+function_7() -> ok.
+function_8() -> ok.
+function_9() -> ok.
+function_10() -> ok.
+function_11() -> ok.
+function_12() -> ok.
+function_13() -> ok.
+function_14() -> ok.
+function_15() -> ok.
+function_16() -> ok.
+function_17() -> ok.
+function_18() -> ok.
+function_19() -> ok.
+function_20() -> ok.
+function_21() -> ok.
+function_22() -> ok.
+function_23() -> ok.
+function_24() -> ok.
+function_25() -> ok.
+function_26() -> ok.

--- a/test/examples/pass_invalid_dynamic_call_elvis_attr.erl
+++ b/test/examples/pass_invalid_dynamic_call_elvis_attr.erl
@@ -1,0 +1,72 @@
+-module(pass_invalid_dynamic_call_elvis_attr).
+
+-ignore_xref({normal, call, 0}).
+-ignore_xref({another_normal, call, 0}).
+
+-elvis([{elvis_style, invalid_dynamic_call, disable}]).
+-elvis([{elvis_style, line_length, #{limit => 100}}]).
+-elvis([{elvis_style, atom_naming_convention, #{regex => "^([a-z][a-z0-9]*_?_?)*(_SUITE)?$"}}]).
+
+-dialyzer(no_match).
+
+-export([
+         dynamic_module_name_call/0,
+         dynamic_function_name_call/0,
+         another_dynamic_module_name_call/0,
+         dynamic_module_name_call_in_case/0,
+         dynamic_module_name_call_in_try_of/0,
+         dynamic_module_name_call_in_try_catch/0,
+         dynamic_module_name_call_in_catch/0
+        ]).
+
+dynamic_module_name_call() ->
+    normal:call(),
+    Module = a_module,
+    Module:call().
+
+dynamic_function_name_call() ->
+    normal:call(),
+    Function = a_function,
+    a_module:Function(),
+    normal:call().
+
+another_dynamic_module_name_call() ->
+    normal:call(),
+    another_normal:call(),
+    Module = another_module,
+    Module:call_to_function(),
+    Module:call_to__another_function().
+
+dynamic_module_name_call_in_case() ->
+    normal:call(),
+    another_normal:call(),
+    case 1 of
+        1 ->
+            Module = another_module,
+            Module:call_to_function();
+        2 -> ok
+    end.
+
+dynamic_module_name_call_in_try_of() ->
+    normal:call(),
+    another_normal:call(),
+    Module = yam,
+    try Module:call_to_function() of
+        a -> ok
+    catch _:_ ->
+        ok
+    end.
+
+dynamic_module_name_call_in_try_catch() ->
+    normal:call(),
+    another_normal:call(),
+    Module = yamm,
+    try
+        Module:call_to_function()
+    catch _:_ ->
+        ok
+    end.
+
+dynamic_module_name_call_in_catch() ->
+    Module = yammm,
+    catch Module:call_to_function().

--- a/test/examples/pass_invalid_dynamic_call_elvis_attr.erl
+++ b/test/examples/pass_invalid_dynamic_call_elvis_attr.erl
@@ -1,13 +1,19 @@
 -module(pass_invalid_dynamic_call_elvis_attr).
 
--ignore_xref({normal, call, 0}).
--ignore_xref({another_normal, call, 0}).
-
 -elvis([{elvis_style, invalid_dynamic_call, disable}]).
 -elvis([{elvis_style, line_length, #{limit => 100}}]).
 -elvis([{elvis_style, atom_naming_convention, #{regex => "^([a-z][a-z0-9]*_?_?)*(_SUITE)?$"}}]).
 
 -dialyzer(no_match).
+
+-ignore_xref({normal, call, 0}).
+-ignore_xref({a_module, call, 0}).
+-ignore_xref({a_module, a_function, 0}).
+-ignore_xref({another_normal, call, 0}).
+-ignore_xref({another_normal, call_to__another_function, 0}).
+-ignore_xref({yam, call_to_function, 0}).
+-ignore_xref({yamm, call_to_function, 0}).
+-ignore_xref({yammm, call_to_function, 0}).
 
 -export([
          dynamic_module_name_call/0,

--- a/test/examples/pass_line_length_elvis_attr.erl
+++ b/test/examples/pass_line_length_elvis_attr.erl
@@ -1,11 +1,11 @@
 -module(pass_line_length_elvis_attr).
 
--ignore_xref({model, random_ant_state, 1}).
-
 -elvis([{elvis_style, line_length, #{limit => 189}}]).
 -elvis([{elvis_style, no_debug_call, disable}]).
 -elvis([{elvis_style, function_naming_convention, #{regex => "^function_[0-9]+$"}}]).
 -elvis([{elvis_style, macro_module_names, disable}]).
+
+-ignore_xref([{model, random_ant_state, 1}]).
 
 -export([
          function_1/0,

--- a/test/examples/pass_line_length_elvis_attr.erl
+++ b/test/examples/pass_line_length_elvis_attr.erl
@@ -1,0 +1,43 @@
+-module(pass_line_length_elvis_attr).
+
+-ignore_xref({model, random_ant_state, 1}).
+
+-elvis([{elvis_style, line_length, #{limit => 189}}]).
+-elvis([{elvis_style, no_debug_call, disable}]).
+-elvis([{elvis_style, function_naming_convention, #{regex => "^function_[0-9]+$"}}]).
+-elvis([{elvis_style, macro_module_names, disable}]).
+
+-export([
+         function_1/0,
+         function_2/0,
+         function_3/0,
+         function_4/0,
+         function_5/0,
+         function_6/2,
+         function_7/0
+        ]).
+
+% Single line comment over 100 characters!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+function_1() ->
+    io:format("Hello").
+
+function_2() ->
+    io:format("This line is 101 characters long and should be detected, yeah!!!!!!!!!!!!!!!!!!!!!!").
+
+function_3() ->
+    io:format("This line is 100 characters long and shouldn't be detected!!!!!!!!!!!!!!!!!!!!!!!!").
+
+function_4() ->
+    %% Single line comment with spaces in front that is over 100 characters. So many test cases!!!!!!!!!!!!!!!!!!!!!!!
+    io:format("This line is 90 characters long and should be detected!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!").
+
+function_5() ->
+    io:format("This line is 90 characters long and should be detected ~p!!!!!!!!!!!!!!!!!!!!!!!!!!", [yeah]),
+    io:format("This line is 90 characters long and should be detected ~p and these two escaped ~p!!!!!!!!!!!!!!!!!!", [yeah, no]).
+
+function_6(Config, AntPositions)->
+    gb_trees:from_orddict([{Pos, #{pos => Pos, state => model:random_ant_state(Config)}} || Pos <- lists:sort(AntPositions)]). % {Pozycja, CałyAgent} - ew. do zmiany, jest zbalansowany [DG]
+
+function_7() ->
+    io:format("Going to put a comment after this..."), % This comment pushes the line past 100 characters...
+    ok.

--- a/test/examples/pass_macro_module_names_elvis_attr.erl
+++ b/test/examples/pass_macro_module_names_elvis_attr.erl
@@ -1,8 +1,5 @@
 -module(pass_macro_module_names_elvis_attr).
 
--ignore_xref({module, function_name, 1}).
--ignore_xref({lists, fail_macro_module_names, 0}).
-
 -dialyzer({nowarn_function, [function_name/0, build_binary/0]}).
 
 -elvis([{elvis_style, macro_module_names, disable}]).
@@ -14,6 +11,10 @@
          no_errors/0,
          build_binary/0
         ]).
+
+-ignore_xref({pass_macro_module_names_elvis_attr, function_name, 0}).
+-ignore_xref({module, function_name, 1}).
+-ignore_xref({lists, pass_macro_module_names_elvis_attr, 0}).
 
 -define(FUN_NAME, function_name).
 -define(BINARY, "bla").

--- a/test/examples/pass_macro_module_names_elvis_attr.erl
+++ b/test/examples/pass_macro_module_names_elvis_attr.erl
@@ -1,0 +1,42 @@
+-module(pass_macro_module_names_elvis_attr).
+
+-ignore_xref({module, function_name, 1}).
+-ignore_xref({lists, fail_macro_module_names, 0}).
+
+-dialyzer({nowarn_function, [function_name/0, build_binary/0]}).
+
+-elvis([{elvis_style, macro_module_names, disable}]).
+-elvis([{elvis_style, macro_names, #{regex => "^[a-zA-Z_]+$"}}]).
+
+-export([
+         module_name/0,
+         function_name/0,
+         no_errors/0,
+         build_binary/0
+        ]).
+
+-define(FUN_NAME, function_name).
+-define(BINARY, "bla").
+-define(BINARY_SIZE, 3).
+-define(function_name, function_name).
+-define(module_name, ?MODULE).
+
+module_name() ->
+    ?MODULE:function_name(),
+    ?module_name:?function_name().
+
+function_name() ->
+    module:?FUN_NAME(params),
+    module:?FUN_NAME (params),
+    lists:?MODULE().
+
+build_binary() ->
+    Bin = <<?BINARY:32>>,
+    _Bin2 = <<Bin:?BINARY_SIZE/binary>>,
+    _Bin3 = <<?BINARY:?BINARY_SIZE>>,
+    BinSize = ?BINARY_SIZE,
+    _Bin4 = <<?BINARY:BinSize>>,
+    <<Bin, ?BINARY:1, "prefix">>.
+
+no_errors() ->
+    ?LINE.

--- a/test/examples/pass_macro_names_elvis_attr.erl
+++ b/test/examples/pass_macro_names_elvis_attr.erl
@@ -1,0 +1,25 @@
+-module(pass_macro_names_elvis_attr).
+
+ -define (bad_name,   "(no)").
+-define(GOOD_NAME,  "(megusta)").
+-define(wtf_NAME,   "(yuno)").
+-define(GOOD_NAME(Arg), "(megusta)").
+-define(GOOD_NAME_TOO (Arg), "(megusta)").
+-define(  'POTENTIAL_BAD-NAME'  , nomegusta).
+-define('A,aZ', 2).
+
+-elvis([{elvis_style, macro_names, #{regex => "^[a-zA-Z_,\-]+$"}}]).
+
+-export([
+         define/1,
+         use_define/1
+        ]).
+
+define(not_a_macro) -> its_not.
+define(_Also, not_a_macro) -> still_not.
+
+%% this is not using -define
+use_define(x) ->
+  define(this_is, not_a_macro),
+  Not = "-define(this_isnt, a_macro)",
+  Not.

--- a/test/examples/pass_max_function_length_elvis_attr.erl
+++ b/test/examples/pass_max_function_length_elvis_attr.erl
@@ -1,0 +1,39 @@
+-module(pass_max_function_length_elvis_attr).
+
+-export([f5/1, f10/1, f15/1]).
+
+-elvis([{elvis_style, max_function_length, #{ max_length => 15,
+                                              count_comments => true,
+                                              count_whitespace => true }}]).
+f5(_) -> %% 1
+    %% 2
+    %% 3
+
+    ok. %% 5
+
+f10(_) -> %% 1
+    %% 2
+    %% 3
+    %% 4
+
+    %% 6
+    %% 7
+
+    %% 9
+    ok. %% 10
+
+f15(_) -> %% 1
+    %% 2
+    %% 3
+    %% 4
+
+    %% 6
+    %% 7
+    %% 8
+    %% 9
+
+    %% 11
+    %% 12
+
+    %% 14
+    ok. %% 15

--- a/test/examples/pass_max_module_length_elvis_attr.erl
+++ b/test/examples/pass_max_module_length_elvis_attr.erl
@@ -1,0 +1,18 @@
+-module(pass_max_module_length_elvis_attr).
+
+-elvis([{elvis_style, max_module_length, #{max_length => 19, count_comments => true, count_whitespace => true}}]).
+-elvis([{elvis_style, line_length, disable}]).
+
+-export([f/1]).
+
+
+
+
+%% Random comment
+
+
+
+
+
+%% @doc A function
+f(_) -> ok.

--- a/test/examples/pass_module_naming-convention_elvis_attr.erl
+++ b/test/examples/pass_module_naming-convention_elvis_attr.erl
@@ -1,0 +1,3 @@
+-module('pass_module_naming-convention_elvis_attr').
+
+-elvis([{elvis_style, module_naming_convention, #{regex => "^[a-z_\-]+$"}}]).

--- a/test/examples/pass_nesting_level_elvis_attr.erl
+++ b/test/examples/pass_nesting_level_elvis_attr.erl
@@ -1,0 +1,203 @@
+-module(pass_nesting_level_elvis_attr).
+
+-elvis([{elvis_style, nesting_level, #{level => 5}}, {elvis_style, no_if_expression, disable}]).
+-elvis([{elvis_style, line_length, #{limit => 100}}]).
+
+-dialyzer(no_match).
+
+%% Used so that the line positions don't change for tests.
+-compile([export_all]).
+
+exceed_with_five_levels() ->
+    case 1 of
+        1 -> case 2 of
+                 2 -> case 3 of
+                          3 -> case 3 of
+                                   4 -> four
+                               end
+                      end
+             end
+    end,
+    case 1 of
+        1 -> case 2 of
+                 2 -> case 3 of
+                          3 -> fourth
+                      end
+             end
+    end.
+
+exceed_at_diff_branches() ->
+    case 1 of
+        1 -> ok;
+        2 -> case 2 of
+                 1 -> ok;
+                 2 -> ok;
+                 3 -> if
+                          true -> true;
+                          false -> false
+                      end;
+                 4 -> ok
+             end;
+        3 -> 3
+    end.
+
+exceed_with_try_of() ->
+    case 1 of
+        1 -> ok;
+        2 -> try 2 of
+                 1 -> ok;
+                 2 -> ok;
+                 3 -> if
+                          true -> true;
+                          false -> false
+                      end;
+                 4 -> ok
+             catch
+                 _:_ -> ok
+             end;
+        3 -> 3
+    end.
+
+dont_exceed_with_try() ->
+    case 1 of
+        1 -> ok;
+        2 -> try
+                 2,
+                 if
+                     true -> true;
+                     false -> false
+                 end
+             catch
+                 _:_ -> ok
+             end;
+        3 -> 3
+    end.
+
+exceed_with_try_catch() ->
+    case 1 of
+        1 -> ok;
+        2 -> try
+                 2
+             catch
+                 _:_ ->
+                     if
+                         true -> true;
+                         false -> false
+                     end
+             end;
+        3 -> 3
+    end.
+
+dont_exceed_with_try_after() ->
+    case 1 of
+        1 -> ok;
+        2 -> try
+                 2
+             catch
+                 _:_ -> ok
+             after
+                 if
+                     true -> true;
+                     false -> false
+                 end
+             end;
+        3 -> 3
+    end.
+
+dont_exceed_with_catch() ->
+    case 1 of
+        1 -> ok;
+        2 -> catch
+                 if
+                     true -> true;
+                     false -> false
+                 end;
+        3 -> 3
+    end.
+
+exceed_with_receive() ->
+    case 1 of
+        1 -> ok;
+        2 -> receive
+                 1 -> ok;
+                 2 -> ok;
+                 3 ->
+                     if
+                         bla -> true;
+                         false -> false
+                     end;
+                 4 -> ok
+             end;
+        3 -> 3
+    end.
+
+dont_exceed_with_receive_after() ->
+    case 1 of
+        1 -> ok;
+        2 -> receive
+                 1 -> ok;
+                 2 -> ok;
+                 3 -> ok
+             after
+                 1000 ->
+                     if
+                         true -> true;
+                         false -> false
+                     end
+             end;
+        3 -> 3
+    end.
+
+dont_exceed_with_list_compr() ->
+    case 1 of
+        1 -> ok;
+        2 -> receive
+                 1 -> ok;
+                 2 -> ok;
+                 3 -> ok
+             after
+                 1000 ->
+                     [X || X <- [1, 2, 3]]
+             end;
+        3 -> 3
+    end.
+
+exceed_with_list_compr() ->
+    case 1 of
+        1 -> ok;
+        2 -> receive
+                 1 -> ok;
+                 2 -> ok;
+                 3 -> [case X of
+                           1 -> ok;
+                           _ -> not_ok
+                       end
+                       || X <- [1, 2, 3]];
+                 4 -> ok
+             end;
+        3 -> 3
+    end.
+
+exceed_with_fun() ->
+    case 1 of
+        1 -> ok;
+        2 -> receive
+                 1 -> ok;
+                 2 -> ok;
+                 3 -> fun() -> ok end;
+                 4 -> ok
+             end;
+        3 -> 3
+    end.
+
+dont_exceed_with_fun() ->
+    case 1 of
+        1 -> ok;
+        2 -> receive
+                 1 -> ok;
+                 2 -> ok;
+                 3 -> fun erlang:display/1;
+                 4 -> ok
+             end;
+        3 -> 3
+    end.

--- a/test/examples/pass_no_behavior_info_elvis_attr.erl
+++ b/test/examples/pass_no_behavior_info_elvis_attr.erl
@@ -1,0 +1,30 @@
+-module(pass_no_behavior_info_elvis_attr).
+
+-elvis([{elvis_style, no_behavior_info, disable}]).
+-elvis([{elvis_style, dont_repeat_yourself, disable}]).
+
+-export([
+         behavior_info/1,
+         behaviour_info/1
+        ]).
+
+-export([
+         foo/0,
+         bar/1,
+         baz/2
+        ]).
+
+behavior_info(callbacks) ->
+    [{foo, 0}, {bar, 1}, {bax, 2}].
+
+behaviour_info(callbacks) ->
+    [{foo, 0}, {bar, 1}, {bax, 2}].
+
+foo() ->
+    ok.
+
+bar(_Arg) ->
+    ok.
+
+baz(_Arg, _ArgTwo) ->
+    ok.

--- a/test/examples/pass_no_call_elvis_attr.erl
+++ b/test/examples/pass_no_call_elvis_attr.erl
@@ -1,0 +1,18 @@
+-module(pass_no_call_elvis_attr).
+-export([fail/0]).
+
+-elvis([{elvis_style, no_call, #{no_call_functions => [{io, format}]}}]).
+
+-spec fail() -> any().
+fail() ->
+    _ = timer:send_after(0, fail_after),
+    _ = timer:send_after(0, self(), fail_after),
+
+    _ = timer:send_interval(0, fail_interval),
+    _ = timer:send_interval(0, self(), fail_interval),
+
+    _ = erlang:size({1, 2, 3}),
+    _ = erlang:size(<<"fail_size">>),
+
+    _ = erlang:tuple_size({1, 2, 3}),
+    _ = erlang:byte_size(<<"ok_size">>).

--- a/test/examples/pass_no_debug_call_elvis_attr.erl
+++ b/test/examples/pass_no_debug_call_elvis_attr.erl
@@ -1,0 +1,18 @@
+-module(pass_no_debug_call_elvis_attr).
+-export([fail/0]).
+
+-ignore_xref({cthr, pal, 1}).
+-ignore_xref({cthr, pal, 2}).
+
+-elvis([{elvis_style, no_debug_call, #{debug_functions => [{ct, log}]}}]).
+
+-spec fail() -> any().
+fail() ->
+    io:format("debug print~n"),
+    io:format("debug print ~s~n", ["debug info"]),
+    % Sending explicit io to a device is not considered debugging
+    io:format(user, "Not a debug print ~s~n", ["Not debug"]),
+    ct:pal("Debug"),
+    ct:pal("Debug ~s", ["Debug Info"]),
+    ct:print("Debug"),
+    ct:print("Debug ~s", ["Debug Info"]).

--- a/test/examples/pass_no_debug_call_elvis_attr.erl
+++ b/test/examples/pass_no_debug_call_elvis_attr.erl
@@ -1,10 +1,10 @@
 -module(pass_no_debug_call_elvis_attr).
 -export([fail/0]).
 
+-elvis([{elvis_style, no_debug_call, #{debug_functions => [{ct, log}]}}]).
+
 -ignore_xref({cthr, pal, 1}).
 -ignore_xref({cthr, pal, 2}).
-
--elvis([{elvis_style, no_debug_call, #{debug_functions => [{ct, log}]}}]).
 
 -spec fail() -> any().
 fail() ->

--- a/test/examples/pass_no_if_expression_elvis_attr.erl
+++ b/test/examples/pass_no_if_expression_elvis_attr.erl
@@ -1,0 +1,37 @@
+-module(pass_no_if_expression_elvis_attr).
+
+-dialyzer(no_match).
+
+-elvis([{elvis_style, no_if_expression, disable}]).
+-elvis([{elvis_style, dont_repeat_yourself, disable}]).
+
+-export([
+         uses_if/1,
+         uses_if_twice/1
+        ]).
+
+uses_if(Arg) ->
+    if
+        Arg -> ok;
+        Arg == false -> not_ok
+    end,
+    case 1 of
+        1 -> ok;
+        2 -> ok;
+        3 -> ok
+    end.
+
+uses_if_twice(Arg) ->
+    if
+        Arg -> ok;
+        Arg == false -> not_ok
+    end,
+    case 1 of
+        1 -> ok;
+        2 -> ok;
+        3 -> ok
+    end,
+    if
+        Arg -> ok;
+        Arg == false -> not_ok
+    end.

--- a/test/examples/pass_no_nested_try_catch_elvis_attr.erl
+++ b/test/examples/pass_no_nested_try_catch_elvis_attr.erl
@@ -1,9 +1,9 @@
 -module(pass_no_nested_try_catch_elvis_attr).
 
--ignore_xref({maybe, throw, 1}).
--ignore_xref({a_function, that_deals, 2}).
-
 -dialyzer({nowarn_function, bad2/0}).
+
+-ignore_xref([{maybe, throw, 1}]).
+-ignore_xref([{a_function, that_deals, 2}]).
 
 -export([
          bad1/0,

--- a/test/examples/pass_no_nested_try_catch_elvis_attr.erl
+++ b/test/examples/pass_no_nested_try_catch_elvis_attr.erl
@@ -1,0 +1,73 @@
+-module(pass_no_nested_try_catch_elvis_attr).
+
+-ignore_xref({maybe, throw, 1}).
+-ignore_xref({a_function, that_deals, 2}).
+
+-dialyzer({nowarn_function, bad2/0}).
+
+-export([
+         bad1/0,
+         bad2/0,
+         good1/0,
+         good2/0
+        ]).
+
+-elvis([{elvis_style, no_nested_try_catch, disable}]).
+bad1() ->
+  try
+    maybe:throw(exception1),
+    try
+      maybe:throw(exception2),
+      "We are safe!"
+    catch
+      _:exception2 ->
+        "Oh, no! Exception #2"
+    end
+  catch
+    _:exception1 ->
+      "Bummer! Exception #1"
+  end.
+
+bad2() ->
+  try
+    maybe:throw(exception1),
+    try
+      maybe:throw(exception2),
+      "We are safe!"
+    catch
+      _:exception2 ->
+        "Oh, no! Exception #2"
+    end,
+    try
+      maybe:throw(exception3),
+      "We are safe!"
+    catch
+      _:exception3 ->
+        "Oh, no! Exception #3"
+    end
+  catch
+    _:exception1 ->
+      "Bummer! Exception #1"
+  end.
+
+good1() ->
+  try
+    maybe:throw(exception1),
+    maybe:throw(exception2),
+    "We are safe!"
+  catch
+    _:exception1 ->
+      "Bummer! Exception #1";
+    _:exception2 ->
+      "Oh, no! Exception #2"
+  end.
+
+good2() ->
+  try
+    maybe:throw(exception1),
+    a_function:that_deals(with, exception2),
+    "We are safe!"
+  catch
+    _:exception1 ->
+      "Bummer! Exception #1"
+  end.

--- a/test/examples/pass_no_spaces_elvis_attr.erl
+++ b/test/examples/pass_no_spaces_elvis_attr.erl
@@ -1,16 +1,17 @@
 -module(pass_no_spaces_elvis_attr).
 
--ignore_xref({x, fail, 1}).
--ignore_xref({x, this_line, 2}).
--ignore_xref({x, this_line, 3}).
 -elvis([{elvis_style, no_spaces, disable}]).
 -elvis([{elvis_style, no_tabs, disable}]).
--ignore_xref({x, this_line_should, 3}).
--ignore_xref({x, this_line_should, 1}).
--ignore_xref({x, this_line_is_good, 0}).
--ignore_xref({x, this_line_is_wrong, 0}).
 
 -export([one/0, two/0, three/0, four/0, five/0]).
+
+-ignore_xref([{x, this_line_is_good, 0}]).
+-ignore_xref([{x, this_line_is_wrong, 0}]).
+-ignore_xref([{x, this_line, 2}]).
+-ignore_xref([{x, this_line, 3}]).
+-ignore_xref([{x, fail, 1}]).
+-ignore_xref([{x, this_line_should, 1}]).
+-ignore_xref([{x, this_line_should, 3}]).
 
 one() ->
   not_ok. %%This lines has a spaces

--- a/test/examples/pass_no_spaces_elvis_attr.erl
+++ b/test/examples/pass_no_spaces_elvis_attr.erl
@@ -1,0 +1,34 @@
+-module(pass_no_spaces_elvis_attr).
+
+-ignore_xref({x, fail, 1}).
+-ignore_xref({x, this_line, 2}).
+-ignore_xref({x, this_line, 3}).
+-elvis([{elvis_style, no_spaces, disable}]).
+-elvis([{elvis_style, no_tabs, disable}]).
+-ignore_xref({x, this_line_should, 3}).
+-ignore_xref({x, this_line_should, 1}).
+-ignore_xref({x, this_line_is_good, 0}).
+-ignore_xref({x, this_line_is_wrong, 0}).
+
+-export([one/0, two/0, three/0, four/0, five/0]).
+
+one() ->
+  not_ok. %%This lines has a spaces
+
+two() ->
+		ok. %%This one doesn't
+
+three() ->
+	ok. %% This one doesn't
+
+four() ->
+    not_ok. %% This lines has 4 spaces
+
+five() ->
+				x:this_line_is_good(),
+				 x:this_line_is_wrong(),
+								x:this_line(is, good),
+								x:this_line(is, also,   good),
+								x:this_line(should,  nott,      x:fail( either )),
+        x:this_line_should(fail),
+							  x:this_line_should(fail, as, well).

--- a/test/examples/pass_no_spec_with_records_elvis_attr.erl
+++ b/test/examples/pass_no_spec_with_records_elvis_attr.erl
@@ -1,0 +1,38 @@
+-module(pass_no_spec_with_records_elvis_attr).
+
+-elvis([{elvis_style, function_naming_convention, disable}]).
+
+-dialyzer({nowarn_function, function_2/2}).
+
+-elvis([{elvis_style, no_spec_with_records, disable}]).
+
+
+-export([
+         function_1/1,
+         function_2/2,
+         function_3/2,
+         function_4/2,
+         function_5/1
+        ]).
+
+-record(state, {}).
+
+-spec function_1(atom()) -> atom().
+function_1(Arg) ->
+    Arg.
+
+-spec function_2(atom(), atom()) -> #state{}.
+function_2(_Arg1, _Arg2) ->
+    ok.
+
+-spec function_3(atom(), #state{}) -> atom().
+function_3(_Arg1, _Arg2) ->
+    ok.
+
+-spec function_4(atom(), integer()) -> atom().
+function_4(_Arg1, _Arg2) ->
+    ok.
+
+-spec function_5(#state{}) -> ok.
+function_5(_Arg1) ->
+    ok.

--- a/test/examples/pass_no_tabs_elvis_attr.erl
+++ b/test/examples/pass_no_tabs_elvis_attr.erl
@@ -1,0 +1,17 @@
+-module(pass_no_tabs_elvis_attr).
+
+-export([one/0, two/0, three/0, four/0]).
+
+-elvis([{elvis_style, no_tabs, disable}]).
+
+one() ->
+	not_ok. %%This lines has a tab
+
+two() ->
+    ok. %%This one doesn't
+
+three() ->
+ ok. %% This one doesn't
+
+four() ->
+		not_ok. %% This lines has 2 tabs

--- a/test/examples/pass_no_trailing_whitespace_elvis_attr.erl
+++ b/test/examples/pass_no_trailing_whitespace_elvis_attr.erl
@@ -1,0 +1,24 @@
+-module(pass_no_trailing_whitespace_elvis_attr).
+
+-export([one/0, two/0, three/0, four/0, five/0]).
+
+-elvis([{elvis_style, no_trailing_whitespace, disable}]).
+-elvis([{elvis_style, no_tabs, disable}]).
+
+one() ->
+    %% Following line ends with a tab
+    not_ok.	
+
+two() ->
+    %% Following line ends with a space
+    not_ok. 
+
+three() -> 
+    %% Previous line ends with a space
+    not_ok.
+ 
+four() -> %% Previous (supposedly blank) line has a space
+    not_ok.
+
+five() ->
+    ok. %% This function should be fine

--- a/test/examples/pass_operator_spaces_elvis_attr.erl
+++ b/test/examples/pass_operator_spaces_elvis_attr.erl
@@ -1,0 +1,80 @@
+%% Initial comment
+%% Another initial comment
+-module(pass_operator_spaces_elvis_attr).
+
+-dialyzer({nowarn_function , function7/0}).
+
+-elvis([{elvis_style , operator_spaces , #{rules => [{right , "++"} ,
+                                                     {left , ","}]}}]).
+
+-export([ function1/2
+        , function2/2
+        , function3/2
+        , function4/2
+        , function5/0
+        , function6/0
+        , function7/0
+        , tag_filters/2
+        , unicode_characters/0
+        ]).
+
+%% No space before and after coma,on a comment.
+
+function1(Should ,Fail) ->
+    [Should ,Fail].
+
+function2(Shouldnt , Fail) ->
+    _Unless = [we , consider]++ [operands , as , well] ,
+    _WithDash = Shouldnt - Fail.
+
+function3(Shouldnt , Fail) ->
+    {
+      Shouldnt ++ "Hello ,Dont't Fail" ++ Fail ,
+      'hello,don\'t fail' ,
+      <<"hello,don't fail">>
+    }.
+
+function4(Should , <<_:10/binary , "," , _/binary>>) ->
+    Should = [$, , "where $, represents the character ,"].
+
+function5() ->
+    User = #{name => <<"Juan">> , email => <<"juan@inaka.com">>} ,
+    <<"juan@inaka.com">> = maps:get(email ,User).
+
+function6() ->
+    _MissingLeftSpace = 2+ 3 ,
+    _MissingRightSpace = 2 +3 ,
+    _Successful = 2 + 3 ,
+    _AlsoSuccessful = +1.
+
+function7() ->
+    % commas within strings must be ignored
+    Name = "anyone" ,
+    re:run(Name , "^.{1,20}$" , [unicode]) ,
+    RegExp = "^.{1,20}$" ,
+    re:run(Name , RegExp , [unicode]).
+
+tag_filters(DocName , #{conn := Conn} = State) ->
+  TableName = atom_to_list(DocName) ,
+  Sql = ["SELECT "
+         " 'tag' AS \"type\", "
+         " tag_name AS value, "
+         " COUNT(1) AS \"count\" "
+         "FROM ( "
+         " SELECT unnest(regexp_split_to_array(tags, ',')) AS tag_name"
+         " FROM " , TableName , " "
+         ") AS tags "
+         "GROUP BY tag_name "
+         "ORDER BY tag_name "] ,
+  Values = [] ,
+  case {Conn , Sql , Values} of
+    {ok , Maps , _} ->
+      {ok , {raw , Maps} , State};
+    {error , Error , _} ->
+      {error , Error , State}
+  end.
+
+unicode_characters() ->
+  <<"©"/utf8>> = <<"\\u00A9">> ,
+  <<"ß"/utf8>> = <<"\\o337">> ,
+  ok.

--- a/test/examples/pass_state_record_and_type_elvis_attr.erl
+++ b/test/examples/pass_state_record_and_type_elvis_attr.erl
@@ -1,0 +1,40 @@
+-module(pass_state_record_and_type_elvis_attr).
+
+-dialyzer(no_behaviours).
+
+-behavior(gen_server).
+
+-export([
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         code_change/3,
+         terminate/2
+        ]).
+
+-elvis([{elvis_style, state_record_and_type, disable}]).
+
+-spec init(term()) -> ok.
+init(_Args) ->
+    ok.
+
+-spec handle_call(term(), term(), term()) -> ok.
+handle_call(_Request, _From, _State) ->
+    ok.
+
+-spec handle_cast(term(), term()) -> ok.
+handle_cast(_Request, _State) ->
+    ok.
+
+-spec handle_info(term(), term()) -> ok.
+handle_info(_Info, _State) ->
+    ok.
+
+-spec code_change(term(), term(), term()) -> term().
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+-spec terminate(term(), term()) -> ok.
+terminate(_Reason, _State) ->
+    ok.

--- a/test/examples/pass_used_ignored_variable_elvis_attr.erl
+++ b/test/examples/pass_used_ignored_variable_elvis_attr.erl
@@ -1,0 +1,34 @@
+-module(pass_used_ignored_variable_elvis_attr).
+
+-export([ use_ignored_var/2
+        , use_ignored_var_in_fun/2
+        , no_used_ignored_vars_here/2, handle_call/3
+        , macro_with_underscore/0
+        ]).
+
+-elvis([{elvis_style, used_ignored_variable, disable}]).
+-elvis([{elvis_style, macro_names, #{regex => ".*"}}]).
+
+use_ignored_var(_One, Two) ->
+    Three = _One + Two,
+    case Three of
+        _Four ->
+            _Four
+    end.
+
+use_ignored_var_in_fun(_One, Two) ->
+    Fun = fun (_Three) -> _One + _Three end,
+    Fun(Two).
+
+no_used_ignored_vars_here(One, _Two) ->
+    {_Bla} = One.
+
+-spec handle_call(Msg, _From, term()) ->
+    {stop, {unknown_request, Msg}, {unknown_request, Msg}, term()}.
+handle_call(Msg, _From, State) ->
+    {stop, {unknown_request, Msg}, {unknown_request, Msg}, State}.
+
+-define(__(X), X).
+
+macro_with_underscore() ->
+    ?__("This string will be translated").

--- a/test/examples/pass_variable_naming_convention_elvis_attr.erl
+++ b/test/examples/pass_variable_naming_convention_elvis_attr.erl
@@ -1,0 +1,14 @@
+-module(pass_variable_naming_convention_elvis_attr).
+
+-export([bad_variables_name/3]).
+
+-elvis([{elvis_style, variable_naming_convention,
+        #{regex => "^[a-zA-Z@_]+$"}}]).
+
+%% CamelCase must be used for variables. Don’t
+%% separate words in variables with _.
+
+%% Cf. https://github.com/inaka/erlang_guidelines#variable-names
+
+bad_variables_name(Im@Home, My_Way, _Bad_Ignored_Variable) ->
+    Im@Home ++ My_Way.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -36,6 +36,32 @@
          verify_no_call/1,
          verify_no_nested_try_catch/1,
          verify_atom_naming_convention/1,
+         %% -elvis attribute
+         verify_elvis_attr_atom_naming_convention/1,
+         verify_elvis_attr_dont_repeat_yourself/1,
+         verify_elvis_attr_function_naming_convention/1,
+         verify_elvis_attr_god_modules/1,
+         verify_elvis_attr_invalid_dynamic_call/1,
+         verify_elvis_attr_line_length/1,
+         verify_elvis_attr_macro_module_names/1,
+         verify_elvis_attr_macro_names/1,
+         verify_elvis_attr_max_function_length/1,
+         verify_elvis_attr_max_module_length/1,
+         verify_elvis_attr_module_naming_convention/1,
+         verify_elvis_attr_nesting_level/1,
+         verify_elvis_attr_no_behavior_info/1,
+         verify_elvis_attr_no_call/1,
+         verify_elvis_attr_no_debug_call/1,
+         verify_elvis_attr_no_if_expression/1,
+         verify_elvis_attr_no_nested_try_catch/1,
+         verify_elvis_attr_no_spaces/1,
+         verify_elvis_attr_no_spec_with_records/1,
+         verify_elvis_attr_no_tabs/1,
+         verify_elvis_attr_no_trailing_whitespace/1,
+         verify_elvis_attr_operator_spaces/1,
+         verify_elvis_attr_state_record_and_type/1,
+         verify_elvis_attr_used_ignored_variable/1,
+         verify_elvis_attr_variable_naming_convention/1,
          %% Non-rule
          results_are_ordered_by_line/1
         ]).
@@ -758,9 +784,212 @@ results_are_ordered_by_line(_Config) ->
     {fail, Results} = elvis_core:rock(ElvisConfig),
     true = lists:all(fun(X) -> X end, is_item_line_sort(Results)).
 
+-spec verify_elvis_attr_atom_naming_convention(config()) -> true.
+verify_elvis_attr_atom_naming_convention(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_atom_naming_convention_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_dont_repeat_yourself(config()) -> true.
+verify_elvis_attr_dont_repeat_yourself(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_dont_repeat_yourself_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_function_naming_convention(config()) -> true.
+verify_elvis_attr_function_naming_convention(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_function_naming_convention_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_god_modules(config()) -> true.
+verify_elvis_attr_god_modules(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_god_modules_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_invalid_dynamic_call(config()) -> true.
+verify_elvis_attr_invalid_dynamic_call(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_invalid_dynamic_call_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_line_length(config()) -> true.
+verify_elvis_attr_line_length(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_line_length_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_macro_module_names(config()) -> true.
+verify_elvis_attr_macro_module_names(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_macro_module_names_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_macro_names(config()) -> true.
+verify_elvis_attr_macro_names(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_macro_names_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_max_function_length(config()) -> true.
+verify_elvis_attr_max_function_length(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_max_function_length_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_max_module_length(config()) -> true.
+verify_elvis_attr_max_module_length(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_max_module_length_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_module_naming_convention(config()) -> true.
+verify_elvis_attr_module_naming_convention(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_module_naming-convention_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_nesting_level(config()) -> true.
+verify_elvis_attr_nesting_level(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_nesting_level_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_no_behavior_info(config()) -> true.
+verify_elvis_attr_no_behavior_info(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_no_behavior_info_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_no_call(config()) -> true.
+verify_elvis_attr_no_call(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_no_call_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_no_debug_call(config()) -> true.
+verify_elvis_attr_no_debug_call(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_no_debug_call_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_no_if_expression(config()) -> true.
+verify_elvis_attr_no_if_expression(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_no_if_expression_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_no_nested_try_catch(config()) -> true.
+verify_elvis_attr_no_nested_try_catch(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_no_nested_try_catch_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_no_spaces(config()) -> true.
+verify_elvis_attr_no_spaces(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_no_spaces_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_no_spec_with_records(config()) -> true.
+verify_elvis_attr_no_spec_with_records(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_no_spec_with_records_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_no_tabs(config()) -> true.
+verify_elvis_attr_no_tabs(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_no_tabs_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_no_trailing_whitespace(config()) -> true.
+verify_elvis_attr_no_trailing_whitespace(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_no_trailing_whitespace_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_operator_spaces(config()) -> true.
+verify_elvis_attr_operator_spaces(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_operator_spaces_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_state_record_and_type(config()) -> true.
+verify_elvis_attr_state_record_and_type(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_state_record_and_type_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_used_ignored_variable(config()) -> true.
+verify_elvis_attr_used_ignored_variable(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_used_ignored_variable_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
+-spec verify_elvis_attr_variable_naming_convention(config()) -> true.
+verify_elvis_attr_variable_naming_convention(_Config) ->
+    ElvisConfig = elvis_test_utils:config(erl_files),
+    SrcDirs = elvis_config:dirs(ElvisConfig),
+
+    {ok, File} = elvis_test_utils:find_file(SrcDirs, "pass_variable_naming_convention_elvis_attr.erl"),
+    verify_elvis_attr_do_rock_results(elvis_core:do_rock(File, ElvisConfig)).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Private
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+verify_elvis_attr_do_rock_results({ok, #{ rules := RuleResults }}) ->
+    [[] = Items || #{ items := Items } <- RuleResults],
+    true.
 
 -spec is_item_line_sort([elvis_result:file()]) -> [boolean()].
 is_item_line_sort(Result) ->


### PR DESCRIPTION
[Fix inaka/elvis#529]

I get the `-elvis(_).` attribute from the parse file tree, and I use it to override potential `elvis.config` -level rules.

What's missing, still?
1. ~tests,~
2. ~`{function(), arity()}` where we find `module`,~
3. ~`{function()}` where we find `module` (should this one exist?),~
~4. anything else?~
~**Edit**: 4.1. documentation.~ (check inaka/elvis#535)
~**Edit**: 4.2. using `elvis_config` `merge_rules/2` instead of my own version of it.~
~**Edit**: 4.3. remove key `module`~

**Edit**: it's ready for final approval and potential merge.