### PR TITLE
change(export_used_types): don't warn on behaviour callbacks

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1500,8 +1500,13 @@ get_behaviour_callbacks(Root) ->
     BehaviourNames =
         lists:map(fun(#{attrs := #{value := Behaviour}}) -> Behaviour end, Behaviours),
 
-    lists:append(
-        lists:map(fun(B) -> apply(B, behaviour_info, [callbacks]) end, BehaviourNames)).
+    try lists:map(fun(B) -> apply(B, behaviour_info, [callbacks]) end, BehaviourNames) of
+        DeepList ->
+            lists:append(DeepList)
+    catch
+        _ ->
+            []
+    end.
 
 get_type_of_type(#{type := type_attr,
                    node_attrs := #{type := #{attrs := #{name := TypeOfType}}}}) ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1504,7 +1504,7 @@ get_behaviour_callbacks(Root) ->
         DeepList ->
             lists:append(DeepList)
     catch
-        _ ->
+        _:_ ->
             []
     end.
 

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1497,11 +1497,11 @@ export_used_types(Config, Target, RuleConfig) ->
 get_behaviour_callbacks(Root) ->
     IsBehaviour = fun(Node) -> ktn_code:type(Node) == behaviour end,
     Behaviours = elvis_code:find(IsBehaviour, Root),
-    BehaviourNames = lists:map(fun(#{attrs := #{value := Behaviour}}) -> Behaviour end, Behaviours),
+    BehaviourNames =
+        lists:map(fun(#{attrs := #{value := Behaviour}}) -> Behaviour end, Behaviours),
 
     lists:append(
-      lists:map(fun(B) -> B:behaviour_info(callbacks) end, BehaviourNames
-    )).
+        lists:map(fun(B) -> B:behaviour_info(callbacks) end, BehaviourNames)).
 
 get_type_of_type(#{type := type_attr,
                    node_attrs := #{type := #{attrs := #{name := TypeOfType}}}}) ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1501,7 +1501,7 @@ get_behaviour_callbacks(Root) ->
         lists:map(fun(#{attrs := #{value := Behaviour}}) -> Behaviour end, Behaviours),
 
     lists:append(
-        lists:map(fun(B) -> B:behaviour_info(callbacks) end, BehaviourNames)).
+        lists:map(fun(B) -> apply(B, behaviour_info, [callbacks]) end, BehaviourNames)).
 
 get_type_of_type(#{type := type_attr,
                    node_attrs := #{type := #{attrs := #{name := TypeOfType}}}}) ->

--- a/test/examples/pass_export_used_types2.erl
+++ b/test/examples/pass_export_used_types2.erl
@@ -1,0 +1,17 @@
+-module(pass_export_used_types2).
+
+-behaviour(gen_server).
+
+-record(state, {a = field}).
+
+-type state() :: #state{}.
+
+-export([init/1, handle_cast/2, handle_call/3]).
+
+-spec init(_) -> {ok, state()}.
+init(_) -> {ok, #state{}}.
+
+handle_call(_, _, State) -> {State, ok, State}.
+
+-spec handle_cast(_, state()) -> {noreply, state()}.
+handle_cast(_, State) -> {noreply, State}.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -753,8 +753,7 @@ verify_state_record_and_type_plus_export_used_types(Config) ->
         elvis_core_apply_rule(Config, elvis_style, export_used_types, #{}, PathPassGenStateM),
 
     PathFail = "fail_state_record_and_type_plus_export_used_types." ++ Ext,
-    [] = elvis_core_apply_rule(Config, elvis_style, state_record_and_type, #{}, PathFail),
-    [_] = elvis_core_apply_rule(Config, elvis_style, export_used_types, #{}, PathFail).
+    [] = elvis_core_apply_rule(Config, elvis_style, state_record_and_type, #{}, PathFail).
 
 -spec verify_behaviour_spelling(config()) -> any().
 verify_behaviour_spelling(Config) ->
@@ -1753,6 +1752,9 @@ verify_export_used_types(Config) ->
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
     PathPass = "pass_export_used_types." ++ Ext,
     [] = elvis_core_apply_rule(Config, elvis_style, export_used_types, #{}, PathPass),
+
+    PathPass2 = "pass_export_used_types2." ++ Ext,
+    [] = elvis_core_apply_rule(Config, elvis_style, export_used_types, #{}, PathPass2),
 
     PathFail = "fail_export_used_types." ++ Ext,
     [#{line_num := 3}] =


### PR DESCRIPTION
# Description

I implemented a way to get the callbacks for the behaviors in the module and subtract them from the function used in the rule's logic. This approach ensures that all callback types are ignored.

Additionally, there was a test that expected a warning from a module that no longer generates one. So, I removed that assertion, but I'm not sure if that was the correct decision.
Closes #308.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
