### PR TITLE
add forbidden regex

### DIFF
--- a/doc_rules/elvis_style/atom_naming_convention.md
+++ b/doc_rules/elvis_style/atom_naming_convention.md
@@ -6,7 +6,8 @@ All atoms should be named according to the regular expression provided.
 Except if it matches with a defined `forbidden_regex`.
 Atoms enclosed in apostrophes have special meaning and are thus handled
 by a different configuration option (use `same` if you want the same value as `regex`).
-To define forbidden enclosed atoms (like the ones in `forbidden_regex` apply for `regex`), use `forbidden_enclosed_regex`(use `same` if you want the same value as `forbidden_regex`).
+To define forbidden enclosed atoms (like the ones in `forbidden_regex` apply for `regex`),
+use `forbidden_enclosed_regex`(use `same` if you want the same value as `forbidden_regex`).
 
 > Works on `.beam` file? Yes!
 

--- a/doc_rules/elvis_style/atom_naming_convention.md
+++ b/doc_rules/elvis_style/atom_naming_convention.md
@@ -18,7 +18,7 @@ To define forbidden enclosed atoms (like the ones in `forbidden_regex` apply for
   - default: `".*"`.
 - `forbidden_regex :: string() | undefined`.
   - default: `undefined`.
-- `forbidden_enclosed_regex :: string() | undefined | same`.
+- `forbidden_enclosed_regex :: string() | undefined`.
   - default: `undefined`.
 
 ## Example

--- a/doc_rules/elvis_style/atom_naming_convention.md
+++ b/doc_rules/elvis_style/atom_naming_convention.md
@@ -6,6 +6,7 @@ All atoms should be named according to the regular expression provided.
 Except if it matches with a defined `forbidden_regex`.
 Atoms enclosed in apostrophes have special meaning and are thus handled
 by a different configuration option (use `same` if you want the same value as `regex`).
+For enclosed atoms we defined a different forbidden regex, called `forbidden_enclosed_regex`.
 
 > Works on `.beam` file? Yes!
 
@@ -16,6 +17,8 @@ by a different configuration option (use `same` if you want the same value as `r
 - `enclosed_atoms :: string()`.
   - default: `".*"`.
 - `forbidden_regex :: string() | undefined`.
+  - default: `undefined`.
+- `forbidden_enclosed_regex :: string() | undefined`.
   - default: `undefined`.
 
 ## Example

--- a/doc_rules/elvis_style/atom_naming_convention.md
+++ b/doc_rules/elvis_style/atom_naming_convention.md
@@ -6,7 +6,7 @@ All atoms should be named according to the regular expression provided.
 Except if it matches with a defined `forbidden_regex`.
 Atoms enclosed in apostrophes have special meaning and are thus handled
 by a different configuration option (use `same` if you want the same value as `regex`).
-For enclosed atoms we defined a different forbidden regex, called `forbidden_enclosed_regex`.
+To define forbidden enclosed atoms (like the ones in `forbidden_regex` apply for `regex`), use `forbidden_enclosed_regex`.
 
 > Works on `.beam` file? Yes!
 

--- a/doc_rules/elvis_style/atom_naming_convention.md
+++ b/doc_rules/elvis_style/atom_naming_convention.md
@@ -2,8 +2,8 @@
 
 (since [1.0.0](https://github.com/inaka/elvis_core/releases/tag/1.0.0))
 
-All atoms should be named according to the regular expression provided.
-Except if it matches with a defined `forbidden_regex`.
+All atoms should be named according to the provided regular expression,
+except if they match with a defined `forbidden_regex`.
 Atoms enclosed in apostrophes have special meaning and are thus handled
 by a different configuration option (use `same` if you want the same value as `regex`).
 To define forbidden enclosed atoms (like the ones in `forbidden_regex` apply for `regex`),

--- a/doc_rules/elvis_style/atom_naming_convention.md
+++ b/doc_rules/elvis_style/atom_naming_convention.md
@@ -15,11 +15,11 @@ use `forbidden_enclosed_regex`(use `same` if you want the same value as `forbidd
 
 - `regex :: string()`.
   - default: `"^([a-z][a-z0-9]*_?)*(_SUITE)?$"`.
-- `enclosed_atoms :: string()`.
+- `enclosed_atoms :: string() | same`.
   - default: `".*"`.
 - `forbidden_regex :: string() | undefined`.
   - default: `undefined`.
-- `forbidden_enclosed_regex :: string() | undefined`.
+- `forbidden_enclosed_regex :: string() | undefined | same`.
   - default: `undefined`.
 
 ## Example

--- a/doc_rules/elvis_style/atom_naming_convention.md
+++ b/doc_rules/elvis_style/atom_naming_convention.md
@@ -4,8 +4,8 @@
 
 All atoms should be named according to the regular expression provided.
 Except if it matches with a defined `forbidden_regex`.
-Atoms enclosed in apostrophes have special meaning and are thus handled by a different configuration option (use
-`same` if you want the same value as `regex`).
+Atoms enclosed in apostrophes have special meaning and are thus handled
+by a different configuration option (use `same` if you want the same value as `regex`).
 
 > Works on `.beam` file? Yes!
 

--- a/doc_rules/elvis_style/atom_naming_convention.md
+++ b/doc_rules/elvis_style/atom_naming_convention.md
@@ -6,7 +6,7 @@ All atoms should be named according to the regular expression provided.
 Except if it matches with a defined `forbidden_regex`.
 Atoms enclosed in apostrophes have special meaning and are thus handled
 by a different configuration option (use `same` if you want the same value as `regex`).
-To define forbidden enclosed atoms (like the ones in `forbidden_regex` apply for `regex`), use `forbidden_enclosed_regex`.
+To define forbidden enclosed atoms (like the ones in `forbidden_regex` apply for `regex`), use `forbidden_enclosed_regex`(use `same` if you want the same value as `forbidden_regex`).
 
 > Works on `.beam` file? Yes!
 
@@ -18,7 +18,7 @@ To define forbidden enclosed atoms (like the ones in `forbidden_regex` apply for
   - default: `".*"`.
 - `forbidden_regex :: string() | undefined`.
   - default: `undefined`.
-- `forbidden_enclosed_regex :: string() | undefined`.
+- `forbidden_enclosed_regex :: string() | undefined | same`.
   - default: `undefined`.
 
 ## Example

--- a/doc_rules/elvis_style/atom_naming_convention.md
+++ b/doc_rules/elvis_style/atom_naming_convention.md
@@ -2,8 +2,9 @@
 
 (since [1.0.0](https://github.com/inaka/elvis_core/releases/tag/1.0.0))
 
-All atoms should be named according to the regular expression provided. Atoms enclosed in
-apostrophes have special meaning and are thus handled by a different configuration option (use
+All atoms should be named according to the regular expression provided.
+Except if it matches with a defined `forbidden_regex`.
+Atoms enclosed in apostrophes have special meaning and are thus handled by a different configuration option (use
 `same` if you want the same value as `regex`).
 
 > Works on `.beam` file? Yes!
@@ -14,6 +15,8 @@ apostrophes have special meaning and are thus handled by a different configurati
   - default: `"^([a-z][a-z0-9]*_?)*(_SUITE)?$"`.
 - `enclosed_atoms :: string()`.
   - default: `".*"`.
+- `forbidden_regex :: string() | undefined`.
+  - default: `undefined`.
 
 ## Example
 

--- a/doc_rules/elvis_style/function_naming_convention.md
+++ b/doc_rules/elvis_style/function_naming_convention.md
@@ -1,6 +1,7 @@
 # Function Naming Convention
 
 All functions should be named according to the regular expression provided.
+Except if it matches with a defined `forbidden_regex`.
 
 > Works on `.beam` file? Yes!
 
@@ -8,6 +9,8 @@ All functions should be named according to the regular expression provided.
 
 - `regex :: string()`.
   - default: `"^[a-z](_?[a-z0-9]+)*$"`.
+- `forbidden_regex :: string() | undefined`.
+  - default: `undefined`.
 
 ## Example
 

--- a/doc_rules/elvis_style/function_naming_convention.md
+++ b/doc_rules/elvis_style/function_naming_convention.md
@@ -1,7 +1,7 @@
 # Function Naming Convention
 
-All functions should be named according to the regular expression provided.
-Except if it matches with a defined `forbidden_regex`.
+All functions should be named according to the provided regular expression,
+except if they match with a defined `forbidden_regex`.
 
 > Works on `.beam` file? Yes!
 

--- a/doc_rules/elvis_style/module_naming_convention.md
+++ b/doc_rules/elvis_style/module_naming_convention.md
@@ -1,7 +1,7 @@
 # Module Naming Convention
 
-All modules should be named according to the regular expression provided.
-Except if it matches with a defined `forbidden_regex`.
+All modules should be named according to the provided regular expression,
+except if they match with a defined `forbidden_regex`.
 
 > Works on `.beam` file? Yes!
 

--- a/doc_rules/elvis_style/module_naming_convention.md
+++ b/doc_rules/elvis_style/module_naming_convention.md
@@ -1,6 +1,7 @@
 # Module Naming Convention
 
 All modules should be named according to the regular expression provided.
+Except if it matches with a defined `forbidden_regex`.
 
 > Works on `.beam` file? Yes!
 
@@ -8,6 +9,8 @@ All modules should be named according to the regular expression provided.
 
 - `regex :: string()`.
   - default: `"^[a-z](_?[a-z0-9]+)*(_SUITE)?$"`.
+- `forbidden_regex :: string() | undefined`.
+  - default: `undefined`.
 
 ## Example
 

--- a/doc_rules/elvis_style/variable_naming_convention.md
+++ b/doc_rules/elvis_style/variable_naming_convention.md
@@ -1,6 +1,7 @@
 # Variable Naming Convention
 
 All variables should be named according to the regular expression provided.
+Except if it matches with a defined `forbidden_regex`.
 
 > Works on `.beam` file? Yes!
 
@@ -8,6 +9,8 @@ All variables should be named according to the regular expression provided.
 
 - `regex :: string()`.
   - default: `"^_?([A-Z][0-9a-zA-Z]*)$"`.
+- `forbidden_regex :: string() | undefined`.
+  - default: `undefined`.
 
 ## Example
 

--- a/doc_rules/elvis_style/variable_naming_convention.md
+++ b/doc_rules/elvis_style/variable_naming_convention.md
@@ -1,7 +1,7 @@
 # Variable Naming Convention
 
-All variables should be named according to the regular expression provided.
-Except if it matches with a defined `forbidden_regex`.
+All variables should be named according to the provided regular expression,
+except if they match with a defined `forbidden_regex`.
 
 > Works on `.beam` file? Yes!
 

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -73,13 +73,13 @@
         "The function ~p does not respect the format defined by the "
         "regular expression '~p'.").
 -define(FORBIDDEN_FUNCTION_NAMING_CONVENTION_MSG,
-        "The function ~p does written in a forbidden format"
+        "The function ~p is written in a forbidden format"
         "defined by the regular expression '~p'.").
 -define(VARIABLE_NAMING_CONVENTION_MSG,
         "The variable ~p on line ~p does not respect the format "
         "defined by the regular expression '~p'.").
 -define(FORBIDDEN_VARIABLE_NAMING_CONVENTION_MSG,
-        "The variable ~p on line ~p does written in a forbidden the format "
+        "The variable ~p on line ~p is written in a forbidden the format "
         "defined by the regular expression '~p'.").
 -define(CONSISTENT_VARIABLE_CASING_MSG,
         "Variable ~ts (first used in line ~p) is written in different ways within the module: ~p.").
@@ -87,7 +87,7 @@
         "The module ~p does not respect the format defined by the "
         "regular expression '~p'.").
 -define(FORBIDDEN_MODULE_NAMING_CONVENTION_MSG,
-        "The module ~p does written in a forbidden format defined by the "
+        "The module ~p is written in a forbidden format defined by the "
         "regular expression '~p'.").
 -define(STATE_RECORD_MISSING_MSG,
         "This module implements an OTP behavior but is missing "
@@ -126,7 +126,7 @@
         "Atom ~p on line ~p does not respect the format "
         "defined by the regular expression '~p'.").
 -define(FORBIDDEN_ATOM_NAMING_CONVENTION_MSG,
-        "Atom ~p on line ~p does does written in a forbidden format "
+        "Atom ~p on line ~p is written in a forbidden format "
         "defined by the regular expression '~p'.").
 -define(NO_THROW_MSG, "Usage of throw/1 on line ~p is not recommended").
 -define(NO_DOLLAR_SPACE_MSG,

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1165,7 +1165,7 @@ atom_naming_convention(Config, Target, RuleConfig) ->
         specific_or_default(option(enclosed_atoms, RuleConfig, atom_naming_convention), Regex),
     ForbiddenEnclosedRegex =
         specific_or_default(option(forbidden_enclosed_regex, RuleConfig, atom_naming_convention),
-                            Regex),
+                            ForbiddenRegex),
     AtomNodes = elvis_code:find(fun is_atom_node/1, Root, #{traverse => all, mode => node}),
     check_atom_names(Regex,
                      ForbiddenRegex,

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -70,24 +70,24 @@
         "Use the '-callback' attribute instead of 'behavior_info/1' "
         "on line ~p.").
 -define(FUNCTION_NAMING_CONVENTION_MSG,
-        "The function ~p does not respect the format defined by the "
+        "The function ~p's name does not respect the format defined by the "
         "regular expression '~p'.").
 -define(FORBIDDEN_FUNCTION_NAMING_CONVENTION_MSG,
-        "The function ~p is written in a forbidden format"
+        "The function ~p's name is written in a forbidden format"
         "defined by the regular expression '~p'.").
 -define(VARIABLE_NAMING_CONVENTION_MSG,
-        "The variable ~p on line ~p does not respect the format "
+        "The variable ~p's name, on line ~p does not respect the format "
         "defined by the regular expression '~p'.").
 -define(FORBIDDEN_VARIABLE_NAMING_CONVENTION_MSG,
-        "The variable ~p on line ~p is written in a forbidden the format "
+        "The variable ~p's name on line ~p is written in a forbidden the format "
         "defined by the regular expression '~p'.").
 -define(CONSISTENT_VARIABLE_CASING_MSG,
         "Variable ~ts (first used in line ~p) is written in different ways within the module: ~p.").
 -define(MODULE_NAMING_CONVENTION_MSG,
-        "The module ~p does not respect the format defined by the "
+        "The module ~p's name does not respect the format defined by the "
         "regular expression '~p'.").
 -define(FORBIDDEN_MODULE_NAMING_CONVENTION_MSG,
-        "The module ~p is written in a forbidden format defined by the "
+        "The module ~p's name is written in a forbidden format defined by the "
         "regular expression '~p'.").
 -define(STATE_RECORD_MISSING_MSG,
         "This module implements an OTP behavior but is missing "
@@ -123,10 +123,10 @@
 -define(NO_SUCCESSIVE_MAPS_MSG,
         "Found map update after map construction/update at line ~p.").
 -define(ATOM_NAMING_CONVENTION_MSG,
-        "Atom ~p on line ~p does not respect the format "
+        "Atom ~p's name, on line ~p does not respect the format "
         "defined by the regular expression '~p'.").
 -define(FORBIDDEN_ATOM_NAMING_CONVENTION_MSG,
-        "Atom ~p on line ~p is written in a forbidden format "
+        "Atom ~p on line ~p's name is written in a forbidden format "
         "defined by the regular expression '~p'.").
 -define(NO_THROW_MSG, "Usage of throw/1 on line ~p is not recommended").
 -define(NO_DOLLAR_SPACE_MSG,

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -323,18 +323,18 @@ errors_for_function_names(Regex, ForbiddenRegex, [FunctionName | RemainingFuncNa
             Result = elvis_result:new(item, Msg, Info, 1),
             [Result | errors_for_function_names(Regex, ForbiddenRegex, RemainingFuncNames)];
         {match, _} ->
-            case ForbiddenRegex =/= undefined
-                 andalso re:run(FunctionNameStr, ForbiddenRegex, [unicode])
-            of
+            case ForbiddenRegex of
+                undefined -> errors_for_function_names(Regex, ForbiddenRegex, RemainingFuncNames);
+                ForbiddenRegex ->
+                    case re:run(FunctionNameStr, ForbiddenRegex, [unicode]) of
                 {match, _} ->
                     Msg = ?FORBIDDEN_FUNCTION_NAMING_CONVENTION_MSG,
                     Info = [FunctionNameStr, Regex],
                     Result = elvis_result:new(item, Msg, Info, 1),
                     [Result | errors_for_function_names(Regex, ForbiddenRegex, RemainingFuncNames)];
                 nomatch ->
-                    errors_for_function_names(Regex, ForbiddenRegex, RemainingFuncNames);
-                false ->
                     errors_for_function_names(Regex, ForbiddenRegex, RemainingFuncNames)
+                 end
             end
     end.
 

--- a/test/examples/forbidden_atom_naming_convention.erl
+++ b/test/examples/forbidden_atom_naming_convention.erl
@@ -1,0 +1,14 @@
+-module(forbidden_atom_naming_convention).
+
+-export([for_test/0]).
+
+for_test() ->
+    this_is_an_ok_atom,
+    'and_so_is_this',
+    'and_this_1_too',
+    non_200,
+    '_', % used by ets/mnesia/etc.
+    non200, % valid, even without underscores
+    valid_200even_if_numb3rs_appear_between_letters,
+    blahblah_SUITE,
+    x.

--- a/test/examples/forbidden_function_naming_convention.erl
+++ b/test/examples/forbidden_function_naming_convention.erl
@@ -1,0 +1,31 @@
+-module(forbidden_function_naming_convention).
+
+-dialyzer({nowarn_function, bad_names_inside/0}).
+
+-export([bad_names_inside/0]).
+
+%% Function names must use only lowercase characters.
+%% Words in function names must be separated with _.
+
+%% Cf. https://github.com/inaka/erlang_guidelines#function-names
+
+bad_names_inside() ->
+    good_name(should, fail),
+    not_forbidden_but_still_bad____(should, fail),
+    no_numbers_1(should, fail),
+    fun2ms(should, fail).
+
+%% Private / hidden functions still checked
+
+good_name(Should, Fail) ->
+    [Should, Fail].
+
+not_forbidden_but_still_bad____(Should, Fail) ->
+    [Should, Fail].
+
+no_numbers_1(Should, Fail) ->
+    [Should, Fail].
+
+fun2ms(Should, Fail) ->
+    [Should, Fail].
+

--- a/test/examples/forbidden_module_naming_convention_12.erl
+++ b/test/examples/forbidden_module_naming_convention_12.erl
@@ -1,0 +1,1 @@
+-module(forbidden_module_naming_convention_12).

--- a/test/examples/forbidden_variable_naming_convention.erl
+++ b/test/examples/forbidden_variable_naming_convention.erl
@@ -1,0 +1,22 @@
+-module(forbidden_variable_naming_convention).
+
+-export([should_pass/5]).
+-export([should_pass/0, should_pass/1]).
+
+%% CamelCase must be used for variables. Don’t
+%% separate words in variables with _.
+
+%% Cf. https://github.com/inaka/erlang_guidelines#variable-names
+
+should_pass(Should, Pass, Way2Home, Fun1, Fun2) ->
+    [_IgnoredVariable, _] = ["Ignored but valid", "also valid"],
+    Should = "Should",
+    Pass = "Pass",
+    Way2Home = "Way to home",
+    Fun1 = Should ++ Pass,
+    Fun2 = Fun1 ++ Way2Home.
+
+should_pass() ->
+  ?MODULE_STRING.
+
+should_pass(_) -> ?MODULE_STRING.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1621,7 +1621,7 @@ verify_atom_naming_convention(Config) ->
                               atom_naming_convention,
                               #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
                                 forbidden_regex => "[0-9]",
-                                forbidden_enclosed_regex => "[0-9]"},
+                                forbidden_enclosed_regex => same},
                               PathForbidden).
 
 -spec verify_no_init_lists(config()) -> any().

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -192,7 +192,7 @@ verify_function_naming_convention(Config) ->
         elvis_core_apply_rule(Config,
                               elvis_style,
                               function_naming_convention,
-                              #{regex => "^[a-z](_?[a-z0-9]+)*$", forbidden_regex => "[0-9]"},
+                              #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
                               PathForbidden).
 
 -spec verify_variable_naming_convention(config()) -> any().
@@ -200,6 +200,7 @@ verify_variable_naming_convention(Config) ->
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
 
     RuleConfig = #{regex => "^_?([A-Z][0-9a-zA-Z]*)$"},
+    #{regex := DefaultRegex} = elvis_style:default(variable_naming_convention),
 
     PathPass = "pass_variable_naming_convention." ++ Ext,
     [] =
@@ -227,7 +228,7 @@ verify_variable_naming_convention(Config) ->
         elvis_core_apply_rule(Config,
                               elvis_style,
                               variable_naming_convention,
-                              #{regex => "^_?([A-Z][0-9a-zA-Z]*)$", forbidden_regex => "[0-9]"},
+                              #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
                               PathForbidden).
 
 -spec verify_consistent_variable_casing(config()) -> any().
@@ -720,8 +721,7 @@ verify_module_naming_convention(Config) ->
         elvis_core_apply_rule(Config,
                               elvis_style,
                               module_naming_convention,
-                              #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
-                                forbidden_regex => "[0-9]"},
+                              #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
                               PathForbidden).
 
 -spec verify_state_record_and_type(config()) -> any().
@@ -1465,6 +1465,8 @@ verify_atom_naming_convention(Config) ->
     Group = proplists:get_value(group, Config, erl_files),
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
 
+    #{regex := DefaultRegex} = elvis_style:default(atom_naming_convention),
+
     BaseRegex = "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
 
     % pass
@@ -1602,16 +1604,14 @@ verify_atom_naming_convention(Config) ->
                     elvis_core_apply_rule(Config,
                                           elvis_style,
                                           atom_naming_convention,
-                                          #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
-                                            forbidden_regex => "[0-9]"},
+                                          #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
                                           PathForbidden);
             erl_files ->
                 [_, _, _] =
                     elvis_core_apply_rule(Config,
                                           elvis_style,
                                           atom_naming_convention,
-                                          #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
-                                            forbidden_regex => "[0-9]"},
+                                          #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
                                           PathForbidden)
         end,
 
@@ -1619,7 +1619,7 @@ verify_atom_naming_convention(Config) ->
         elvis_core_apply_rule(Config,
                               elvis_style,
                               atom_naming_convention,
-                              #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
+                              #{regex => DefaultRegex,
                                 forbidden_regex => "[0-9]",
                                 forbidden_enclosed_regex => same},
                               PathForbidden).

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1596,12 +1596,32 @@ verify_atom_naming_convention(Config) ->
 
     % forbidden
     PathForbidden = "forbidden_atom_naming_convention." ++ Ext,
+    _ = case Group of
+            beam_files -> % 'or_THIS' getting stripped of enclosing '
+                [_, _, _, _] =
+                    elvis_core_apply_rule(Config,
+                                          elvis_style,
+                                          atom_naming_convention,
+                                          #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
+                                            forbidden_regex => "[0-9]"},
+                                          PathForbidden);
+            erl_files ->
+                [_, _, _] =
+                    elvis_core_apply_rule(Config,
+                                          elvis_style,
+                                          atom_naming_convention,
+                                          #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
+                                            forbidden_regex => "[0-9]"},
+                                          PathForbidden)
+        end,
+
     [_, _, _, _] =
         elvis_core_apply_rule(Config,
                               elvis_style,
                               atom_naming_convention,
                               #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
-                                forbidden_regex => "[0-9]"},
+                                forbidden_regex => "[0-9]",
+                                forbidden_enclosed_regex => "[0-9]"},
                               PathForbidden).
 
 -spec verify_no_init_lists(config()) -> any().

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -184,7 +184,16 @@ verify_function_naming_convention(Config) ->
                               elvis_style,
                               function_naming_convention,
                               RuleConfig4,
-                              PathIgnored).
+                              PathIgnored),
+
+    % forbidden
+    PathForbidden = "forbidden_function_naming_convention." ++ Ext,
+    [_, _, _] =
+        elvis_core_apply_rule(Config,
+                              elvis_style,
+                              function_naming_convention,
+                              #{regex => "^[a-z](_?[a-z0-9]+)*$", forbidden_regex => "[0-9]"},
+                              PathForbidden).
 
 -spec verify_variable_naming_convention(config()) -> any().
 verify_variable_naming_convention(Config) ->
@@ -210,7 +219,16 @@ verify_variable_naming_convention(Config) ->
                               elvis_style,
                               variable_naming_convention,
                               RuleConfig,
-                              PathFail).
+                              PathFail),
+
+    % forbidden
+    PathForbidden = "forbidden_variable_naming_convention." ++ Ext,
+    [_, _, _, _, _, _, _, _] =
+        elvis_core_apply_rule(Config,
+                              elvis_style,
+                              variable_naming_convention,
+                              #{regex => "^_?([A-Z][0-9a-zA-Z]*)$", forbidden_regex => "[0-9]"},
+                              PathForbidden).
 
 -spec verify_consistent_variable_casing(config()) -> any().
 verify_consistent_variable_casing(Config) ->
@@ -694,7 +712,17 @@ verify_module_naming_convention(Config) ->
                               elvis_style,
                               module_naming_convention,
                               RuleConfigIgnore,
-                              PathFail).
+                              PathFail),
+
+    % forbidden
+    PathForbidden = "forbidden_module_naming_convention_12." ++ Ext,
+    [_] =
+        elvis_core_apply_rule(Config,
+                              elvis_style,
+                              module_naming_convention,
+                              #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
+                                forbidden_regex => "[0-9]"},
+                              PathForbidden).
 
 -spec verify_state_record_and_type(config()) -> any().
 verify_state_record_and_type(Config) ->
@@ -1564,7 +1592,17 @@ verify_atom_naming_convention(Config) ->
                                           #{regex => KeepRegex,
                                             enclosed_atoms => "^([\\\\][\-a-z0-9A-Z_' \\\\]*)$"},
                                           FailPath)
-        end.
+        end,
+
+    % forbidden
+    PathForbidden = "forbidden_atom_naming_convention." ++ Ext,
+    [_, _, _, _] =
+        elvis_core_apply_rule(Config,
+                              elvis_style,
+                              atom_naming_convention,
+                              #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
+                                forbidden_regex => "[0-9]"},
+                              PathForbidden).
 
 -spec verify_no_init_lists(config()) -> any().
 verify_no_init_lists(Config) ->


### PR DESCRIPTION
# Description

I added the `forbidden_regex' to all "naming_convention" rules.
I made tests for a simple case about making numbers forbidden.

I can't decide in these situations that making a "case in case" is a good implementation. I feel that moving these into another function is not much cleaner, and maybe reading is more frustrating if you need to look into another function just for another case. What do you think about it?

Closes #151.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
