### PR TITLE
fix(no_successive_maps): prevent failing on nested maps

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1094,7 +1094,8 @@ no_successive_maps(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Predicate = fun(Node) -> ktn_code:type(Node) == map end,
     ResultFun = result_node_line_fun(?NO_SUCCESSIVE_MAPS_MSG),
-    case elvis_code:find(Predicate, Root) of
+    FindOpts = #{mode => node, traverse => all},
+    case elvis_code:find(Predicate, Root, FindOpts) of
         [] ->
             [];
         MapExprs ->

--- a/test/examples/fail_no_successive_maps2.erl
+++ b/test/examples/fail_no_successive_maps2.erl
@@ -1,0 +1,31 @@
+-module(fail_no_successive_maps2).
+
+-export([test1/0, test2/0]).
+
+test1() ->
+  _ = #{
+    x => [
+        #{a => b, c => d},
+        #{a => b, c => d} % expected a warning here
+        #{a => b, c => d},
+        #{a => b, c => d}
+    ]
+}.
+
+test2() ->
+  _ = #{
+    map => #{
+          x => [
+              #{a => b, c => d},
+              #{a => b, c => d} % expected a warning here
+              #{a => b, c => d},
+              #{a => b, c => d}
+          ],
+          y => [
+              #{a => b, c => d},
+              #{a => b, c => d} % expected a warning here
+              #{a => b, c => d},
+              #{a => b, c => d}
+          ]
+      }
+}.

--- a/test/examples/fail_no_successive_maps2.erl
+++ b/test/examples/fail_no_successive_maps2.erl
@@ -2,6 +2,7 @@
 
 -export([test1/0, test2/0]).
 
+-if(?OTP_RELEASE<27).
 test1() ->
   _ = #{
     x => [
@@ -11,7 +12,12 @@ test1() ->
         #{a => b, c => d}
     ]
 }.
+-else.
+test1() ->
+    #{}.
+-endif.
 
+-if(?OTP_RELEASE<27).
 test2() ->
   _ = #{
     map => #{
@@ -29,3 +35,7 @@ test2() ->
           ]
       }
 }.
+-else.
+test2() ->
+    #{}.
+-endif.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1369,7 +1369,7 @@ verify_no_successive_maps(Config) ->
             erl_files ->
                 [#{line_num := 7}, #{line_num := 8}, #{line_num := 9}] =
                     elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path),
-                [#{line_num := 9}, #{line_num := 20}, #{line_num := 26}] =
+                [#{line_num := 10}, #{line_num := 26}, #{line_num := 32}] =
                     elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path2)
         end,
 

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1358,13 +1358,19 @@ verify_no_successive_maps(Config) ->
 
     Module = fail_no_successive_maps,
     Path = atom_to_list(Module) ++ "." ++ Ext,
+
+    Path2 = "fail_no_successive_maps2." ++ Ext,
     _ = case Group of
             beam_files ->
                 [_, _, _] =
-                    elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path);
+                    elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path),
+                [_, _, _] =
+                    elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path2);
             erl_files ->
                 [#{line_num := 7}, #{line_num := 8}, #{line_num := 9}] =
-                    elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path)
+                    elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path),
+                [#{line_num := 9}, #{line_num := 20}, #{line_num := 26}] =
+                    elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path2)
         end,
 
     [] =


### PR DESCRIPTION
# Description

I just added the option: `traverse => all` to the rule because when I investigated the problem with the provided example, I realized that the `elvis_code:find` does not go deep into this nested map, because the zippers can go deeper only if a `node` is a `branch`.  A node is identified as a `branch` if it has something in its `content` field(if the traverse is set to `content`). So we need to change `traverse` to `all` so the `elvis_code` can use the `node_attrs` as the children of the node.

In this example, the rule fails because a `map_field_assoc` type node contains no content, preventing the function `elvis_code:find` from going deeper; it only returns that one map.

Closes #339.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
