### PR TITLE
Fix macro name resolution (`call` gets highest precedence)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       matrix:
         otp_vsn: [23, 24, 25]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         id: setup-beam
         with:
           otp-version: ${{matrix.otp_vsn}}
-          rebar3-version: '3.18'
+          rebar3-version: '3'
       - name: Restore _build
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        otp_vsn: [23.3, 24.3, 25.0]
+        otp_vsn: [23, 24, 25]
         os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v3

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1129,7 +1129,7 @@ is_macro_define_node(MaybeMacro) ->
 
 macro_name_from_node(MacroNode) ->
     MacroNodeValue = ktn_code:attr(value, MacroNode),
-    MacroAsAtom = macro_as_atom(false, [var, atom, call], MacroNodeValue),
+    MacroAsAtom = macro_as_atom(false, [call, var, atom], MacroNodeValue),
     MacroNameOriginal = atom_to_list(MacroAsAtom),
     MacroNameStripped = string:strip(MacroNameOriginal, both, $'),
     {MacroNameStripped, MacroNameOriginal}.

--- a/test/examples/fail_macro_names.erl
+++ b/test/examples/fail_macro_names.erl
@@ -5,7 +5,10 @@
 -define(GOOD_NAME,  "(megusta)").
 -define(wtf_NAME,   "(yuno)").
 -define(GOOD_NAME(Arg), "(megusta)").
+-define(GOOD_NAME_WITH_ATOM_RESULT(Arg), some_atom).
+-define(GOOD_NAME_WITH_VAR_RESULT(Arg), Arg).
 -define(GOOD_NAME_TOO (Arg), "(megusta)").
+-define(CALLING_SOMETHING, call(1)).
 -define(  'POTENTIAL_BAD-NAME'  , nomegusta).
 -define('A,aZ', 2).
 

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -330,7 +330,7 @@ verify_macro_names_rule(Config) ->
                               #{regex => "^[A-Za-z_, \-]+$"},
                               Path),
 
-    [_, _, _, _, _, _, _] =
+    [_, _, _, _, _, _, _, _, _, _] =
         elvis_core_apply_rule(Config,
                               elvis_style,
                               macro_names,


### PR DESCRIPTION
The `call` node has to be used with highest precedence when looking for
the macro name, as otherwise `-define(CALL(A), some_atom).` will pick
`some_atom` as the macro name instead.
