### PR TITLE
Move to a GitHub action (instead of container-based) CI approach

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,14 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        otp_vsn: [19.3.6.13, 20.3.8.26, 21.3.8.17, 22.3.4.9, 23.1.5]
-        os: [ubuntu-18.04]
+        otp_vsn: [20, 21, 22, 23]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - uses: gleam-lang/setup-erlang@v1.1.1
+      - uses: erlef/setup-beam@v1.7.0
         with:
           otp-version: ${{matrix.otp_vsn}}
-      - run: |
-          rebar3 --version
-          erl -version
+          rebar3-version: '3.14'
       - run: rebar3 dialyzer
       - run: rebar3 ct
       - run: rebar3 cover


### PR DESCRIPTION
Also, that GitHub action is now the "official" action for Erlang+rebar3 CI, as per EEF