### PR TITLE
Fix #191: Replace actual line by just the length on line_length message

### DIFF
--- a/src/elvis_text_style.erl
+++ b/src/elvis_text_style.erl
@@ -2,7 +2,7 @@
 
 -export([default/1, line_length/3, no_tabs/3, no_spaces/3, no_trailing_whitespace/3]).
 
--define(LINE_LENGTH_MSG, "Line ~p is too long: ~s.").
+-define(LINE_LENGTH_MSG, "Line ~p is too long. It has ~p characters.").
 -define(NO_TABS_MSG, "Line ~p has a tab at column ~p.").
 -define(NO_SPACES_MSG, "Line ~p has a spaces at column ~p.").
 -define(NO_TRAILING_WHITESPACE_MSG, "Line ~b has ~b trailing whitespace characters.").
@@ -121,7 +121,7 @@ check_line_length(Line, Num, [Limit, Encoding]) ->
     case length(Chars) of
         Large when Large > Limit ->
             Msg = ?LINE_LENGTH_MSG,
-            Info = [Num, binary_to_list(Line)],
+            Info = [Num, Large],
             Result = elvis_result:new(item, Msg, Info, Num),
             {ok, Result};
         _ ->

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -224,8 +224,7 @@ verify_line_length_rule(Config) ->
         elvis_core_apply_rule(Config, elvis_text_style, line_length, #{limit => 100}, Path),
     8 = length(Result),
     #{info := Info, message := Msg} = lists:nth(7, Result),
-    <<"Line 34 is too long:     gb_trees:from_orddict(", _/binary>> =
-        list_to_binary(io_lib:format(Msg, Info)),
+    <<"Line 34 is too long. It has ", _/binary>> = list_to_binary(io_lib:format(Msg, Info)),
 
     WholeLineResult =
         elvis_core_apply_rule(Config,
@@ -253,7 +252,7 @@ verify_line_length_rule_latin1(Config) ->
         elvis_core_apply_rule(Config, elvis_text_style, line_length, #{limit => 100}, Path),
     1 = length(Result),
     #{info := Info, message := Msg} = lists:nth(1, Result),
-    <<"Line 13 is too long:", _/binary>> = list_to_binary(io_lib:format(Msg, Info)).
+    <<"Line 13 is too long. It has", _/binary>> = list_to_binary(io_lib:format(Msg, Info)).
 
 -spec verify_unicode_line_length_rule(config()) -> any().
 verify_unicode_line_length_rule(Config) ->


### PR DESCRIPTION
Fixes #191, but instead of _adding_ the line length, I replaced the line with its length to make warnings less verbose.