### PR TITLE
change(atom_naming_convention): do not apply to function names

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2048,12 +2048,7 @@ check_parent_remote(Zipper) ->
             false;
         ParentZipper ->
             Parent = zipper:node(ParentZipper),
-            case ktn_code:type(Parent) of
-                remote ->
-                    true;
-                _ ->
-                    false
-            end
+            remote == ktn_code:type(Parent)
     end.
 
 %% State record in OTP module

--- a/test/examples/atom_naming_convention_utils.erl
+++ b/test/examples/atom_naming_convention_utils.erl
@@ -1,0 +1,5 @@
+-module(atom_naming_convention_utils).
+
+-export([thisIsIgnored/0]).
+
+thisIsIgnored() -> ok.

--- a/test/examples/pass_atom_naming_convention.erl
+++ b/test/examples/pass_atom_naming_convention.erl
@@ -11,4 +11,5 @@ for_test() ->
     non200, % valid, even without underscores
     valid_200even_if_numb3rs_appear_between_letters,
     blahblah_SUITE,
-    x.
+    x,
+    atom_naming_convention_utils:thisIsIgnored().


### PR DESCRIPTION
# Description

I just added a check to filter out the atom nodes with a parent with type `remote`.
I should add some other types as well.

Closes #204.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
