### PR TITLE
Act on `non_reversible_form` as an exception to atom naming conventions

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1413,13 +1413,15 @@ is_float_node(Node) ->
     ktn_code:type(Node) =:= float.
 
 %% @private
-is_exception_class(error) ->
+is_exception_or_non_reversible(error) ->
     true;
-is_exception_class(exit) ->
+is_exception_or_non_reversible(exit) ->
     true;
-is_exception_class(throw) ->
+is_exception_or_non_reversible(throw) ->
     true;
-is_exception_class(_) ->
+is_exception_or_non_reversible(non_reversible_form) ->
+    true;
+is_exception_or_non_reversible(_) ->
     false.
 
 %% @private
@@ -1429,7 +1431,7 @@ check_atom_names(Regex, RegexEnclosed, [AtomNode | RemainingAtomNodes], AccIn) -
     AtomName0 = ktn_code:attr(text, AtomNode),
     ValueAtomName = ktn_code:attr(value, AtomNode),
     {IsEnclosed, AtomName} = string_strip_enclosed(AtomName0),
-    IsExceptionClass = is_exception_class(ValueAtomName),
+    IsExceptionClass = is_exception_or_non_reversible(ValueAtomName),
     RE = re_compile_for_atom_type(IsEnclosed, Regex, RegexEnclosed),
     AccOut =
         case re:run(

--- a/test/examples/pass_maybe.erl
+++ b/test/examples/pass_maybe.erl
@@ -1,10 +1,15 @@
 -module(pass_maybe).
 
+-if(?OTP_RELEASE >= 25).
+
 -feature(maybe_expr, enable).
+
+-endif.
 
 -export([sum_numbers/2]).
 
 
+-if(?OTP_RELEASE >= 25).
 sum_numbers(Number1, Number2) ->
     maybe
         ValidNumber1 ?= validate_number(Number1),
@@ -19,3 +24,7 @@ validate_number(Number) when is_number(Number) ->
     Number;
 validate_number(_) ->
     {error, invalid_number}.
+-else.
+sum_numbers(Number1, Number2) ->
+    Number1 + Number2.
+-endif.

--- a/test/examples/pass_maybe.erl
+++ b/test/examples/pass_maybe.erl
@@ -1,0 +1,21 @@
+-module(pass_maybe).
+
+-feature(maybe_expr, enable).
+
+-export([sum_numbers/2]).
+
+
+sum_numbers(Number1, Number2) ->
+    maybe
+        ValidNumber1 ?= validate_number(Number1),
+        ValidNumber2 ?= validate_number(Number2),
+        ValidNumber1 + ValidNumber2
+    else
+        {error, invalid_number} ->
+            {error, "One or both inputs are invalid numbers"}
+    end.
+
+validate_number(Number) when is_number(Number) ->
+    Number;
+validate_number(_) ->
+    {error, invalid_number}.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1281,6 +1281,8 @@ verify_atom_naming_convention(Config) ->
     PassPath = atom_to_list(PassModule) ++ "." ++ Ext,
     PassModule2 = pass_atom_naming_convention_exception_class,
     PassPath2 = atom_to_list(PassModule2) ++ "." ++ Ext,
+    PassModule3 = pass_maybe,
+    PassPath3 = atom_to_list(PassModule3) ++ "." ++ Ext,
 
     [] =
         elvis_core_apply_rule(Config,
@@ -1294,6 +1296,12 @@ verify_atom_naming_convention(Config) ->
                               atom_naming_convention,
                               #{regex => "^[^xwyhr]*$"},
                               PassPath2),
+    [] =
+        elvis_core_apply_rule(Config,
+                              elvis_style,
+                              atom_naming_convention,
+                              #{regex => "^^[a-z]([a-zA-Z0-9@]*_?)*(_SUITE)?$"},
+                              PassPath3),
 
     % fail
     FailModule = fail_atom_naming_convention,


### PR DESCRIPTION
Closes #344.

@elbrujohalcon, not really sure we should make this more explicit with a test (?)