### PR TITLE
Closes #311 - fix no_match_in_condition reports a warning even when the condition includes a valid match

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1302,7 +1302,8 @@ no_match_in_condition(Config, Target, RuleConfig) ->
               CaseNodes).
 
 is_match_in_condition(Node) ->
-    ktn_code:type(Node) == case_expr andalso [] =/= elvis_code:find(fun is_match/1, Node).
+    (ktn_code:type(Node) == case_expr orelse ktn_code:type(Node) == block)
+    andalso lists:any(fun is_match/1, ktn_code:content(Node)).
 
 is_match(Node) ->
     ktn_code:type(Node) == match orelse ktn_code:type(Node) == maybe_match.

--- a/test/examples/pass_no_match_in_condition2.erl
+++ b/test/examples/pass_no_match_in_condition2.erl
@@ -1,0 +1,14 @@
+-module(pass_no_match_in_condition2).
+
+-export([valid/1]).
+
+valid(List) ->
+    case lists:all(fun ({K, V}) ->
+                           Something = find:something(for, K),
+                           check:something(V, Something)
+                   end,
+                   List)
+        of
+        true -> all_true;
+        false -> found_a_bad_one
+    end.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1638,9 +1638,10 @@ verify_no_match_in_condition(Config) ->
 
     PassPath = "pass_no_match_in_condition." ++ Ext,
     [] = elvis_core_apply_rule(Config, elvis_style, no_match_in_condition, #{}, PassPath),
+    PassPath2 = "pass_no_match_in_condition2." ++ Ext,
+    [] = elvis_core_apply_rule(Config, elvis_style, no_match_in_condition, #{}, PassPath2),
 
     FailPath = "fail_no_match_in_condition." ++ Ext,
-
     R = elvis_core_apply_rule(Config, elvis_style, no_match_in_condition, #{}, FailPath),
     case Group of
         beam_files ->


### PR DESCRIPTION
# Description

My idea was to check only the "first layer of children" of the `case` type Node.
And I added the type `block` too.

Closes #311;.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
