### PR TITLE
Allow for custom rules in elvis configuration

### DIFF
--- a/config/elvis-test-custom-ruleset.config
+++ b/config/elvis-test-custom-ruleset.config
@@ -1,0 +1,15 @@
+[
+ {
+  elvis,
+  [
+   {rulesets,
+    #{project => [{elvis_style, no_tabs}]}
+   },
+   {config,
+    [#{dirs => ["."],
+       filter => "*.erl",
+       ruleset => project}]
+   }
+  ]
+ }
+].

--- a/config/elvis-test-unknown-ruleset.config
+++ b/config/elvis-test-unknown-ruleset.config
@@ -5,7 +5,7 @@
    {config,
     [#{dirs => ["."],
        filter => "*.erl",
-       ruleset => missing}]
+       ruleset => project}]
    }
   ]
  }

--- a/config/elvis-test-unknown-ruleset.config
+++ b/config/elvis-test-unknown-ruleset.config
@@ -1,0 +1,12 @@
+[
+ {
+  elvis,
+  [
+   {config,
+    [#{dirs => ["."],
+       filter => "*.erl",
+       ruleset => missing}]
+   }
+  ]
+ }
+].

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -49,6 +49,8 @@ from_file(Path) ->
 -spec load(atom(), term()) -> config().
 load(Key, AppConfig) ->
     ElvisConfig = proplists:get_value(Key, AppConfig, []),
+    Rulesets = proplists:get_value(rulesets, ElvisConfig, #{}),
+    register_rulesets(Rulesets),
     Config =  proplists:get_value(config, ElvisConfig, []),
     ensure_config_list(Config).
 
@@ -56,6 +58,11 @@ ensure_config_list(Config) when is_map(Config) ->
     [Config];
 ensure_config_list(Config) ->
     Config.
+
+register_rulesets(Rulesets) ->
+    lists:foreach(fun({Name, Rules}) ->
+                          elvis_rulesets:register_ruleset(Name, Rules)
+                  end, maps:to_list(Rulesets)).
 
 -spec validate(Config::config()) -> ok.
 validate([]) ->

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -50,7 +50,7 @@ from_file(Path) ->
 load(Key, AppConfig) ->
     ElvisConfig = proplists:get_value(Key, AppConfig, []),
     Rulesets = proplists:get_value(rulesets, ElvisConfig, #{}),
-    register_rulesets(Rulesets),
+    elvis_rulesets:set_rulesets(Rulesets),
     Config =  proplists:get_value(config, ElvisConfig, []),
     ensure_config_list(Config).
 
@@ -58,11 +58,6 @@ ensure_config_list(Config) when is_map(Config) ->
     [Config];
 ensure_config_list(Config) ->
     Config.
-
-register_rulesets(Rulesets) ->
-    lists:foreach(fun({Name, Rules}) ->
-                          elvis_rulesets:register_ruleset(Name, Rules)
-                  end, maps:to_list(Rulesets)).
 
 -spec validate(Config::config()) -> ok.
 validate([]) ->
@@ -133,7 +128,8 @@ files(_RuleGroup = #{files := Files}) ->
 files(#{}) ->
     [].
 
--spec rules(Rules::config() | map()) -> [elvis_core:rule()].
+-spec rules(Rules::config()) -> [[elvis_core:rule()]];
+           (map()) -> [elvis_core:rule()].
 rules(Rules) when is_list(Rules) ->
     lists:map(fun rules/1, Rules);
 rules(#{rules := UserRules, ruleset := RuleSet}) ->

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -27,6 +27,8 @@
          rock_this_skipping_files/1,
          rock_this_not_skipping_files/1,
          %% Util & Config
+         custom_ruleset/1,
+         unknown_ruleset/1,
          throw_configuration/1,
          find_file_and_check_src/1,
          find_file_with_ignore/1,
@@ -319,6 +321,20 @@ rock_this_not_skipping_files(_Config) ->
 
 %%%%%%%%%%%%%%%
 %%% Utils
+
+-spec custom_ruleset(config()) -> any().
+custom_ruleset(_Config) ->
+    ConfigPath = "../../config/elvis-test-custom-ruleset.config",
+    ElvisConfig = elvis_config:from_file(ConfigPath),
+    [[{elvis_style, no_tabs}]] = elvis_config:rules(ElvisConfig),
+    ok.
+
+-spec unknown_ruleset(config()) -> any().
+unknown_ruleset(_Config) ->
+    ConfigPath = "../../config/elvis-test-unknown-ruleset.config",
+    ElvisConfig = elvis_config:from_file(ConfigPath),
+    [[]] = elvis_config:rules(ElvisConfig),
+    ok.
 
 -spec throw_configuration(config()) -> any().
 throw_configuration(_Config) ->

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -28,7 +28,6 @@
          rock_this_not_skipping_files/1,
          %% Util & Config
          custom_ruleset/1,
-         unknown_ruleset/1,
          throw_configuration/1,
          find_file_and_check_src/1,
          find_file_with_ignore/1,
@@ -327,13 +326,12 @@ custom_ruleset(_Config) ->
     ConfigPath = "../../config/elvis-test-custom-ruleset.config",
     ElvisConfig = elvis_config:from_file(ConfigPath),
     [[{elvis_style, no_tabs}]] = elvis_config:rules(ElvisConfig),
-    ok.
 
--spec unknown_ruleset(config()) -> any().
-unknown_ruleset(_Config) ->
-    ConfigPath = "../../config/elvis-test-unknown-ruleset.config",
-    ElvisConfig = elvis_config:from_file(ConfigPath),
-    [[]] = elvis_config:rules(ElvisConfig),
+    %% read unknown ruleset configuration to ensure rulesets from
+    %% previous load do not stick around
+    ConfigPathMissing = "../../config/elvis-test-unknown-ruleset.config",
+    ElvisConfigMissing = elvis_config:from_file(ConfigPathMissing),
+    [[]] = elvis_config:rules(ElvisConfigMissing),
     ok.
 
 -spec throw_configuration(config()) -> any().


### PR DESCRIPTION
If using multiple RuleGroups with custom made rules, instead of having
to duplicate the rules support a custom rules section of the configuration
that can be referenced in the rules argument:

```erlang
[
 {
  elvis,
  [
   {rules,
    #{project => [{elvis_style, no_tabs}]}
   },
   {config,
    #{rules => {custom_rules, project}}
   }
  ]
 }
].
```