### PR TITLE
Feature more `no_common_caveats_call` default options

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -26,6 +26,8 @@ This file's format is influenced by [Keep a Changelog](https://keepachangelog.co
 <https://github.com/inaka/elvis_core/blob/3.2.5/doc_rules/elvis_style/module_naming_convention.md#options>
 - your `no_debug_call` options to be the ones defined at
 <https://github.com/inaka/elvis_core/blob/3.2.5/doc_rules/elvis_style/no_debug_call.md#options>
+- your `no_common_caveats_call` options to be the ones defined at
+<https://github.com/inaka/elvis_core/blob/3.2.5/doc_rules/elvis_style/no_common_caveats_call.md#options>
 
 On the other hand you may choose to not implement those changes and merely adapt your code.
 

--- a/doc_rules/elvis_style/no_call.md
+++ b/doc_rules/elvis_style/no_call.md
@@ -3,7 +3,7 @@
 (since [0.4.0](https://github.com/inaka/elvis_core/releases/tag/0.4.0))
 
 This rule raise a warning when certain functions are called. It is also used internally to implement
-`no_debug_call` and `no_common_caveats` but, on its own, makes no checks on your code (the default
+`no_debug_call` and `no_common_caveats_call` but, on its own, makes no checks on your code (the default
 `no_call_functions` list is empty).  However, it is a convenient place to add your own list of calls
 to avoid (especially calls to third party libraries, where you can't just deprecate undesired
 functions).

--- a/doc_rules/elvis_style/no_common_caveats_call.md
+++ b/doc_rules/elvis_style/no_common_caveats_call.md
@@ -5,7 +5,8 @@
 The [Erlang Efficiency Guide](https://erlang.org/doc/efficiency_guide/commoncaveats.html) has a list
 of "Common Caveats" suggesting more efficient alternatives to several common functions.  This rule
 provides warnings if you call "inefficient" functions with entirely equivalent (efficient)
-alternatives.
+alternatives. It also warns you about functions with a more explicit interface (e.g. `gen_server:call/3`
+instead of `gen_server:call/2`) so you're sure to not have forgotten it.
 
 > Works on `.beam` file? Yes!
 
@@ -17,6 +18,9 @@ alternatives.
              , {timer, send_interval, 2}
              , {timer, send_interval, 3}
              , {erlang, size, 1}
+             , {gen_statem, call, 2}
+             , {gen_server, call, 2}
+             , {gen_event, call, 3}
               ]`.
 
 **Notice**: this rule is not enforced by default. Check the

--- a/test/examples/fail_no_call_classes.erl
+++ b/test/examples/fail_no_call_classes.erl
@@ -13,4 +13,13 @@ fail() ->
     _ = erlang:size(<<"fail_size">>),
 
     _ = erlang:tuple_size({1,2,3}),
-    _ = erlang:byte_size(<<"ok_size">>).
+    _ = erlang:byte_size(<<"ok_size">>),
+
+    _ = gen_server:call(self(), request),
+    _ = gen_server:call(self(), request, infinity),
+
+    _ = gen_event:call(self(), self(), request),
+    _ = gen_event:call(self(), self(), request, infinity),
+
+    _ = gen_statem:call(self(), request),
+    _ = gen_statem:call(self(), request, infinity).

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1232,7 +1232,10 @@ verify_no_call_flavours(Config,
          {{erlang, size, 1}, 2},
          {{timer, send_after}, 2},
          {{timer, '_', '_'}, 4},
-         {{'_', tuple_size, 1}, 1}],
+         {{'_', tuple_size, 1}, 1},
+         {{gen_statem, call, 2}, 1},
+         {{gen_server, call, 2}, 1},
+         {{gen_event, call, 3}, 1}],
 
     lists:foreach(fun({FunSpec, ExpectedCount}) ->
                      ThisRuleConfig = maps:from_list([{RuleConfigMapKey, [FunSpec]}]),


### PR DESCRIPTION
# Description

Closes #320.

Mind you this is only present in `erl_files_strict` so less far-reaching than it first it may seem.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
