### PR TITLE
Prevent crash for operators being analyzed at the left-most line position

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -998,9 +998,11 @@ character_at_location(Position, Lines, Operator, {LineNo, Col}, Encoding) ->
     % If ColToCheck is greater than the length of OperatorLineStr variable, it
     % means the end of line was reached so return " " to make the check pass,
     % otherwise return the character at the given column.
-    % NOTE: text below only applies when the given Position is equal to `right`.
+    % NOTE: text below only applies when the given Position is equal to `right`,
+    %       or Position is equal to `left` and Col is 1.
     SpaceChar = $\s,
-    case {Position, (ColToCheck > length(OperatorLineStr))} of
+    case ColToCheck =:= 0 orelse {Position, (ColToCheck > length(OperatorLineStr))} of
+        true -> SpaceChar;
         {right, true}  -> SpaceChar;
         _ -> lists:nth(ColToCheck, OperatorLineStr)
     end.

--- a/test/examples/fail_operator_spaces.erl
+++ b/test/examples/fail_operator_spaces.erl
@@ -13,6 +13,8 @@
         , function7/0
         , tag_filters/2
         , unicode_characters/0
+        , this/0
+        , this/1
         ]).
 
 %% No space before and after coma,on a comment.
@@ -75,3 +77,14 @@ unicode_characters() ->
   <<"©"/utf8>> = <<"\\u00A9">>,
   <<"ß"/utf8>> = <<"\\o337">>,
   ok.
+
+-spec this()
+-> should_not_crash.
+this()
+-> should_not_crash.
+
+-spec this(shouldnt_either)
+-> -1.
+this(shouldnt_either)
+-> A = 1
+- 2, A.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -324,11 +324,15 @@ verify_operator_spaces(Config) ->
     MinusOperation = #{rules => [{right, "-"}, {left, "-"}]},
     [] = elvis_core_apply_rule(Config, elvis_style, operator_spaces, MinusOperation, Path),
 
+    Arrow = #{rules => [{left, "->"}]},
+    [] = elvis_core_apply_rule(Config, elvis_style, operator_spaces, Arrow, Path),
+
     AllOptions = #{rules => [{right, ","},
                              {right, "++"},
                              {left, "++"},
                              {right, "+"},
-                             {left, "+"}]},
+                             {left, "+"},
+                             {left, "->"}]},
     [_, _, _, _, _, _] =
         elvis_core_apply_rule(Config, elvis_style, operator_spaces, AllOptions, Path).
 


### PR DESCRIPTION
Closes #183.

cc: @robertoaloi 