### PR TITLE
Catch errors when parsing

### DIFF
--- a/config/elvis.config
+++ b/config/elvis.config
@@ -7,7 +7,7 @@
         filter => "*.erl",
         ruleset => erl_files
        },
-       #{dirs => ["../../_build/test/lib/elvis_core/test/non_compilable_examples"],
+      #{dirs => ["../../_build/test/lib/elvis_core/test/non_compilable_examples"],
          filter => "*.erl",
          ruleset => erl_files
        },

--- a/config/elvis.config
+++ b/config/elvis.config
@@ -7,6 +7,10 @@
         filter => "*.erl",
         ruleset => erl_files
        },
+       #{dirs => ["../../_build/test/lib/elvis_core/test/non_compilable_examples"],
+         filter => "*.erl",
+         ruleset => erl_files
+       },
       #{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
         filter => "*.beam",
         ruleset => beam_files

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -100,7 +100,7 @@ do_parallel_rock(Config0) ->
         {error, {T, E}} ->
             %% {T, E} will be put into an {error, _} tuple higher on the call stack,
             %% let's not encapsulate it multiple times.
-            {fail, {T, E}}
+            {fail, [{T, E}]}
     end.
 
 -spec do_rock(elvis_file:file(), elvis_config:configs() | elvis_config:config())

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -87,14 +87,21 @@ do_parallel_rock(Config0) ->
     Config = elvis_config:resolve_files(Config0),
     Files = elvis_config:files(Config),
 
-    {ok, Results} =
+    Result =
         elvis_task:chunk_fold({?MODULE, do_rock},
                               fun(Elem, Acc) ->
                                       elvis_result:print_results(Elem),
                                       {ok, [Elem | Acc]}
                               end,
                               [], [Config], Files, Parallel),
-    elvis_result_status(Results).
+    case Result of
+        {ok, Results} ->
+            elvis_result_status(Results);
+        {error, {T, E}} ->
+            %% {T, E} will be put into an {error, _} tuple higher on the call stack,
+            %% let's not encapsulate it multiple times.
+            {fail, {T, E}}
+    end.
 
 -spec do_rock(elvis_file:file(), elvis_config:configs() | elvis_config:config())
     -> {ok, elvis_result:file()}.

--- a/src/elvis_task.erl
+++ b/src/elvis_task.erl
@@ -5,8 +5,8 @@
 %% @doc chunk_fold evaluates apply(Module, Function, [Elem|ExtrArgs]) for
 %% every element Elem in JobItemList in parallel with max concurrcy factor
 %% equal to Concurrency. On succesfull evaluation FunAcc function is called
-%% with the result of succesfull execution as a first parametr and accumulator
-%% as a second parametr.
+%% with the result of succesfull execution as a first parameter and accumulator
+%% as a second parameter.
 -spec chunk_fold(FunWork :: {Module :: module(), Function :: atom()},
                  FunAcc :: fun((NewElem :: term(), Acc :: term()) ->
                                       Acc :: term()),

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -253,6 +253,10 @@ rock_without_errors_has_no_output(_Config) ->
     ElvisConfig = elvis_config:from_file(ConfigPath),
     Fun = fun() -> elvis_core:rock(ElvisConfig) end,
     Output = get_output(Fun),
+    %% This is related to the test case `rock_with_non_parsable_file`,
+    %% which will print an error to the standard output
+    %% and CT will capture it.
+    %% Thus, we remove it from the list of captures before doing the actual check
     RemoveSearchPattern = "fail_non_parsable_file.erl",
     ct:pal("Output=~p~n", [Output]),
     [] = lists:filter(fun(String) -> string:find(String, RemoveSearchPattern) == nomatch end,

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -24,6 +24,7 @@
          rock_without_colors/1,
          rock_with_parsable/1,
          rock_with_no_output_has_no_output/1,
+         rock_with_non_parsable_file/1,
          rock_with_errors_has_output/1,
          rock_without_errors_has_no_output/1,
          rock_without_errors_and_with_verbose_has_output/1,
@@ -218,6 +219,16 @@ rock_with_parsable(_Config) ->
          after
              application:set_env(elvis_core, output_format, Default)
          end.
+
+rock_with_non_parsable_file(_Config) ->
+    ElvisConfig = elvis_test_utils:config(),
+    Path =
+        "../../_build/test/lib/elvis_core/test/non_compilable_examples/fail_non_parsable_file.erl",
+    try
+        elvis_core:rock_this(Path, ElvisConfig)
+    catch
+        {fail, {error, {badmatch, _}}} -> ok
+    end.
 
 -spec rock_with_no_output_has_no_output(config()) -> ok.
 rock_with_no_output_has_no_output(_Config) ->

--- a/test/non_compilable_examples/fail_non_parsable_file.erl
+++ b/test/non_compilable_examples/fail_non_parsable_file.erl
@@ -1,0 +1,6 @@
+-module(fail_non_parsable_file).
+
+-export([one/0]).
+
+one() ->
+  <<"


### PR DESCRIPTION
This will fix https://github.com/inaka/elvis/issues/509.

When dealing with non-parsable files, `elvis_core` will crash with a `badmatch`, instead of handling said crash and merely reporting the error.