### PR TITLE
Allow errorless consumption by `rebar3_lint`

### DIFF
--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -38,7 +38,8 @@ start() ->
 
 %%% Rock Command
 
--spec rock(elvis_config:configs()) -> ok | {fail, [elvis_result:file()]}.
+-spec rock(elvis_config:configs()) ->
+              ok | {fail, [{throw, term()} | elvis_result:file() | elvis_result:rule()]}.
 rock(Config) ->
     ok = elvis_config:validate(Config),
     NewConfig = elvis_config:normalize(Config),


### PR DESCRIPTION
This will be required once we want to add more context to errors in the plugin. I'll prepare a pull request for that and only propose it for acceptance once this is merged, tagged and Hex-published, at least.