### PR TITLE
Ease consumption of warning

### DIFF
--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -160,9 +160,11 @@ resolve_files(RuleGroup, Files) ->
     FilteredFiles = elvis_file:filter_files(Files, Dirs, Filter, Ignore),
     _ = case FilteredFiles of
             [] ->
-                Error = elvis_result:new(warn, "Searching for files in ~p, for ruleset ~p, yielded "
-                                               "none. Update your configuration.",
-                                               [Dirs, maps:get(ruleset, RuleGroup)]),
+                Ruleset = maps:get(ruleset, RuleGroup, undefined),
+                Error = elvis_result:new(warn, "Searching for files in ~p, for ruleset ~p, "
+                                               "with filter ~p, yielded none. "
+                                               "Update your configuration.",
+                                               [Dirs, Ruleset, Filter]),
                 ok = elvis_result:print_results([Error]);
             _ ->
                 ok

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -160,8 +160,9 @@ resolve_files(RuleGroup, Files) ->
     FilteredFiles = elvis_file:filter_files(Files, Dirs, Filter, Ignore),
     _ = case FilteredFiles of
             [] ->
-                Error = elvis_result:new(warn, "Searching for files in ~p yielded none. "
-                                               "Update your configuration.", [Dirs]),
+                Error = elvis_result:new(warn, "Searching for files in ~p, for ruleset ~p, yielded "
+                                               "none. Update your configuration.",
+                                               [Dirs, maps:get(ruleset, RuleGroup)]),
                 ok = elvis_result:print_results([Error]);
             _ ->
                 ok

--- a/src/elvis_result.erl
+++ b/src/elvis_result.erl
@@ -113,7 +113,7 @@ get_line_num(#{line_num := LineNum}) -> LineNum.
 
 %% Print
 
--spec print_results(file()) -> ok.
+-spec print_results(file() | [elvis_warn()]) -> ok.
 print_results(Results) ->
     Format = application:get_env(elvis_core, output_format, colors),
     print(Format, Results).


### PR DESCRIPTION
Found this while pulling 1.1.1 into `rebar3_lint`. Since this is a minor detail I guess we can leave it here, in `master`, until we need a new release.

Also, mind you that this message might need to be further improved, in the future, if an even more complicated setup (`elvis.config`) is done.