### PR TITLE
Add new rule no_space

### DIFF
--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -179,7 +179,7 @@ print_node(Node) ->
 -spec print_node(ktn_code:tree_node(), integer()) -> ok.
 print_node(Node = #{type := Type}, CurrentLevel) ->
     Type = ktn_code:type(Node),
-    Indentation = lists:duplicate(CurrentLevel * 4, $ ),
+    Indentation = lists:duplicate(CurrentLevel * 4, $\s),
     Content = ktn_code:content(Node),
 
     ok = elvis_utils:info("~s - [~p] ~p~n", [Indentation, CurrentLevel, Type]),

--- a/src/elvis_rulesets.erl
+++ b/src/elvis_rulesets.erl
@@ -22,6 +22,7 @@ rules(erl_files) ->
         , {elvis_style, macro_names}
         , {elvis_style, macro_module_names}
         , {elvis_style, operator_spaces}
+        , {elvis_style, no_space}
         , {elvis_style, nesting_level}
         , {elvis_style, god_modules}
         , {elvis_style, no_if_expression}

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -8,6 +8,7 @@
          macro_module_names/3,
          no_macros/3,
          operator_spaces/3,
+         no_space/3,
          nesting_level/3,
          god_modules/3,
          no_if_expression/3,
@@ -49,7 +50,9 @@
 -define(NO_MACROS_MSG,
             "Unexpected macro (~p) used on line ~p.").
 
--define(OPERATOR_SPACE_MSG, "Missing space ~s ~p on line ~p").
+-define(MISSING_SPACE_MSG, "Missing space ~s ~p on line ~p").
+
+-define(UNEXPECTED_SPACE_MSG, "Unexpected space ~s ~p on line ~p").
 
 -define(NESTING_LEVEL_MSG,
         "The expression on line ~p and column ~p is nested "
@@ -158,6 +161,12 @@ default(operator_spaces) ->
     #{ rules => [ {right, ","}
                 , {right, "++"}
                 , {left, "++"}
+                ]
+     };
+
+default(no_space) ->
+    #{ rules => [ {right, "("}
+                , {left, ")"}
                 ]
      };
 
@@ -415,7 +424,7 @@ operator_spaces(Config, Target, RuleConfig) ->
     AllNodes = OpNodes ++ PunctuationTokens,
 
     FlatMap = fun(Rule) ->
-                  check_operator_spaces(Lines, AllNodes, Rule, Encoding)
+                  check_spaces(Lines, AllNodes, Rule, Encoding, should_have)
               end,
     lists:flatmap(FlatMap, Rules).
 
@@ -423,6 +432,29 @@ operator_spaces(Config, Target, RuleConfig) ->
 -spec is_operator_node(ktn_code:tree_node()) -> boolean().
 is_operator_node(Node) ->
     ktn_code:type(Node) =:= op andalso length(ktn_code:content(Node)) > 1.
+
+-type no_space_config() :: #{ ignore => [ignorable()]
+                                   , rules => [{right | left, string()}]
+                                   }.
+
+-spec no_space(elvis_config:config(),
+               elvis_file:file(),
+               no_space_config()) ->
+    [elvis_result:item()].
+no_space(Config, Target, RuleConfig) ->
+    Rules = option(rules, RuleConfig, no_space),
+    Root = get_root(Config, Target, RuleConfig),
+    Tokens = ktn_code:attr(tokens, Root),
+    TextNodes = lists:filter(fun is_text_node/1, Tokens),
+    {Src, #{encoding := Encoding}} = elvis_file:src(Target),
+    Lines = elvis_utils:split_all_lines(Src),
+    FlatMap = fun(Rule) ->
+                  check_spaces(Lines, TextNodes, Rule, Encoding, should_not_have)
+              end,
+    lists:flatmap(FlatMap, Rules).
+
+is_text_node(Node) ->
+    ktn_code:attr(text, Node) =/= "".
 
 %% @doc Returns true when the token is one of the ?PUNCTUATION_SYMBOLS
 -spec is_punctuation_token(ktn_code:tree_node()) -> boolean().
@@ -1144,26 +1176,34 @@ has_remote_call_parent(Zipper) ->
             has_remote_call_parent(zipper:up(Zipper))
     end.
 
-%% Operator Spaces
--spec check_operator_spaces(Lines :: [binary()],
-                            OperatorNodes :: [ktn_code:tree_node()],
-                            Rule :: {right | left, string()},
-                            Encoding :: latin1 | utf8) ->
+%% Operator (and Text) Spaces
+-spec check_spaces(Lines :: [binary()],
+                   Nodes :: [ktn_code:tree_node()],
+                   Rule :: {right | left, string()},
+                   Encoding :: latin1 | utf8,
+                   How :: should_have | should_not_have) ->
     [elvis_result:item()].
-check_operator_spaces(Lines, OperatorNodes, {Position, Operator}, Encoding) ->
-  FilterFun = fun(Node) -> ktn_code:attr(text, Node) =:= Operator end,
-  Nodes = lists:filter(FilterFun, OperatorNodes),
+check_spaces(Lines, UnfilteredNodes, {Position, Text}, Encoding, How) ->
+  FilterFun = fun(Node) -> ktn_code:attr(text, Node) =:= Text end,
+  Nodes = lists:filter(FilterFun, UnfilteredNodes),
   SpaceChar = $\s,
   FlatFun = fun(Node) ->
                 Location = ktn_code:attr(location, Node),
                 case
-                  character_at_location(Position, Lines, Operator, Location, Encoding)
+                  character_at_location(Position, Lines, Text, Location, Encoding, How)
                 of
-                  SpaceChar -> [];
-                  _         ->
-                    Msg = ?OPERATOR_SPACE_MSG,
+                  Char when Char =:= SpaceChar andalso How =:= should_have -> [];
+                  Char when Char =/= SpaceChar andalso How =:= should_not_have -> [];
+                  _ when How =:= should_have ->
+                    Msg = ?MISSING_SPACE_MSG,
                     {Line, _Col} = Location,
-                    Info = [Position, Operator, Line],
+                    Info = [Position, Text, Line],
+                    Result = elvis_result:new(item, Msg, Info, Line),
+                    [Result];
+                  _ when How =:= should_not_have ->
+                    Msg = ?UNEXPECTED_SPACE_MSG,
+                    {Line, _Col} = Location,
+                    Info = [Position, Text, Line],
                     Result = elvis_result:new(item, Msg, Info, Line),
                     [Result]
                 end
@@ -1172,26 +1212,29 @@ check_operator_spaces(Lines, OperatorNodes, {Position, Operator}, Encoding) ->
 
 -spec character_at_location(Position::atom(),
                             Lines::[binary()],
-                            Operator::string(),
+                            Text::string(),
                             Location::{integer(), integer()},
-                            Encoding::latin1|utf8) -> char().
-character_at_location(Position, Lines, Operator, {LineNo, Col}, Encoding) ->
+                            Encoding::latin1|utf8,
+                            How :: should_have | should_not_have) -> char().
+character_at_location(Position, Lines, Text, {LineNo, Col}, Encoding, How) ->
     Line = lists:nth(LineNo, Lines),
-    OperatorLineStr = unicode:characters_to_list(Line, Encoding),
+    TextLineStr = unicode:characters_to_list(Line, Encoding),
     ColToCheck = case Position of
         left  -> Col - 1;
-        right -> Col + length(Operator)
+        right -> Col + length(Text)
     end,
-    % If ColToCheck is greater than the length of OperatorLineStr variable, it
-    % means the end of line was reached so return " " to make the check pass,
+    % If ColToCheck is greater than the length of TextLineStr variable, it
+    % means the end of line was reached so return " " (or "") to make the check pass,
     % otherwise return the character at the given column.
     % NOTE: text below only applies when the given Position is equal to `right`,
     %       or Position is equal to `left` and Col is 1.
     SpaceChar = $\s,
-    case ColToCheck =:= 0 orelse {Position, (ColToCheck > length(OperatorLineStr))} of
-        true -> SpaceChar;
-        {right, true}  -> SpaceChar;
-        _ -> lists:nth(ColToCheck, OperatorLineStr)
+    case ColToCheck =:= 0 orelse {Position, (ColToCheck > length(TextLineStr))} of
+        true when How =:= should_have -> SpaceChar;
+        true when How =:= should_not_have -> "";
+        {right, true} when How =:= should_have -> SpaceChar;
+        {right, true} when How =:= should_not_have -> "";
+        _ -> lists:nth(ColToCheck, TextLineStr)
     end.
 
 %% Nesting Level

--- a/test/examples/fail_no_space.erl
+++ b/test/examples/fail_no_space.erl
@@ -31,7 +31,9 @@ function1(Should,Fail) ->
 
 function2( Shouldnt, Fail) ->
     _Unless = [we, consider]++ [operands, as, well],
-    _WithDash = Shouldnt - Fail.
+    _WithDash = Shouldnt - Fail,
+    fun (a
+    ) -> ok end. % only spaces between start of line and ')'
 
 function3(Shouldnt, Fail) ->
     {
@@ -67,6 +69,7 @@ function8(
 
 function9(
 ) ->
+    _ = $ ,
     [X|| X <- [fail]] ++ [X ||X <- [fail]] ++ [X || X <- [notfail]].
 
 tag_filters(DocName, #{conn := Conn} = State ) ->
@@ -108,4 +111,4 @@ this()
 -> -1.
 this(shouldnt_either)
 -> A = 1
-- 2, A.
+- 2, A, $ . % there's a space after $ that we should complain about :) 

--- a/test/examples/fail_no_space.erl
+++ b/test/examples/fail_no_space.erl
@@ -1,0 +1,111 @@
+%% Initial comment
+%% Another initial comment
+-module( fail_no_space).
+
+-dialyzer({nowarn_function, function7/0}).
+
+-export([ function1/2
+        , function2/2
+        , function3/2
+        , function4/2
+        , function5/0
+        , function6/0
+        , function7/0
+        , function8/0
+        , function9/0
+        , tag_filters/2
+        , unicode_characters/0
+        , windows_newlines/0
+        , this/0
+        , this/1
+        ]).
+
+%% No space before and after coma,on a comment.
+%% ( inside a comment
+%% ( 
+%%  ^ there's a space here
+
+function1(Should,Fail) ->
+    _AsAnAtom = '( ',
+    [Should,Fail].
+
+function2( Shouldnt, Fail) ->
+    _Unless = [we, consider]++ [operands, as, well],
+    _WithDash = Shouldnt - Fail.
+
+function3(Shouldnt, Fail) ->
+    {
+      Shouldnt ++ "Hello,Dont't Fail" ++ Fail,
+      'hello,don\'t fail',
+      <<"hello,don't fail">>
+    }.
+
+function4(Should, <<_:10/binary, ",", _/binary>>) ->
+    Should = [$,, "where $, represents the character ,"].
+
+function5( ) ->
+    User = #{name => <<"Juan">>, email => <<"juan@inaka.com">>},
+    <<"juan@inaka.com">> = maps:get(email,User).
+
+function6() ->
+    _MissingLeftSpace = 2+ 3,
+    _MissingRightSpace = 2 +3,
+    _Successful = 2 + 3,
+    _AsString = "( ",
+    _AlsoSuccessful = +1.
+
+function7() ->
+    % commas within strings must be ignored
+    Name = "anyone",
+    re:run(Name, "^.{1,20}$", [unicode]),
+    RegExp = "^.{1,20}$",
+    re:run(Name, RegExp, [unicode]).
+
+function8(
+ ) ->
+    [should| [fail]] ++ [should |[fail]] ++ [shouldnot | [fail]].
+
+function9(
+) ->
+    [X|| X <- [fail]] ++ [X ||X <- [fail]] ++ [X || X <- [notfail]].
+
+tag_filters(DocName, #{conn := Conn} = State ) ->
+  TableName = atom_to_list(DocName),
+  Sql = ["SELECT "
+         " 'tag' AS \"type\", "
+         " tag_name AS value, "
+         " COUNT(1) AS \"count\" "
+         "FROM ( "
+         " SELECT unnest(regexp_split_to_array(tags, ',')) AS tag_name"
+         " FROM ", TableName, " "
+         ") AS tags "
+         "GROUP BY tag_name "
+         "ORDER BY tag_name "],
+  Values = [],
+  case {Conn, Sql, Values} of
+    {ok, Maps, _} ->
+      {ok, {raw, Maps}, State};
+    {error, Error, _} ->
+      {error, Error, State}
+  end.
+
+unicode_characters() ->
+  <<"©"/utf8>> = <<"\\u00A9">>,
+  <<"ß"/utf8>> = <<"\\o337">>,
+  ok.
+
+windows_newlines() ->
+    <<_/bytes>> = <<"Foo",
+                    "bar">>,
+    ok.
+
+-spec this( )
+-> should_not_crash.
+this()
+-> should_not_crash.
+
+-spec this(shouldnt_either)
+-> -1.
+this(shouldnt_either)
+-> A = 1
+- 2, A.

--- a/test/examples/fail_no_space.erl
+++ b/test/examples/fail_no_space.erl
@@ -111,4 +111,4 @@ this()
 -> -1.
 this(shouldnt_either)
 -> A = 1
-- 2, A, $ . % there's a space after $ that we should complain about :) 
+- 2, A, $ . 

--- a/test/examples/pass_macro_names_elvis_attr.erl
+++ b/test/examples/pass_macro_names_elvis_attr.erl
@@ -9,6 +9,7 @@
 -define('A,aZ', 2).
 
 -elvis([{elvis_style, macro_names, #{regex => "^[a-zA-Z_,\-]+$"}}]).
+-elvis([{elvis_style, no_space, #{rules => []}}]).
 
 -export([
          define/1,

--- a/test/examples/pass_no_spaces_elvis_attr.erl
+++ b/test/examples/pass_no_spaces_elvis_attr.erl
@@ -1,6 +1,7 @@
 -module(pass_no_spaces_elvis_attr).
 
 -elvis([{elvis_text_style, no_spaces, disable}]).
+-elvis([{elvis_style, no_space, disable}]).
 -elvis([{elvis_text_style, no_tabs, disable}]).
 
 -export([one/0, two/0, three/0, four/0, five/0]).

--- a/test/examples/pass_operator_spaces_elvis_attr.erl
+++ b/test/examples/pass_operator_spaces_elvis_attr.erl
@@ -6,7 +6,7 @@
 
 -elvis([{elvis_style , operator_spaces , #{rules => [{right , "++"} ,
                                                      {left , ","}]}}]).
-
+-elvis([{elvis_style , no_space , #{rules => [{right , "("} , {left , ")"}]}}]).
 -export([ function1/2
         , function2/2
         , function3/2

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -391,12 +391,11 @@ verify_no_space(Config) ->
     Path1 = "fail_no_space." ++ Ext,
     [#{info := [right, "(", 3]},
      #{info := [right, "(", 32]},
-     #{info := [right, "(", 46]},
-     #{info := [left,  ")", 46]},
-     #{info := [left,  ")", 65]},
-     #{info := [left,  ")", 72]},
-     #{info := [right, "(", 102]},
-     #{info := [left,  ")", 102]}]
+     #{info := [right, "(", 48]},
+     #{info := [left,  ")", 48]},
+     #{info := [left,  ")", 75]},
+     #{info := [right, "(", 105]},
+     #{info := [left,  ")", 105]}]
         = elvis_core_apply_rule(Config, elvis_style, no_space, #{rules=>[{right, "("}, {left, ")"}]}, Path1).
 
 -spec verify_operator_spaces_latin1(config()) -> any().

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -27,6 +27,7 @@
          verify_macro_module_names/1,
          verify_no_macros/1,
          verify_operator_spaces/1,
+         verify_no_space/1,
          verify_operator_spaces_latin1/1,
          verify_nesting_level/1,
          verify_god_modules/1,
@@ -382,6 +383,21 @@ verify_operator_spaces(Config) ->
                              {left, "||"}]},
     [_, _, _, _, _, _, _, _, _, _] =
         elvis_core_apply_rule(Config, elvis_style, operator_spaces, AllOptions, Path).
+
+-spec verify_no_space(config()) -> any().
+verify_no_space(Config) ->
+    Ext = proplists:get_value(test_file_ext, Config, "erl"),
+
+    Path1 = "fail_no_space." ++ Ext,
+    [#{info := [right, "(", 3]},
+     #{info := [right, "(", 32]},
+     #{info := [right, "(", 46]},
+     #{info := [left,  ")", 46]},
+     #{info := [left,  ")", 65]},
+     #{info := [left,  ")", 72]},
+     #{info := [right, "(", 102]},
+     #{info := [left,  ")", 102]}]
+        = elvis_core_apply_rule(Config, elvis_style, no_space, #{rules=>[{right, "("}, {left, ")"}]}, Path1).
 
 -spec verify_operator_spaces_latin1(config()) -> any().
 verify_operator_spaces_latin1(Config) ->


### PR DESCRIPTION
**Edit**: the [Wiki](https://github.com/inaka/elvis_core/wiki/Rules#no-space) already expects this from 1.4.0 on. If we decide to make it default I'm sure it can be considered a breaking change (for those relying on `main`).