### PR TITLE
Add `no_whitespace` to the `line_length` options

### DIFF
--- a/doc_rules/elvis_text_style/line_length.md
+++ b/doc_rules/elvis_text_style/line_length.md
@@ -13,11 +13,15 @@ No line should be longer than a given limit. Comments can be skipped.
   - `any` means _don't emit a warning if the part of the line that goes over `Limit` belongs to a
   comment_
   - `whole_line` means _don't emit a warning if the line that goes over `Limit` is __just__ a comment_
+- `no_whitespace :: boolean()`
+  - default: `true`, means _emit a warning when there is a whitespace beyond the configured `Limit`_.
+    When `false`, allows include items such as long URLs without being forced to break them in the middle
 
 ## Example
 
 ```erlang
 {elvis_text_style, line_length, #{ limit => 100
                                  , skip_comments => false
+                                 , no_whitespace => true
                                  }}
 ```

--- a/test/examples/fail_line_length.erl
+++ b/test/examples/fail_line_length.erl
@@ -10,7 +10,7 @@
          function_7/0
         ]).
 
-% Single line comment over 100 characters!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+% Single line comment with a URL https://github.com/inaka/elvis_core/blob/main/doc_rules/elvis_text_style/line_length.md
 function_1() ->
     io:format("Hello").
 

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -279,7 +279,17 @@ verify_line_length_rule(Config) ->
                               line_length,
                               #{limit => 100, skip_comments => any},
                               Path),
-    6 = length(AnyResult).
+    6 = length(AnyResult),
+
+    WhistespaceResult =
+        elvis_core_apply_rule(Config,
+                              elvis_text_style,
+                              line_length,
+                              #{limit => 100,
+                                skip_comments => false,
+                                no_whitespace => false},
+                              Path),
+    3 = length(WhistespaceResult).
 
 -spec verify_line_length_rule_latin1(config()) -> any().
 verify_line_length_rule_latin1(Config) ->
@@ -1434,7 +1444,7 @@ verify_no_successive_maps(Config) ->
                               #{ignore => [Module]},
                               Path).
 
--else.
+- else .
 
 verify_no_successive_maps(_Config) ->
     [].


### PR DESCRIPTION
# Description

This PR adds the `no_whitespace` option to the `line_length` style rule.
When `false`, allows include items such as long URLs without being forced to break them in the middle.
The default is `true`, therefore, no breaking changes.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
