### PR TITLE
Prevent Hex.pm complaint on invalid license type

### DIFF
--- a/src/elvis_core.app.src
+++ b/src/elvis_core.app.src
@@ -6,6 +6,6 @@
   {applications, [kernel, stdlib, zipper, katana_code]},
   {modules, [elvis_core, elvis_config, elvis_result, elvis_utils, elvis_style]},
   {registered, []},
-  {licenses, ["Apache 2.0"]},
+  {licenses, ["Apache-2.0"]},
   {links, [{"GitHub", "https://github.com/inaka/elvis_core"}]},
   {build_tools, ["rebar3"]}]}.


### PR DESCRIPTION
No big change here, we just prevent a Hex.pm complaint like

```console
===> elvis_core.app.src : invalid license types detected - 'Apache 2.0'
     See https://spdx.org/licenses/ for a list of valid license identifiers
```

on publishing.

**Note**: license is still (as-was before) Apache 2.0.