### PR TITLE
Accept British spelling for behaviour.

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1102,7 +1102,11 @@ is_otp_module(Root) ->
                              gen_statem,
                              supervisor_bridge
                             ]),
-    IsBehaviorAttr = fun(Node) -> behavior == ktn_code:type(Node) end,
+    IsBehaviorAttr =
+        fun(Node) ->
+            behavior == ktn_code:type(Node) orelse
+            behaviour == ktn_code:type(Node)
+        end,
     case elvis_code:find(IsBehaviorAttr, Root) of
         [] ->
             false;

--- a/test/examples/fail_state_record_and_type_behaviour.erl
+++ b/test/examples/fail_state_record_and_type_behaviour.erl
@@ -1,0 +1,38 @@
+-module(fail_state_record_and_type_behaviour).
+
+-dialyzer(no_behaviours).
+
+-behaviour(gen_server).
+
+-export([
+         init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         code_change/3,
+         terminate/2
+        ]).
+
+-spec init(term()) -> ok.
+init(_Args) ->
+    ok.
+
+-spec handle_call(term(), term(), term()) -> ok.
+handle_call(_Request, _From, _State) ->
+    ok.
+
+-spec handle_cast(term(), term()) -> ok.
+handle_cast(_Request, _State) ->
+    ok.
+
+-spec handle_info(term(), term()) -> ok.
+handle_info(_Info, _State) ->
+    ok.
+
+-spec code_change(term(), term(), term()) -> term().
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+-spec terminate(term(), term()) -> ok.
+terminate(_Reason, _State) ->
+    ok.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -467,6 +467,10 @@ verify_state_record_and_type(_Config) ->
     {ok, FileFail1} = elvis_test_utils:find_file(SrcDirs, PathFail1),
     [_] = elvis_style:state_record_and_type(ElvisConfig, FileFail1, #{}),
 
+    PathBehaviourFail = "fail_state_record_and_type_behaviour.erl",
+    {ok, FileBehaviourFail} = elvis_test_utils:find_file(SrcDirs, PathBehaviourFail),
+    [_] = elvis_style:state_record_and_type(ElvisConfig, FileBehaviourFail, #{}),
+
     PathFailGenStateMType = "fail_state_record_and_type_gen_statem_type.erl",
     {ok, FileFailGenStateMType} = elvis_test_utils:find_file(SrcDirs, PathFailGenStateMType),
     [_] = elvis_style:state_record_and_type(ElvisConfig, FileFailGenStateMType, #{}),


### PR DESCRIPTION
Erlang accepts the `-behaviour` spelling too, so when checking for OTP behaviours, check this spelling.