### PR TITLE
Fix a crash happening when a macro is also an atom (as a function)

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -879,7 +879,8 @@ macro_as_atom({var, _Text, MacroAsAtom}, _Types, _MacroNodeValue) ->
     MacroAsAtom;
 macro_as_atom({atom, _Text, MacroAsAtom}, _Types, _MacroNodeValue) ->
     MacroAsAtom;
-macro_as_atom({call, _CallText, {var, _VarText, MacroAsAtom}, _VarArg}, _Types, _MacroNodeValue) ->
+macro_as_atom({call, _CallText, {Type, _AtomText, MacroAsAtom}, _VarArg}, _Types, _MacroNodeValue)
+        when Type =:= var orelse Type =:= atom ->
     MacroAsAtom;
 macro_as_atom(false, [Type | OtherTypes], MacroNodeValue) ->
     macro_as_atom(lists:keyfind(Type, _N = 1, MacroNodeValue), OtherTypes, MacroNodeValue).

--- a/test/examples/fail_macro_names.erl
+++ b/test/examples/fail_macro_names.erl
@@ -1,6 +1,7 @@
 -module(fail_macro_names).
 
  -define (bad_name,   "(no)").
+ -define (error(A),   {error, A}).
 -define(GOOD_NAME,  "(megusta)").
 -define(wtf_NAME,   "(yuno)").
 -define(GOOD_NAME(Arg), "(megusta)").

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -284,7 +284,7 @@ verify_macro_names_rule(Config) ->
 
     Path = "fail_macro_names." ++ Ext,
 
-    [_, _, _, _] = elvis_core_apply_rule(Config, elvis_style, macro_names, #{}, Path),
+    [_, _, _, _, _] = elvis_core_apply_rule(Config, elvis_style, macro_names, #{}, Path),
 
     [_, _] = elvis_core_apply_rule(Config, elvis_style, macro_names, #{ regex => "^[A-Za-z_ ]+$" }, Path),
 
@@ -292,7 +292,7 @@ verify_macro_names_rule(Config) ->
 
     [] = elvis_core_apply_rule(Config, elvis_style, macro_names, #{ regex => "^[A-Za-z_, \-]+$" }, Path),
 
-    [_, _, _, _, _, _] = elvis_core_apply_rule(Config, elvis_style, macro_names, #{ regex => "^POTENTIAL_BAD-NAME$" }, Path),
+    [_, _, _, _, _, _, _] = elvis_core_apply_rule(Config, elvis_style, macro_names, #{ regex => "^POTENTIAL_BAD-NAME$" }, Path),
 
     [] = elvis_core_apply_rule(Config, elvis_style, macro_names, #{ ignore => [fail_macro_names] }, Path).
 


### PR DESCRIPTION
@elbrujohalcon: remember how you love macros? 😄 

This was crashing (prior to this pull request)...

```
The macro named "debug" on line 
```