### PR TITLE
Test over OTP 27 and rebar3 3.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        otp_vsn: ['24', '25', '26']
-        rebar3_vsn: ['3.22']
+        otp_vsn: ['24', '25', '26', '27']
+        rebar3_vsn: ['3.23']
         os: [ubuntu-22.04, windows-2022]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Compile
         run: rebar3 compile
       - name: Format check
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.os == 'ubuntu-22.04' && matrix.otp_vsn == '26' }}
         run: rebar3 format --verify
       - name: Run test
         run: rebar3 test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
         rebar3_vsn: ['3.23']
         os: [ubuntu-22.04, windows-2022]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         id: setup-beam
         with:
           otp-version: ${{matrix.otp_vsn}}
           rebar3-version: ${{matrix.rebar3_vsn}}
       - name: Restore _build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _build
           key: "_build-cache-for\
@@ -27,7 +27,7 @@ jobs:
                 -rebar3-${{steps.setup-beam.outputs.rebar3-version}}\
                 -hash-${{hashFiles('rebar.lock')}}"
       - name: Restore rebar3's cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/rebar3
           key: "rebar3-cache-for\

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # uses .markdownlint.yml for configuration
       - name: markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v11
+        uses: DavidAnson/markdownlint-cli2-action@v16
         with:
           globs: |
             LICENSE

--- a/test/examples/fail_no_successive_maps.erl
+++ b/test/examples/fail_no_successive_maps.erl
@@ -2,12 +2,22 @@
 
 -export([bad/0, good/0]).
 
+-if(?OTP_RELEASE<27).
 bad() ->
     M = #{this => is}#{wrong => "and"},
     M2 = M#{this := is}#{wrong := "as well"},
     M2#{this := is}#{also => wrong}.
+-else.
+bad() ->
+    #{}.
+-endif.
 
+-if(?OTP_RELEASE<27).
 good() ->
     M = #{this => is, good => "and"},
     M2 = M#{this := is, good := #{as => well}},
     M2#{this := is, also => good}.
+-else.
+good() ->
+    #{}.
+-endif.

--- a/test/examples/pass_no_successive_maps_elvis_attr.erl
+++ b/test/examples/pass_no_successive_maps_elvis_attr.erl
@@ -4,12 +4,22 @@
 
 -elvis([{elvis_style, no_successive_maps, disable}]).
 
+-if(?OTP_RELEASE<27).
 bad() ->
     M = #{this => is}#{wrong => "and"},
     M2 = M#{this := is}#{wrong := "as well"},
     M2#{this := is}#{also => wrong}.
+-else.
+bad() ->
+    #{}.
+-endif.
 
+-if(?OTP_RELEASE<27).
 good() ->
     M = #{this => is, good => "and"},
     M2 = M#{this := is, good := "as well"},
     M2#{this := is, also => good}.
+-else.
+good() ->
+    #{}.
+-endif.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1238,6 +1238,8 @@ verify_no_nested_try_catch(Config) ->
                               Path).
 
 -spec verify_no_successive_maps(config()) -> any().
+-if(?OTP_RELEASE < 27).
+
 verify_no_successive_maps(Config) ->
     Group = proplists:get_value(group, Config, erl_files),
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
@@ -1259,6 +1261,13 @@ verify_no_successive_maps(Config) ->
                               no_successive_maps,
                               #{ignore => [Module]},
                               Path).
+
+- else .
+
+verify_no_successive_maps(_Config) ->
+    [].
+
+-endif.
 
 -spec verify_atom_naming_convention(config()) -> any().
 verify_atom_naming_convention(Config) ->

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1251,7 +1251,7 @@ verify_no_successive_maps(Config) ->
                 [_, _, _] =
                     elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path);
             erl_files ->
-                [#{line_num := 6}, #{line_num := 7}, #{line_num := 8}] =
+                [#{line_num := 7}, #{line_num := 8}, #{line_num := 9}] =
                     elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path)
         end,
 

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1262,7 +1262,7 @@ verify_no_successive_maps(Config) ->
                               #{ignore => [Module]},
                               Path).
 
-- else .
+-else.
 
 verify_no_successive_maps(_Config) ->
     [].


### PR DESCRIPTION
## Notes on pull request

Found issues are around the development and maintenance of this library and `rebar3_format`. They do not seem to indicate `elvis_core` as non- OTP-27-ready.