### PR TITLE
Improve debug

### DIFF
--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -212,9 +212,9 @@ apply_rule({Module, Function, ConfigArgs}, {Result, Config, File}) ->
                     elvis_result:new(rule, Function, [])
             end
         catch
-            _:Reason ->
-                Msg = "'~p' while applying rule '~p'.",
-                elvis_result:new(error, Msg, [Reason, Function])
+            _:Reason:Stacktrace ->
+                Msg = "'~p' while applying rule '~p': ~p.",
+                elvis_result:new(error, Msg, [Reason, Function, Stacktrace])
         end,
     {[RuleResult | Result], Config, File}.
 


### PR DESCRIPTION
Exceptions aren't supposed to occur, so instead of just hiding the stacktrace we display it in all its glory...

Closes #182.