### PR TITLE
add erlfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
                 -hash-${{hashFiles('rebar.lock')}}"
       - name: Format check
         if: ${{ matrix.os == 'ubuntu-24.04' && matrix.otp_vsn == '26' }}
-        run: rebar3 format --verify
+        run: rebar3 fmt --check
       - name: Run test
         run: rebar3 test
       - name: Run elvis on elvis

--- a/config/elvis-test-custom-ruleset.config
+++ b/config/elvis-test-custom-ruleset.config
@@ -1,6 +1,12 @@
-[{elvis,
-  [{rulesets, #{project => [{elvis_text_style, no_tabs}]}},
-   {config,
-    [#{dirs => ["."],
-       filter => "*.erl",
-       ruleset => project}]}]}].
+[
+    {elvis, [
+        {rulesets, #{project => [{elvis_text_style, no_tabs}]}},
+        {config, [
+            #{
+                dirs => ["."],
+                filter => "*.erl",
+                ruleset => project
+            }
+        ]}
+    ]}
+].

--- a/config/elvis-test-hrl-files.config
+++ b/config/elvis-test-hrl-files.config
@@ -1,5 +1,11 @@
-[{elvis,
-  [{config,
-    [#{dirs => ["../../_build/test/lib/elvis_core/test/examples/"],
-       filter => "test-*.hrl",
-       ruleset => hrl_files}]}]}].
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples/"],
+                filter => "test-*.hrl",
+                ruleset => hrl_files
+            }
+        ]}
+    ]}
+].

--- a/config/elvis-test-pa.config
+++ b/config/elvis-test-pa.config
@@ -1,5 +1,11 @@
-[{elvis,
-  [{config,
-    [#{dirs => ["../../test/examples"],
-       filter => "user_defined_rules.erl",
-       rules => [{user_defined_rules, rule}]}]}]}].
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["../../test/examples"],
+                filter => "user_defined_rules.erl",
+                rules => [{user_defined_rules, rule}]
+            }
+        ]}
+    ]}
+].

--- a/config/elvis-test-unknown-ruleset.config
+++ b/config/elvis-test-unknown-ruleset.config
@@ -1,5 +1,11 @@
-[{elvis,
-  [{config,
-    [#{dirs => ["."],
-       filter => "*.erl",
-       ruleset => project}]}]}].
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["."],
+                filter => "*.erl",
+                ruleset => project
+            }
+        ]}
+    ]}
+].

--- a/config/elvis-test.config
+++ b/config/elvis-test.config
@@ -1,51 +1,73 @@
-[{elvis,
-  [{config,
-    [#{dirs => ["../../src"],
-       filter => "*.erl",
-       rules =>
-           [{elvis_text_style, line_length, #{limit => 80, skip_comments => false}},
-            {elvis_text_style, no_tabs},
-            {elvis_style, macro_names},
-            {elvis_style, macro_module_names},
-            {elvis_style, operator_spaces, #{rules => [{right, ","}, {right, "++"}, {left, "++"}]}},
-            {elvis_style, nesting_level, #{level => 3}},
-            {elvis_style, god_modules, #{limit => 25}},
-            {elvis_style, no_if_expression},
-            {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
-            {elvis_style, used_ignored_variable},
-            {elvis_style, no_behavior_info},
-            {elvis_style,
-             module_naming_convention,
-             #{regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$", ignore => []}},
-            {elvis_style, state_record_and_type},
-            {elvis_style, no_spec_with_records}],
-       ruleset => erl_files},
-     #{dirs => ["../../_build/test/lib/elvis_core/ebin"],
-       filter => "*.beam",
-       rules =>
-           [{elvis_text_style, line_length, #{limit => 80, skip_comments => false}},
-            {elvis_text_style, no_tabs},
-            {elvis_style, macro_names},
-            {elvis_style, macro_module_names},
-            {elvis_style, operator_spaces, #{rules => [{right, ","}, {right, "++"}, {left, "++"}]}},
-            {elvis_style, nesting_level, #{level => 3}},
-            {elvis_style, god_modules, #{limit => 25}},
-            {elvis_style, no_if_expression},
-            {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
-            {elvis_style, used_ignored_variable},
-            {elvis_style, no_behavior_info},
-            {elvis_style,
-             module_naming_convention,
-             #{regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$", ignore => []}},
-            {elvis_style, state_record_and_type},
-            {elvis_style, no_spec_with_records}],
-       ruleset => beam_files},
-     #{dirs => ["."],
-       filter => "rebar.config",
-       rules =>
-           [{elvis_project, no_branch_deps, #{ignore => []}},
-            {elvis_project, protocol_for_deps, #{ignore => []}}],
-       ruleset => rebar_config},
-     #{dirs => ["."],
-       filter => "elvis.config",
-       rules => [{elvis_project, old_configuration_format}]}]}]}].
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["../../src"],
+                filter => "*.erl",
+                rules =>
+                    [
+                        {elvis_text_style, line_length, #{limit => 80, skip_comments => false}},
+                        {elvis_text_style, no_tabs},
+                        {elvis_style, macro_names},
+                        {elvis_style, macro_module_names},
+                        {elvis_style, operator_spaces, #{
+                            rules => [{right, ","}, {right, "++"}, {left, "++"}]
+                        }},
+                        {elvis_style, nesting_level, #{level => 3}},
+                        {elvis_style, god_modules, #{limit => 25}},
+                        {elvis_style, no_if_expression},
+                        {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
+                        {elvis_style, used_ignored_variable},
+                        {elvis_style, no_behavior_info},
+                        {elvis_style, module_naming_convention, #{
+                            regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$", ignore => []
+                        }},
+                        {elvis_style, state_record_and_type},
+                        {elvis_style, no_spec_with_records}
+                    ],
+                ruleset => erl_files
+            },
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/ebin"],
+                filter => "*.beam",
+                rules =>
+                    [
+                        {elvis_text_style, line_length, #{limit => 80, skip_comments => false}},
+                        {elvis_text_style, no_tabs},
+                        {elvis_style, macro_names},
+                        {elvis_style, macro_module_names},
+                        {elvis_style, operator_spaces, #{
+                            rules => [{right, ","}, {right, "++"}, {left, "++"}]
+                        }},
+                        {elvis_style, nesting_level, #{level => 3}},
+                        {elvis_style, god_modules, #{limit => 25}},
+                        {elvis_style, no_if_expression},
+                        {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
+                        {elvis_style, used_ignored_variable},
+                        {elvis_style, no_behavior_info},
+                        {elvis_style, module_naming_convention, #{
+                            regex => "^([a-z][a-z0-9]*_?)*(_SUITE)?$", ignore => []
+                        }},
+                        {elvis_style, state_record_and_type},
+                        {elvis_style, no_spec_with_records}
+                    ],
+                ruleset => beam_files
+            },
+            #{
+                dirs => ["."],
+                filter => "rebar.config",
+                rules =>
+                    [
+                        {elvis_project, no_branch_deps, #{ignore => []}},
+                        {elvis_project, protocol_for_deps, #{ignore => []}}
+                    ],
+                ruleset => rebar_config
+            },
+            #{
+                dirs => ["."],
+                filter => "elvis.config",
+                rules => [{elvis_project, old_configuration_format}]
+            }
+        ]}
+    ]}
+].

--- a/config/elvis-umbrella.config
+++ b/config/elvis-umbrella.config
@@ -1,9 +1,17 @@
-[{elvis,
-  [{config,
-    [#{dirs =>
-           ["../../_build/test/lib/elvis_core/test/dirs/src/**",
-            "../../_build/test/lib/elvis_core/test/dirs/test/**",
-            "../../_build/test/lib/elvis_core/test/dirs/apps/**/src",
-            "../../_build/test/lib/elvis_core/test/dirs/apps/**/test"],
-       filter => "*.erl",
-       ruleset => erl_files}]}]}].
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs =>
+                    [
+                        "../../_build/test/lib/elvis_core/test/dirs/src/**",
+                        "../../_build/test/lib/elvis_core/test/dirs/test/**",
+                        "../../_build/test/lib/elvis_core/test/dirs/apps/**/src",
+                        "../../_build/test/lib/elvis_core/test/dirs/apps/**/test"
+                    ],
+                filter => "*.erl",
+                ruleset => erl_files
+            }
+        ]}
+    ]}
+].

--- a/config/elvis.config
+++ b/config/elvis.config
@@ -1,20 +1,36 @@
-[{elvis,
-  [{config,
-    [#{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-       filter => "*.erl",
-       ruleset => erl_files},
-     #{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-       filter => "*.hrl",
-       ruleset => hrl_files},
-     #{dirs => ["../../_build/test/lib/elvis_core/test/non_compilable_examples"],
-       filter => "*.erl",
-       ruleset => erl_files},
-     #{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-       filter => "*.beam",
-       ruleset => beam_files},
-     #{dirs => ["."],
-       filter => "rebar.config",
-       ruleset => rebar_config},
-     #{dirs => ["."],
-       filter => "elvis.config",
-       ruleset => elvis_config}]}]}].
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+                filter => "*.erl",
+                ruleset => erl_files
+            },
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+                filter => "*.hrl",
+                ruleset => hrl_files
+            },
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/non_compilable_examples"],
+                filter => "*.erl",
+                ruleset => erl_files
+            },
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+                filter => "*.beam",
+                ruleset => beam_files
+            },
+            #{
+                dirs => ["."],
+                filter => "rebar.config",
+                ruleset => rebar_config
+            },
+            #{
+                dirs => ["."],
+                filter => "elvis.config",
+                ruleset => elvis_config
+            }
+        ]}
+    ]}
+].

--- a/config/old/elvis-test-rule-config-list.config
+++ b/config/old/elvis-test-rule-config-list.config
@@ -1,28 +1,44 @@
-[{elvis,
-  [{config,
-    [#{dirs => ["test/examples"],
-       filter => "*.erl",
-       rules =>
-           [{elvis_text_style, line_length, [80]},
-            {elvis_text_style, no_tabs, []},
-            {elvis_style, macro_names, []},
-            {elvis_style, macro_module_names, []},
-            {elvis_style, operator_spaces, [{right, ","}, {right, "++"}, {left, "++"}]},
-            {elvis_style, nesting_level, [3]},
-            {elvis_style, god_modules, [25]},
-            {elvis_style, no_if_expression, []},
-            {elvis_style, invalid_dynamic_call, [elvis]},
-            {elvis_style, used_ignored_variable, []},
-            {elvis_style, no_behavior_info, []},
-            {elvis_style, module_naming_convention, ["^([a-z][a-z0-9]*_?)*(_SUITE)?$", []]},
-            {elvis_style, state_record_and_type, []},
-            {elvis_style, no_spec_with_records, []}],
-       ruleset => erl_files},
-     #{dirs => ["."],
-       filter => "rebar.config",
-       rules => [{elvis_project, no_branch_deps, []}, {elvis_project, protocol_for_deps, []}],
-       ruleset => rebar_config},
-     #{dirs => ["."],
-       filter => "elvis.config",
-       rules => [{elvis_project, old_configuration_format, []}],
-       ruleset => elvis_config}]}]}].
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["test/examples"],
+                filter => "*.erl",
+                rules =>
+                    [
+                        {elvis_text_style, line_length, [80]},
+                        {elvis_text_style, no_tabs, []},
+                        {elvis_style, macro_names, []},
+                        {elvis_style, macro_module_names, []},
+                        {elvis_style, operator_spaces, [{right, ","}, {right, "++"}, {left, "++"}]},
+                        {elvis_style, nesting_level, [3]},
+                        {elvis_style, god_modules, [25]},
+                        {elvis_style, no_if_expression, []},
+                        {elvis_style, invalid_dynamic_call, [elvis]},
+                        {elvis_style, used_ignored_variable, []},
+                        {elvis_style, no_behavior_info, []},
+                        {elvis_style, module_naming_convention, [
+                            "^([a-z][a-z0-9]*_?)*(_SUITE)?$", []
+                        ]},
+                        {elvis_style, state_record_and_type, []},
+                        {elvis_style, no_spec_with_records, []}
+                    ],
+                ruleset => erl_files
+            },
+            #{
+                dirs => ["."],
+                filter => "rebar.config",
+                rules => [
+                    {elvis_project, no_branch_deps, []}, {elvis_project, protocol_for_deps, []}
+                ],
+                ruleset => rebar_config
+            },
+            #{
+                dirs => ["."],
+                filter => "elvis.config",
+                rules => [{elvis_project, old_configuration_format, []}],
+                ruleset => elvis_config
+            }
+        ]}
+    ]}
+].

--- a/config/old/elvis-test.config
+++ b/config/old/elvis-test.config
@@ -1,19 +1,25 @@
-[{elvis,
-  [{config,
-    #{src_dirs => ["src"],
-      rules =>
-          [{elvis_text_style, line_length, [80]},
-           {elvis_text_style, no_tabs, []},
-           {elvis_style, macro_names, []},
-           {elvis_style, macro_module_names, []},
-           {elvis_style, operator_spaces, [{right, ","}, {right, "++"}, {left, "++"}]},
-           {elvis_style, nesting_level, [3]},
-           {elvis_style, god_modules, [25]},
-           {elvis_style, no_if_expression, []},
-           {elvis_style, invalid_dynamic_call, [elvis]},
-           {elvis_style, used_ignored_variable, []},
-           {elvis_style, no_behavior_info, []},
-           {elvis_style, module_naming_convention, ["^([a-z][a-z0-9]*_?)*(_SUITE)?$", []]},
-           {elvis_style, state_record_and_type, []},
-           {elvis_style, no_spec_with_records, []}],
-      ruleset => erl_files}}]}].
+[
+    {elvis, [
+        {config, #{
+            src_dirs => ["src"],
+            rules =>
+                [
+                    {elvis_text_style, line_length, [80]},
+                    {elvis_text_style, no_tabs, []},
+                    {elvis_style, macro_names, []},
+                    {elvis_style, macro_module_names, []},
+                    {elvis_style, operator_spaces, [{right, ","}, {right, "++"}, {left, "++"}]},
+                    {elvis_style, nesting_level, [3]},
+                    {elvis_style, god_modules, [25]},
+                    {elvis_style, no_if_expression, []},
+                    {elvis_style, invalid_dynamic_call, [elvis]},
+                    {elvis_style, used_ignored_variable, []},
+                    {elvis_style, no_behavior_info, []},
+                    {elvis_style, module_naming_convention, ["^([a-z][a-z0-9]*_?)*(_SUITE)?$", []]},
+                    {elvis_style, state_record_and_type, []},
+                    {elvis_style, no_spec_with_records, []}
+                ],
+            ruleset => erl_files
+        }}
+    ]}
+].

--- a/config/old/elvis.config
+++ b/config/old/elvis.config
@@ -1,19 +1,25 @@
-[{elvis,
-  [{config,
-    #{src_dirs => ["src"],
-      rules =>
-          [{elvis_text_style, line_length, [80]},
-           {elvis_text_style, no_tabs, []},
-           {elvis_style, macro_names, []},
-           {elvis_style, macro_module_names, []},
-           {elvis_style, operator_spaces, [{right, ","}, {right, "++"}, {left, "++"}]},
-           {elvis_style, nesting_level, [3]},
-           {elvis_style, god_modules, [25]},
-           {elvis_style, no_if_expression, []},
-           {elvis_style, invalid_dynamic_call, [elvis]},
-           {elvis_style, used_ignored_variable, []},
-           {elvis_style, no_behavior_info, []},
-           {elvis_style, module_naming_convention, ["^([a-z][a-z0-9]*_?)*(_SUITE)?$", []]},
-           {elvis_style, state_record_and_type, []},
-           {elvis_style, no_spec_with_records, []}],
-      ruleset => erl_files}}]}].
+[
+    {elvis, [
+        {config, #{
+            src_dirs => ["src"],
+            rules =>
+                [
+                    {elvis_text_style, line_length, [80]},
+                    {elvis_text_style, no_tabs, []},
+                    {elvis_style, macro_names, []},
+                    {elvis_style, macro_module_names, []},
+                    {elvis_style, operator_spaces, [{right, ","}, {right, "++"}, {left, "++"}]},
+                    {elvis_style, nesting_level, [3]},
+                    {elvis_style, god_modules, [25]},
+                    {elvis_style, no_if_expression, []},
+                    {elvis_style, invalid_dynamic_call, [elvis]},
+                    {elvis_style, used_ignored_variable, []},
+                    {elvis_style, no_behavior_info, []},
+                    {elvis_style, module_naming_convention, ["^([a-z][a-z0-9]*_?)*(_SUITE)?$", []]},
+                    {elvis_style, state_record_and_type, []},
+                    {elvis_style, no_spec_with_records, []}
+                ],
+            ruleset => erl_files
+        }}
+    ]}
+].

--- a/config/rebar.config
+++ b/config/rebar.config
@@ -1,12 +1,17 @@
-{deps,
- [{lager, "2.1.1"},
-  {meck, "0.8.2", {git, "https://github.com/basho/meck.git", {tag, "0.8.2"}}},
-  {jiffy, {git, "https://github.com/davisp/jiffy.git"}},
-  recon]}.
+{deps, [
+    {lager, "2.1.1"},
+    {meck, "0.8.2", {git, "https://github.com/basho/meck.git", {tag, "0.8.2"}}},
+    {jiffy, {git, "https://github.com/davisp/jiffy.git"}},
+    recon
+]}.
 
-{elvis,
- [{config,
-   [#{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-      filter => "*.erl",
-      rules => [{elvis_text_style, line_length, #{limit => 135}}]}]},
-  {output_format, plain}]}.
+{elvis, [
+    {config, [
+        #{
+            dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+            filter => "*.erl",
+            rules => [{elvis_text_style, line_length, #{limit => 135}}]
+        }
+    ]},
+    {output_format, plain}
+]}.

--- a/config/test.config
+++ b/config/test.config
@@ -1,35 +1,57 @@
-[{elvis_core,
-  [{config,
-    [#{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-       filter => "*.erl",
-       rules =>
-           [{elvis_text_style, line_length, #{limit => 80, skip_comments => false}},
-            {elvis_style, nesting_level, #{level => 3}},
-            {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
-            {elvis_style, no_macros},
-            {elvis_style, param_pattern_matching, #{side => right}}],
-       ruleset => erl_files},
-     #{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-       filter => "*.hrl",
-       rules => [],
-       ruleset => hrl_files},
-     #{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-       filter => "*.beam",
-       rules =>
-           [{elvis_text_style, line_length, #{limit => 80, skip_comments => false}},
-            {elvis_style, nesting_level, #{level => 3}},
-            {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
-            {elvis_style, no_macros}],
-       ruleset => beam_files},
-     #{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-       filter => "rebar.config",
-       ruleset => rebar_config},
-     #{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-       filter => "elvis.config",
-       ruleset => elvis_config},
-     #{dirs =>
-           ["../../_build/test/lib/elvis_core/test/dirs/apps/app1",
-            "../../_build/test/lib/elvis_core/test/dirs/apps/app2"],
-       filter => ".gitignore",
-       ruleset => gitignore}]},
-   {output_format, plain}]}].
+[
+    {elvis_core, [
+        {config, [
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+                filter => "*.erl",
+                rules =>
+                    [
+                        {elvis_text_style, line_length, #{limit => 80, skip_comments => false}},
+                        {elvis_style, nesting_level, #{level => 3}},
+                        {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
+                        {elvis_style, no_macros},
+                        {elvis_style, param_pattern_matching, #{side => right}}
+                    ],
+                ruleset => erl_files
+            },
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+                filter => "*.hrl",
+                rules => [],
+                ruleset => hrl_files
+            },
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+                filter => "*.beam",
+                rules =>
+                    [
+                        {elvis_text_style, line_length, #{limit => 80, skip_comments => false}},
+                        {elvis_style, nesting_level, #{level => 3}},
+                        {elvis_style, invalid_dynamic_call, #{ignore => [elvis]}},
+                        {elvis_style, no_macros}
+                    ],
+                ruleset => beam_files
+            },
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+                filter => "rebar.config",
+                ruleset => rebar_config
+            },
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+                filter => "elvis.config",
+                ruleset => elvis_config
+            },
+            #{
+                dirs =>
+                    [
+                        "../../_build/test/lib/elvis_core/test/dirs/apps/app1",
+                        "../../_build/test/lib/elvis_core/test/dirs/apps/app2"
+                    ],
+                filter => ".gitignore",
+                ruleset => gitignore
+            }
+        ]},
+        {output_format, plain}
+    ]}
+].

--- a/config/test.pass.config
+++ b/config/test.pass.config
@@ -1,7 +1,13 @@
 % this check passes
-[{elvis,
-  [{config,
-    [#{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-       filter => "*.erl",
-       rules => [{elvis_text_style, line_length, #{limit => 800}}]}]},
-   {output_format, plain}]}].
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+                filter => "*.erl",
+                rules => [{elvis_text_style, line_length, #{limit => 800}}]
+            }
+        ]},
+        {output_format, plain}
+    ]}
+].

--- a/elvis.config
+++ b/elvis.config
@@ -1,27 +1,43 @@
-[{elvis,
-  [{config,
-    [#{dirs => ["src"],
-       filter => "*.erl",
-       rules =>
-           [{elvis_style, invalid_dynamic_call, #{ignore => [elvis_core]}},
-            {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
-            {elvis_style, no_debug_call, #{ignore => [elvis_result, elvis_utils]}},
-            {elvis_style, god_modules, #{ignore => [elvis_style]}},
-            {elvis_style, no_throw, disable}],
-       ruleset => erl_files},
-     #{dirs => ["_build/default/lib/elvis_core/ebin"],
-       filter => "*.beam",
-       rules =>
-           [{elvis_style, invalid_dynamic_call, #{ignore => [elvis_core]}},
-            {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
-            {elvis_style, no_debug_call, #{ignore => [elvis_result, elvis_utils]}},
-            {elvis_style, atom_naming_convention, #{ignore => [elvis_task]}},
-            {elvis_style, god_modules, #{ignore => [elvis_style]}},
-            {elvis_style, no_throw, disable}],
-       ruleset => beam_files},
-     #{dirs => ["."],
-       filter => "rebar.config",
-       ruleset => rebar_config},
-     #{dirs => ["."],
-       filter => "elvis.config",
-       ruleset => elvis_config}]}]}].
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["src"],
+                filter => "*.erl",
+                rules =>
+                    [
+                        {elvis_style, invalid_dynamic_call, #{ignore => [elvis_core]}},
+                        {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+                        {elvis_style, no_debug_call, #{ignore => [elvis_result, elvis_utils]}},
+                        {elvis_style, god_modules, #{ignore => [elvis_style]}},
+                        {elvis_style, no_throw, disable}
+                    ],
+                ruleset => erl_files
+            },
+            #{
+                dirs => ["_build/default/lib/elvis_core/ebin"],
+                filter => "*.beam",
+                rules =>
+                    [
+                        {elvis_style, invalid_dynamic_call, #{ignore => [elvis_core]}},
+                        {elvis_style, dont_repeat_yourself, #{min_complexity => 20}},
+                        {elvis_style, no_debug_call, #{ignore => [elvis_result, elvis_utils]}},
+                        {elvis_style, atom_naming_convention, #{ignore => [elvis_task]}},
+                        {elvis_style, god_modules, #{ignore => [elvis_style]}},
+                        {elvis_style, no_throw, disable}
+                    ],
+                ruleset => beam_files
+            },
+            #{
+                dirs => ["."],
+                filter => "rebar.config",
+                ruleset => rebar_config
+            },
+            #{
+                dirs => ["."],
+                filter => "elvis.config",
+                ruleset => elvis_config
+            }
+        ]}
+    ]}
+].

--- a/rebar.config
+++ b/rebar.config
@@ -1,21 +1,22 @@
 %% == Compiler and Profiles ==
 
-{erl_opts,
- [warn_unused_import, warn_export_vars, warnings_as_errors, verbose, report, debug_info]}.
+{erl_opts, [warn_unused_import, warn_export_vars, warnings_as_errors, verbose, report, debug_info]}.
 
 {minimum_otp_vsn, "25"}.
 
-{profiles,
- [{test,
-   [{extra_src_dirs, ["test/examples"]},
-    {deps, [{meck, "0.9.2"}]},
-    {erl_opts, [nowarn_missing_spec, nowarn_export_all]},
-    {dialyzer, [{warnings, [no_return, error_handling]}, {plt_extra_apps, [common_test]}]},
-    {ct_opts, [{sys_config, ["./config/test.config"]}, {logdir, "./logs"}, {verbose, true}]},
-    {cover_enabled, true},
-    {cover_opts, [verbose]}]}]}.
+{profiles, [
+    {test, [
+        {extra_src_dirs, ["test/examples"]},
+        {deps, [{meck, "0.9.2"}]},
+        {erl_opts, [nowarn_missing_spec, nowarn_export_all]},
+        {dialyzer, [{warnings, [no_return, error_handling]}, {plt_extra_apps, [common_test]}]},
+        {ct_opts, [{sys_config, ["./config/test.config"]}, {logdir, "./logs"}, {verbose, true}]},
+        {cover_enabled, true},
+        {cover_opts, [verbose]}
+    ]}
+]}.
 
-{alias, [{test, [compile, format, hank, xref, dialyzer, ct, cover, ex_doc]}]}.
+{alias, [{test, [compile, fmt, hank, xref, dialyzer, ct, cover, ex_doc]}]}.
 
 {shell, [{config, "config/test.config"}]}.
 
@@ -23,27 +24,30 @@
 
 {deps, [{zipper, "1.1.0"}, {katana_code, "~> 2.1.0"}]}.
 
-{project_plugins,
- [{rebar3_hank, "~> 1.4.0"},
-  {rebar3_hex, "~> 7.0.7"},
-  {rebar3_format, "~> 1.3.0"},
-  {rebar3_ex_doc, "~> 0.2.20"}]}.
+{project_plugins, [
+    {rebar3_hank, "~> 1.4.0"},
+    {rebar3_hex, "~> 7.0.7"},
+    erlfmt,
+    {rebar3_ex_doc, "~> 0.2.20"}
+]}.
 
 %% == Documentation ==
 
-{ex_doc,
- [{source_url, <<"https://github.com/inaka/elvis_core">>},
-  {extras, [<<"README.md">>, <<"LICENSE">>]},
-  {main, <<"README.md">>},
-  {prefix_ref_vsn_with_v, false}]}.
+{ex_doc, [
+    {source_url, <<"https://github.com/inaka/elvis_core">>},
+    {extras, [<<"README.md">>, <<"LICENSE">>]},
+    {main, <<"README.md">>},
+    {prefix_ref_vsn_with_v, false}
+]}.
 
 {hex, [{doc, #{provider => ex_doc}}]}.
 
 %% == Format ==
 
-{format,
- [{files,
-   ["config/**/*.config", "src/**/*.app.src", "src/**/*.erl", "test/*.erl", "*.config"]}]}.
+{erlfmt, [
+    write,
+    {files, ["config/**/*.config", "src/**/*.app.src", "src/**/*.erl", "test/*.erl", "*.config"]}
+]}.
 
 %% == Hank ==
 
@@ -53,7 +57,6 @@
 
 {dialyzer, [{warnings, [no_return, unmatched_returns, error_handling, unknown]}]}.
 
-{xref_checks,
- [undefined_function_calls, deprecated_function_calls, deprecated_functions]}.
+{xref_checks, [undefined_function_calls, deprecated_function_calls, deprecated_functions]}.
 
 {xref_extra_paths, ["test/**"]}.

--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,7 @@
 {project_plugins, [
     {rebar3_hank, "~> 1.4.0"},
     {rebar3_hex, "~> 7.0.7"},
-    erlfmt,
+    {erlfmt, "~> v1.6.0"},
     {rebar3_ex_doc, "~> 0.2.20"}
 ]}.
 

--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -3,8 +3,14 @@
 %% General
 -export([find/2, find/3, find_by_location/2, find_token/2, code_zipper/1, code_zipper/2]).
 %% Specific
--export([past_nesting_limit/2, exported_functions/1, exported_types/1, function_names/1,
-         module_name/1, print_node/1, print_node/2]).
+-export([
+    past_nesting_limit/2,
+    exported_functions/1,
+    exported_types/1,
+    function_names/1,
+    module_name/1,
+    print_node/1, print_node/2
+]).
 
 -export_type([find_options/0]).
 
@@ -18,7 +24,7 @@
 %%      the options map.
 %% @end
 -spec find(fun((zipper:zipper(_)) -> boolean()), ktn_code:tree_node()) ->
-              [ktn_code:tree_node()].
+    [ktn_code:tree_node()].
 find(Pred, Root) ->
     find(Pred, Root, #{mode => node, traverse => content}).
 
@@ -40,7 +46,7 @@ find(Pred, Root) ->
 %% @end
 
 -spec find(fun((zipper:zipper(_)) -> boolean()), ktn_code:tree_node(), find_options()) ->
-              [ktn_code:tree_node()].
+    [ktn_code:tree_node()].
 find(Pred, Root, Opts) ->
     Mode = maps:get(mode, Opts, node),
     ZipperMode = maps:get(traverse, Opts, content),
@@ -64,7 +70,8 @@ code_zipper(Root, Mode) ->
 -spec content_zipper(ktn_code:tree_node()) -> zipper:zipper(_).
 content_zipper(Root) ->
     IsBranch =
-        fun (#{content := [_ | _]}) ->
+        fun
+            (#{content := [_ | _]}) ->
                 true;
             (_) ->
                 false
@@ -78,13 +85,16 @@ all_zipper(Root) ->
     IsBranch =
         fun(#{} = Node) -> ktn_code:content(Node) =/= [] orelse maps:is_key(node_attrs, Node) end,
     Children =
-        fun (#{content := Content, node_attrs := NodeAttrs}) ->
-                Content
-                ++ lists:flatten(
-                       maps:values(NodeAttrs));
+        fun
+            (#{content := Content, node_attrs := NodeAttrs}) ->
+                Content ++
+                    lists:flatten(
+                        maps:values(NodeAttrs)
+                    );
             (#{node_attrs := NodeAttrs}) ->
                 lists:flatten(
-                    maps:values(NodeAttrs));
+                    maps:values(NodeAttrs)
+                );
             (#{content := Content}) ->
                 Content
         end,
@@ -114,7 +124,7 @@ find(Pred, Zipper, Results, Mode) ->
     end.
 
 -spec find_by_location(ktn_code:tree_node(), {integer(), integer()}) ->
-                          not_found | {ok, ktn_code:tree_node()}.
+    not_found | {ok, ktn_code:tree_node()}.
 find_by_location(Root, Location) ->
     Fun = fun(Node) -> is_at_location(Node, Location) end,
     case find(Fun, Root, #{traverse => all}) of
@@ -146,7 +156,7 @@ find_token(Root, Location) ->
 
 %% @doc Takes a node and returns all nodes where the nesting limit is exceeded.
 -spec past_nesting_limit(ktn_code:tree_node(), integer()) ->
-                            [{ktn_code:tree_node(), integer()}].
+    [{ktn_code:tree_node(), integer()}].
 past_nesting_limit(Node, MaxLevel) ->
     ResultNodes = past_nesting_limit(Node, 1, MaxLevel),
     lists:reverse(ResultNodes).
@@ -155,9 +165,9 @@ past_nesting_limit(Node, CurrentLevel, MaxLevel) when CurrentLevel > MaxLevel ->
     [Node];
 past_nesting_limit(#{content := Content}, CurrentLevel, MaxLevel) ->
     Fun = fun(ChildNode) ->
-             Increment = level_increment(ChildNode),
-             past_nesting_limit(ChildNode, Increment + CurrentLevel, MaxLevel)
-          end,
+        Increment = level_increment(ChildNode),
+        past_nesting_limit(ChildNode, Increment + CurrentLevel, MaxLevel)
+    end,
     lists:flatmap(Fun, Content);
 past_nesting_limit(_Node, _CurrentLeve, _MaxLevel) ->
     [].
@@ -230,19 +240,22 @@ level_increment(#{type := Type}) ->
 %% @doc Returns an anonymous Fun to be flatmapped over node content, as
 %% appropriate for the exported function whose name is the argument given.
 make_extractor_fun(exported_functions) ->
-    fun (#{type := export} = Node) ->
+    fun
+        (#{type := export} = Node) ->
             ktn_code:attr(value, Node);
         (_) ->
             []
     end;
 make_extractor_fun(exported_types) ->
-    fun (#{type := export_type} = Node) ->
+    fun
+        (#{type := export_type} = Node) ->
             ktn_code:attr(value, Node);
         (_) ->
             []
     end;
 make_extractor_fun(function_names) ->
-    fun (#{type := function} = Node) ->
+    fun
+        (#{type := function} = Node) ->
             [ktn_code:attr(name, Node)];
         (_) ->
             []

--- a/src/elvis_core.app.src
+++ b/src/elvis_core.app.src
@@ -1,10 +1,10 @@
-{application,
- elvis_core,
- [{pkg_name, elvis_core},
-  {description, "Core library for the Erlang style reviewer"},
-  {vsn, git},
-  {applications, [kernel, stdlib, zipper, katana_code]},
-  {modules, [elvis_core, elvis_config, elvis_result, elvis_utils, elvis_style]},
-  {licenses, ["Apache-2.0"]},
-  {links, [{"GitHub", "https://github.com/inaka/elvis_core"}]},
-  {build_tools, ["rebar3"]}]}.
+{application, elvis_core, [
+    {pkg_name, elvis_core},
+    {description, "Core library for the Erlang style reviewer"},
+    {vsn, git},
+    {applications, [kernel, stdlib, zipper, katana_code]},
+    {modules, [elvis_core, elvis_config, elvis_result, elvis_utils, elvis_style]},
+    {licenses, ["Apache-2.0"]},
+    {links, [{"GitHub", "https://github.com/inaka/elvis_core"}]},
+    {build_tools, ["rebar3"]}
+]}.

--- a/src/elvis_gitignore.erl
+++ b/src/elvis_gitignore.erl
@@ -5,8 +5,7 @@
 -define(REQUIRED_PATTERN, "Your .gitignore file should contain pattern '~s'.").
 -define(FORBIDDEN_PATTERN, "Your .gitignore file should not contain pattern '~s'.").
 
--hank([{unnecessary_function_arguments,
-        [{required_patterns, 3}, {forbidden_patterns, 3}]}]).
+-hank([{unnecessary_function_arguments, [{required_patterns, 3}, {forbidden_patterns, 3}]}]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Default values
@@ -14,14 +13,18 @@
 
 -spec default(Rule :: atom()) -> DefaultRuleConfig :: term().
 default(required_patterns) ->
-    #{regexes =>
-          ["^.rebar3/$",
-           "^_build/$",
-           "^_checkouts/$",
-           "^doc/$",
-           "^/erl_crash.dump$",
-           "^/rebar3.crashdump$",
-           "^test/logs/$"]};
+    #{
+        regexes =>
+            [
+                "^.rebar3/$",
+                "^_build/$",
+                "^_checkouts/$",
+                "^doc/$",
+                "^/erl_crash.dump$",
+                "^/rebar3.crashdump$",
+                "^test/logs/$"
+            ]
+    };
 default(forbidden_patterns) ->
     #{regexes => ["^rebar.lock$"]}.
 
@@ -29,10 +32,12 @@ default(forbidden_patterns) ->
 %% Rules
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec required_patterns(elvis_config:config(),
-                        elvis_file:file(),
-                        elvis_style:empty_rule_config()) ->
-                           [elvis_result:item()].
+-spec required_patterns(
+    elvis_config:config(),
+    elvis_file:file(),
+    elvis_style:empty_rule_config()
+) ->
+    [elvis_result:item()].
 required_patterns(_Config, #{path := Path}, RuleConfig) ->
     Regexes = option(regexes, RuleConfig, required_patterns),
     case file:read_file(Path) of
@@ -43,10 +48,12 @@ required_patterns(_Config, #{path := Path}, RuleConfig) ->
             []
     end.
 
--spec forbidden_patterns(elvis_config:config(),
-                         elvis_file:file(),
-                         elvis_style:empty_rule_config()) ->
-                            [elvis_result:item()].
+-spec forbidden_patterns(
+    elvis_config:config(),
+    elvis_file:file(),
+    elvis_style:empty_rule_config()
+) ->
+    [elvis_result:item()].
 forbidden_patterns(_Config, #{path := Path}, RuleConfig) ->
     Regexes = option(regexes, RuleConfig, forbidden_patterns),
     case file:read_file(Path) of
@@ -88,19 +95,19 @@ check_patterns_in_lines(Lines, [Pattern | Rest], Results0, Mode) ->
 %% Internal Function Definitions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec option(OptionName, RuleConfig, Rule) -> OptionValue
-    when OptionName :: atom(),
-         RuleConfig :: elvis_config:config(),
-         Rule :: atom(),
-         OptionValue :: term().
+-spec option(OptionName, RuleConfig, Rule) -> OptionValue when
+    OptionName :: atom(),
+    RuleConfig :: elvis_config:config(),
+    Rule :: atom(),
+    OptionValue :: term().
 option(OptionName, RuleConfig, Rule) ->
     maybe_default_option(maps:get(OptionName, RuleConfig, undefined), OptionName, Rule).
 
--spec maybe_default_option(UserDefinedOptionValue, OptionName, Rule) -> OptionValue
-    when UserDefinedOptionValue :: undefined | term(),
-         OptionName :: atom(),
-         Rule :: atom(),
-         OptionValue :: term().
+-spec maybe_default_option(UserDefinedOptionValue, OptionName, Rule) -> OptionValue when
+    UserDefinedOptionValue :: undefined | term(),
+    OptionName :: atom(),
+    Rule :: atom(),
+    OptionValue :: term().
 maybe_default_option(undefined = _UserDefinedOptionValue, OptionName, Rule) ->
     maps:get(OptionName, default(Rule));
 maybe_default_option(UserDefinedOptionValue, _OptionName, _Rule) ->

--- a/src/elvis_project.erl
+++ b/src/elvis_project.erl
@@ -5,22 +5,28 @@
 -export_type([protocol_for_deps_config/0]).
 
 -define(DEP_BRANCH,
-        "Dependency '~s' uses a branch. "
-        "Please change this to a tag or specific commit.").
+    "Dependency '~s' uses a branch. "
+    "Please change this to a tag or specific commit."
+).
 -define(DEP_NO_GIT,
-        "Dependency '~s' is not using appropriate protocol, "
-        "please change this to something like '~s'").
+    "Dependency '~s' is not using appropriate protocol, "
+    "please change this to something like '~s'"
+).
 -define(OLD_CONFIG_FORMAT,
-        "The current Elvis configuration file has an outdated format. "
-        "Please check Elvis's GitHub repository to find out what the "
-        "new format is.").
+    "The current Elvis configuration file has an outdated format. "
+    "Please check Elvis's GitHub repository to find out what the "
+    "new format is."
+).
 
 % These are part of a non-declared "behaviour"
 % The reason why we don't try to handle them with different arity is
 %  that arguments are ignored in different positions (1 and 3) so that'd
 %  probably be messier than to ignore the warning
--hank([{unnecessary_function_arguments,
-        [{old_configuration_format, 3}, {no_branch_deps, 3}, {protocol_for_deps, 3}]}]).
+-hank([
+    {unnecessary_function_arguments, [
+        {old_configuration_format, 3}, {no_branch_deps, 3}, {protocol_for_deps, 3}
+    ]}
+]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Default values
@@ -40,33 +46,41 @@ default(old_configuration_format) ->
 
 -type protocol_for_deps_config() :: #{ignore => [module()], regex => string()}.
 
--spec protocol_for_deps(elvis_config:config(),
-                        elvis_file:file(),
-                        protocol_for_deps_config()) ->
-                           [elvis_result:item()].
+-spec protocol_for_deps(
+    elvis_config:config(),
+    elvis_file:file(),
+    protocol_for_deps_config()
+) ->
+    [elvis_result:item()].
 protocol_for_deps(_Config, Target, RuleConfig) ->
     IgnoreDeps = option(ignore, RuleConfig, protocol_for_deps),
     Regex = option(regex, RuleConfig, protocol_for_deps),
     Deps = get_deps(Target),
     NoHexDeps = lists:filter(fun(Dep) -> not is_hex_dep(Dep) end, Deps),
     BadDeps = lists:filter(fun(Dep) -> is_not_git_dep(Dep, Regex) end, NoHexDeps),
-    lists:flatmap(fun(Line) -> dep_to_result(Line, ?DEP_NO_GIT, {IgnoreDeps, Regex}) end,
-                  BadDeps).
+    lists:flatmap(
+        fun(Line) -> dep_to_result(Line, ?DEP_NO_GIT, {IgnoreDeps, Regex}) end,
+        BadDeps
+    ).
 
--spec no_branch_deps(elvis_config:config(),
-                     elvis_file:file(),
-                     elvis_style:empty_rule_config()) ->
-                        [elvis_result:item()].
+-spec no_branch_deps(
+    elvis_config:config(),
+    elvis_file:file(),
+    elvis_style:empty_rule_config()
+) ->
+    [elvis_result:item()].
 no_branch_deps(_Config, Target, RuleConfig) ->
     IgnoreDeps = option(ignore, RuleConfig, no_branch_deps),
     Deps = get_deps(Target),
     BadDeps = lists:filter(fun is_branch_dep/1, Deps),
     lists:flatmap(fun(Line) -> dep_to_result(Line, ?DEP_BRANCH, IgnoreDeps) end, BadDeps).
 
--spec old_configuration_format(elvis_config:config(),
-                               elvis_file:file(),
-                               elvis_style:empty_rule_config()) ->
-                                  [elvis_result:item()].
+-spec old_configuration_format(
+    elvis_config:config(),
+    elvis_file:file(),
+    elvis_style:empty_rule_config()
+) ->
+    [elvis_result:item()].
 old_configuration_format(_Config, Target, _RuleConfig) ->
     {Content, _} = elvis_file:src(Target),
     [AllConfig] = ktn_code:consult(Content),
@@ -93,7 +107,8 @@ get_deps(File) ->
     {Src, _} = elvis_file:src(File),
     Terms = ktn_code:consult(Src),
     IsDepsTerm =
-        fun ({deps, _}) ->
+        fun
+            ({deps, _}) ->
                 true;
             (_) ->
                 false
@@ -124,8 +139,9 @@ is_branch_dep(_) ->
 %% @private
 is_hex_dep(_AppName) when is_atom(_AppName) ->
     true;
-is_hex_dep({_AppName, _Vsn, {pkg, _PackageName}})
-    when is_atom(_AppName), is_list(_Vsn), is_atom(_PackageName) ->
+is_hex_dep({_AppName, _Vsn, {pkg, _PackageName}}) when
+    is_atom(_AppName), is_list(_Vsn), is_atom(_PackageName)
+->
     true;
 is_hex_dep({_AppName, {pkg, _OtherName}}) when is_atom(_AppName), is_atom(_OtherName) ->
     true;
@@ -137,12 +153,14 @@ is_hex_dep(_) ->
 %% @private
 is_not_git_dep({_AppName, {_SCM, Url, _Branch}}, Regex) ->
     nomatch == re:run(Url, Regex, []);
-is_not_git_dep({_AppName,
-                {git_subdir, Url, {BranchTagOrRefType, _BranchTagOrRef}, _SubDir}},
-               Regex)
-    when BranchTagOrRefType =:= branch;
-         BranchTagOrRefType =:= tag;
-         BranchTagOrRefType =:= ref ->
+is_not_git_dep(
+    {_AppName, {git_subdir, Url, {BranchTagOrRefType, _BranchTagOrRef}, _SubDir}},
+    Regex
+) when
+    BranchTagOrRefType =:= branch;
+    BranchTagOrRefType =:= tag;
+    BranchTagOrRefType =:= ref
+->
     nomatch == re:run(Url, Regex, []);
 %% Specific to plugin rebar_raw_resource
 is_not_git_dep({AppName, {raw, DepResourceSpecification}}, Regex) ->
@@ -154,10 +172,11 @@ is_not_git_dep({_AppName, _Vsn, {_SCM, Url}}, Regex) ->
     nomatch == re:run(Url, Regex, []);
 is_not_git_dep({_AppName, _Vsn, {_SCM, Url, _Branch}}, Regex) ->
     nomatch == re:run(Url, Regex, []);
-is_not_git_dep({_AppName, _Vsn, {_SCM, Url, {BranchTagOrRefType, _Branch}}, _Opts}, Regex)
-    when BranchTagOrRefType =:= branch;
-         BranchTagOrRefType =:= tag;
-         BranchTagOrRefType =:= ref ->
+is_not_git_dep({_AppName, _Vsn, {_SCM, Url, {BranchTagOrRefType, _Branch}}, _Opts}, Regex) when
+    BranchTagOrRefType =:= branch;
+    BranchTagOrRefType =:= tag;
+    BranchTagOrRefType =:= ref
+->
     nomatch == re:run(Url, Regex, []).
 
 %% @private
@@ -193,7 +212,8 @@ is_old_config(ElvisConfig) ->
             true;
         Config when is_list(Config) ->
             SrcDirsIsKey =
-                fun(RuleGroup) -> maps:is_key(src_dirs, RuleGroup) orelse exists_old_rule(RuleGroup)
+                fun(RuleGroup) ->
+                    maps:is_key(src_dirs, RuleGroup) orelse exists_old_rule(RuleGroup)
                 end,
             lists:filter(SrcDirsIsKey, Config) /= []
     end.
@@ -201,7 +221,8 @@ is_old_config(ElvisConfig) ->
 %% @private
 exists_old_rule(#{rules := Rules}) ->
     Filter =
-        fun ({_, _, Args}) when is_list(Args) ->
+        fun
+            ({_, _, Args}) when is_list(Args) ->
                 true;
             (_) ->
                 false
@@ -214,19 +235,19 @@ exists_old_rule(_) ->
 %% Internal Function Definitions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec option(OptionName, RuleConfig, Rule) -> OptionValue
-    when OptionName :: atom(),
-         RuleConfig :: elvis_config:config(),
-         Rule :: atom(),
-         OptionValue :: term().
+-spec option(OptionName, RuleConfig, Rule) -> OptionValue when
+    OptionName :: atom(),
+    RuleConfig :: elvis_config:config(),
+    Rule :: atom(),
+    OptionValue :: term().
 option(OptionName, RuleConfig, Rule) ->
     maybe_default_option(maps:get(OptionName, RuleConfig, undefined), OptionName, Rule).
 
--spec maybe_default_option(UserDefinedOptionValue, OptionName, Rule) -> OptionValue
-    when UserDefinedOptionValue :: undefined | term(),
-         OptionName :: atom(),
-         Rule :: atom(),
-         OptionValue :: term().
+-spec maybe_default_option(UserDefinedOptionValue, OptionName, Rule) -> OptionValue when
+    UserDefinedOptionValue :: undefined | term(),
+    OptionName :: atom(),
+    Rule :: atom(),
+    OptionValue :: term().
 maybe_default_option(undefined = _UserDefinedOptionValue, OptionName, Rule) ->
     maps:get(OptionName, default(Rule));
 maybe_default_option(UserDefinedOptionValue, _OptionName, _Rule) ->

--- a/src/elvis_result.erl
+++ b/src/elvis_result.erl
@@ -4,8 +4,15 @@
 
 %% API
 -export([new/3, new/4, status/1, clean/1, print_results/1]).
--export([get_path/1, get_rules/1, get_name/1, get_items/1, get_message/1, get_info/1,
-         get_line_num/1]).
+-export([
+    get_path/1,
+    get_rules/1,
+    get_name/1,
+    get_items/1,
+    get_message/1,
+    get_info/1,
+    get_line_num/1
+]).
 
 %% Types
 -export_type([item/0, rule/0, file/0, elvis_error/0, elvis_warn/0]).
@@ -15,13 +22,17 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 -type item() ::
-    #{message => string(),
-      info => iodata(),
-      line_num => integer()}.
+    #{
+        message => string(),
+        info => iodata(),
+        line_num => integer()
+    }.
 -type rule() ::
-    #{scope => atom(),
-      name => atom(),
-      items => [item()]}.
+    #{
+        scope => atom(),
+        name => atom(),
+        items => [item()]
+    }.
 -type file() :: #{file => string(), rules => [rule()]}.
 -type elvis_error() :: #{error_msg => string(), info => list()}.
 -type elvis_warn() :: #{warn_msg => string(), info => list()}.
@@ -32,17 +43,20 @@
 
 %% New
 
--spec new(item, string(), [term()]) -> item();
-         (rule, {atom(), atom()}, [item()]) -> rule();
-         (file, elvis_file:file(), [elvis_error() | rule()]) -> file();
-         (error, string(), string()) -> elvis_error();
-         (warn, string(), string()) -> elvis_warn().
+-spec new
+    (item, string(), [term()]) -> item();
+    (rule, {atom(), atom()}, [item()]) -> rule();
+    (file, elvis_file:file(), [elvis_error() | rule()]) -> file();
+    (error, string(), string()) -> elvis_error();
+    (warn, string(), string()) -> elvis_warn().
 new(item, Msg, Info) ->
     new(item, Msg, Info, 0);
 new(rule, {Scope, Name}, Results) ->
-    #{scope => Scope,
-      name => Name,
-      items => Results};
+    #{
+        scope => Scope,
+        name => Name,
+        items => Results
+    };
 new(file, #{path := Path}, Rules) ->
     #{file => Path, rules => Rules};
 new(error, Msg, Info) ->
@@ -52,9 +66,11 @@ new(warn, Msg, Info) ->
 
 -spec new(item, string(), [term()], integer()) -> item().
 new(item, Msg, Info, LineNum) ->
-    #{message => Msg,
-      info => Info,
-      line_num => LineNum}.
+    #{
+        message => Msg,
+        info => Info,
+        line_num => LineNum
+    }.
 
 %% Getters
 
@@ -122,19 +138,27 @@ print_rules(_Format, _File, []) ->
     ok;
 print_rules(Format, File, [#{items := []} | Items]) ->
     print_rules(Format, File, Items);
-print_rules(Format,
-            File,
-            [#{scope := Scope,
-               items := Items,
-               name := Name}
-             | EItems]) ->
+print_rules(
+    Format,
+    File,
+    [
+        #{
+            scope := Scope,
+            items := Items,
+            name := Name
+        }
+        | EItems
+    ]
+) ->
     case Format of
         parsable ->
             ok;
         _ ->
-            elvis_utils:error("  - ~p "
-                              "(https://github.com/inaka/elvis_core/tree/main/doc_rules/~p/~p.md)",
-                              [Name, Scope, Name])
+            elvis_utils:error(
+                "  - ~p "
+                "(https://github.com/inaka/elvis_core/tree/main/doc_rules/~p/~p.md)",
+                [Name, Scope, Name]
+            )
     end,
     print_item(Format, File, Name, Items),
     print_rules(Format, File, EItems);
@@ -143,13 +167,19 @@ print_rules(Format, File, [Error | Items]) ->
     print_rules(Format, File, Items).
 
 %% Item
-print_item(Format,
-           File,
-           Name,
-           [#{message := Msg,
-              line_num := Ln,
-              info := Info}
-            | Items]) ->
+print_item(
+    Format,
+    File,
+    Name,
+    [
+        #{
+            message := Msg,
+            line_num := Ln,
+            info := Info
+        }
+        | Items
+    ]
+) ->
     case Format of
         parsable ->
             FMsg = io_lib:format(Msg, Info),

--- a/src/elvis_rulesets.erl
+++ b/src/elvis_rulesets.erl
@@ -1,147 +1,177 @@
 -module(elvis_rulesets).
 
--format #{inline_items => none}.
+-format(#{inline_items => none}).
 
 -export([rules/1, set_rulesets/1]).
 
 -spec set_rulesets(#{atom() => list()}) -> ok.
 set_rulesets(RuleSets) ->
     Tid = ensure_clean_table(),
-    lists:foreach(fun({Name, Rules}) -> true = ets:insert(Tid, {Name, Rules}) end,
-                  maps:to_list(RuleSets)).
+    lists:foreach(
+        fun({Name, Rules}) -> true = ets:insert(Tid, {Name, Rules}) end,
+        maps:to_list(RuleSets)
+    ).
 
 -spec rules(Group :: atom()) -> [elvis_core:rule()].
 rules(gitignore) ->
-    lists:map(fun({Mod, Rule}) -> {Mod, Rule, apply(Mod, default, [Rule])} end,
-              [{elvis_gitignore, Rule} || Rule <- [required_patterns, forbidden_patterns]]);
+    lists:map(
+        fun({Mod, Rule}) -> {Mod, Rule, apply(Mod, default, [Rule])} end,
+        [{elvis_gitignore, Rule} || Rule <- [required_patterns, forbidden_patterns]]
+    );
 rules(hrl_files) ->
-    lists:map(fun({Mod, Rule}) -> {Mod, Rule, apply(Mod, default, [Rule])} end,
-              [{elvis_text_style, Rule} || Rule <- [line_length, no_tabs, no_trailing_whitespace]]
-              ++ [{elvis_style, Rule}
-                  || Rule
-                         <- [atom_naming_convention,
-                             consistent_variable_casing,
-                             macro_module_names,
-                             macro_names,
-                             nesting_level,
-                             no_author,
-                             no_behavior_info,
-                             no_boolean_in_comparison,
-                             no_block_expressions,
-                             no_catch_expressions,
-                             no_debug_call,
-                             no_dollar_space,
-                             no_if_expression,
-                             no_import,
-                             no_match_in_condition,
-                             no_nested_try_catch,
-                             no_single_clause_case,
-                             no_space,
-                             no_space_after_pound,
-                             no_specs,
-                             no_successive_maps,
-                             no_throw,
-                             no_types,
-                             numeric_format,
-                             operator_spaces,
-                             used_ignored_variable,
-                             variable_naming_convention]]);
+    lists:map(
+        fun({Mod, Rule}) -> {Mod, Rule, apply(Mod, default, [Rule])} end,
+        [{elvis_text_style, Rule} || Rule <- [line_length, no_tabs, no_trailing_whitespace]] ++
+            [
+                {elvis_style, Rule}
+             || Rule <-
+                    [
+                        atom_naming_convention,
+                        consistent_variable_casing,
+                        macro_module_names,
+                        macro_names,
+                        nesting_level,
+                        no_author,
+                        no_behavior_info,
+                        no_boolean_in_comparison,
+                        no_block_expressions,
+                        no_catch_expressions,
+                        no_debug_call,
+                        no_dollar_space,
+                        no_if_expression,
+                        no_import,
+                        no_match_in_condition,
+                        no_nested_try_catch,
+                        no_single_clause_case,
+                        no_space,
+                        no_space_after_pound,
+                        no_specs,
+                        no_successive_maps,
+                        no_throw,
+                        no_types,
+                        numeric_format,
+                        operator_spaces,
+                        used_ignored_variable,
+                        variable_naming_convention
+                    ]
+            ]
+    );
 rules(erl_files) ->
-    lists:map(fun({Mod, Rule}) -> {Mod, Rule, apply(Mod, default, [Rule])} end,
-              [{elvis_text_style, Rule} || Rule <- [line_length, no_tabs, no_trailing_whitespace]]
-              ++ [{elvis_style, Rule}
-                  || Rule
-                         <- [atom_naming_convention,
-                             behaviour_spelling,
-                             consistent_variable_casing,
-                             dont_repeat_yourself,
-                             export_used_types,
-                             function_naming_convention,
-                             god_modules,
-                             invalid_dynamic_call,
-                             macro_module_names,
-                             macro_names,
-                             max_anonymous_function_arity,
-                             max_function_arity,
-                             module_naming_convention,
-                             nesting_level,
-                             no_author,
-                             no_behavior_info,
-                             no_boolean_in_comparison,
-                             no_block_expressions,
-                             no_catch_expressions,
-                             no_debug_call,
-                             no_dollar_space,
-                             no_if_expression,
-                             no_import,
-                             no_match_in_condition,
-                             no_nested_try_catch,
-                             no_single_clause_case,
-                             no_space,
-                             no_space_after_pound,
-                             no_spec_with_records,
-                             no_successive_maps,
-                             no_throw,
-                             numeric_format,
-                             operator_spaces,
-                             param_pattern_matching,
-                             private_data_types,
-                             used_ignored_variable,
-                             variable_naming_convention]]);
+    lists:map(
+        fun({Mod, Rule}) -> {Mod, Rule, apply(Mod, default, [Rule])} end,
+        [{elvis_text_style, Rule} || Rule <- [line_length, no_tabs, no_trailing_whitespace]] ++
+            [
+                {elvis_style, Rule}
+             || Rule <-
+                    [
+                        atom_naming_convention,
+                        behaviour_spelling,
+                        consistent_variable_casing,
+                        dont_repeat_yourself,
+                        export_used_types,
+                        function_naming_convention,
+                        god_modules,
+                        invalid_dynamic_call,
+                        macro_module_names,
+                        macro_names,
+                        max_anonymous_function_arity,
+                        max_function_arity,
+                        module_naming_convention,
+                        nesting_level,
+                        no_author,
+                        no_behavior_info,
+                        no_boolean_in_comparison,
+                        no_block_expressions,
+                        no_catch_expressions,
+                        no_debug_call,
+                        no_dollar_space,
+                        no_if_expression,
+                        no_import,
+                        no_match_in_condition,
+                        no_nested_try_catch,
+                        no_single_clause_case,
+                        no_space,
+                        no_space_after_pound,
+                        no_spec_with_records,
+                        no_successive_maps,
+                        no_throw,
+                        numeric_format,
+                        operator_spaces,
+                        param_pattern_matching,
+                        private_data_types,
+                        used_ignored_variable,
+                        variable_naming_convention
+                    ]
+            ]
+    );
 rules(erl_files_strict) ->
-    rules(erl_files)
-    ++ lists:map(fun({Mod, Rule}) -> {Mod, Rule, apply(Mod, default, [Rule])} end,
-                 [{elvis_style, Rule}
-                  || Rule
-                         <- [always_shortcircuit,
-                             consistent_generic_type,
-                             max_function_clause_length,
-                             max_function_length,
-                             max_module_length,
-                             ms_transform_included,
-                             no_call,
-                             no_init_lists,
-                             no_common_caveats_call,
-                             no_macros,
-                             state_record_and_type]]);
+    rules(erl_files) ++
+        lists:map(
+            fun({Mod, Rule}) -> {Mod, Rule, apply(Mod, default, [Rule])} end,
+            [
+                {elvis_style, Rule}
+             || Rule <-
+                    [
+                        always_shortcircuit,
+                        consistent_generic_type,
+                        max_function_clause_length,
+                        max_function_length,
+                        max_module_length,
+                        ms_transform_included,
+                        no_call,
+                        no_init_lists,
+                        no_common_caveats_call,
+                        no_macros,
+                        state_record_and_type
+                    ]
+            ]
+        );
 rules(beam_files) ->
-    lists:map(fun(Rule) -> {elvis_style, Rule, elvis_style:default(Rule)} end,
-              [atom_naming_convention,
-               behaviour_spelling,
-               consistent_variable_casing,
-               dont_repeat_yourself,
-               export_used_types,
-               function_naming_convention,
-               god_modules,
-               invalid_dynamic_call,
-               max_anonymous_function_arity,
-               max_function_arity,
-               ms_transform_included,
-               module_naming_convention,
-               nesting_level,
-               no_author,
-               no_boolean_in_comparison,
-               no_catch_expressions,
-               no_debug_call,
-               no_if_expression,
-               no_import,
-               no_init_lists,
-               no_match_in_condition,
-               no_nested_try_catch,
-               no_single_clause_case,
-               no_spec_with_records,
-               no_successive_maps,
-               no_throw,
-               param_pattern_matching,
-               private_data_types,
-               used_ignored_variable,
-               variable_naming_convention]);
+    lists:map(
+        fun(Rule) -> {elvis_style, Rule, elvis_style:default(Rule)} end,
+        [
+            atom_naming_convention,
+            behaviour_spelling,
+            consistent_variable_casing,
+            dont_repeat_yourself,
+            export_used_types,
+            function_naming_convention,
+            god_modules,
+            invalid_dynamic_call,
+            max_anonymous_function_arity,
+            max_function_arity,
+            ms_transform_included,
+            module_naming_convention,
+            nesting_level,
+            no_author,
+            no_boolean_in_comparison,
+            no_catch_expressions,
+            no_debug_call,
+            no_if_expression,
+            no_import,
+            no_init_lists,
+            no_match_in_condition,
+            no_nested_try_catch,
+            no_single_clause_case,
+            no_spec_with_records,
+            no_successive_maps,
+            no_throw,
+            param_pattern_matching,
+            private_data_types,
+            used_ignored_variable,
+            variable_naming_convention
+        ]
+    );
 rules(rebar_config) ->
-    lists:map(fun(Rule) -> {elvis_project, Rule, elvis_project:default(Rule)} end,
-              [no_branch_deps, protocol_for_deps]);
+    lists:map(
+        fun(Rule) -> {elvis_project, Rule, elvis_project:default(Rule)} end,
+        [no_branch_deps, protocol_for_deps]
+    );
 rules(elvis_config) ->
-    lists:map(fun(Rule) -> {elvis_project, Rule, elvis_project:default(Rule)} end,
-              [old_configuration_format]);
+    lists:map(
+        fun(Rule) -> {elvis_project, Rule, elvis_project:default(Rule)} end,
+        [old_configuration_format]
+    );
 rules(Group) ->
     try
         ets:lookup_element(?MODULE, Group, 2)

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1,166 +1,271 @@
 -module(elvis_style).
 
--export([default/1, function_naming_convention/3, variable_naming_convention/3,
-         consistent_variable_casing/3, macro_names/3, macro_module_names/3, no_macros/3,
-         no_specs/3, no_types/3, no_block_expressions/3, operator_spaces/3, no_space/3,
-         no_space_after_pound/3, nesting_level/3, god_modules/3, no_if_expression/3,
-         invalid_dynamic_call/3, used_ignored_variable/3, no_behavior_info/3,
-         module_naming_convention/3, state_record_and_type/3, no_spec_with_records/3,
-         dont_repeat_yourself/3, max_module_length/3, max_anonymous_function_arity/3,
-         max_function_arity/3, max_function_length/3, max_function_clause_length/3, no_call/3,
-         no_debug_call/3, no_common_caveats_call/3, no_nested_try_catch/3, no_successive_maps/3,
-         atom_naming_convention/3, no_throw/3, no_dollar_space/3, no_author/3, no_import/3,
-         no_catch_expressions/3, no_single_clause_case/3, numeric_format/3, behaviour_spelling/3,
-         always_shortcircuit/3, consistent_generic_type/3, export_used_types/3,
-         no_match_in_condition/3, param_pattern_matching/3, private_data_types/3, option/3,
-         no_init_lists/3, ms_transform_included/3, no_boolean_in_comparison/3]).
+-export([
+    default/1,
+    function_naming_convention/3,
+    variable_naming_convention/3,
+    consistent_variable_casing/3,
+    macro_names/3,
+    macro_module_names/3,
+    no_macros/3,
+    no_specs/3,
+    no_types/3,
+    no_block_expressions/3,
+    operator_spaces/3,
+    no_space/3,
+    no_space_after_pound/3,
+    nesting_level/3,
+    god_modules/3,
+    no_if_expression/3,
+    invalid_dynamic_call/3,
+    used_ignored_variable/3,
+    no_behavior_info/3,
+    module_naming_convention/3,
+    state_record_and_type/3,
+    no_spec_with_records/3,
+    dont_repeat_yourself/3,
+    max_module_length/3,
+    max_anonymous_function_arity/3,
+    max_function_arity/3,
+    max_function_length/3,
+    max_function_clause_length/3,
+    no_call/3,
+    no_debug_call/3,
+    no_common_caveats_call/3,
+    no_nested_try_catch/3,
+    no_successive_maps/3,
+    atom_naming_convention/3,
+    no_throw/3,
+    no_dollar_space/3,
+    no_author/3,
+    no_import/3,
+    no_catch_expressions/3,
+    no_single_clause_case/3,
+    numeric_format/3,
+    behaviour_spelling/3,
+    always_shortcircuit/3,
+    consistent_generic_type/3,
+    export_used_types/3,
+    no_match_in_condition/3,
+    param_pattern_matching/3,
+    private_data_types/3,
+    option/3,
+    no_init_lists/3,
+    ms_transform_included/3,
+    no_boolean_in_comparison/3
+]).
 
 -export_type([empty_rule_config/0]).
 -export_type([ignorable/0]).
--export_type([max_anonymous_function_arity_config/0, max_function_arity_config/0,
-              max_function_length_config/0, max_module_length_config/0,
-              function_naming_convention_config/0, variable_naming_convention_config/0,
-              macro_names_config/0, no_macros_config/0, no_types_config/0, no_specs_config/0,
-              no_block_expressions_config/0, no_space_after_pound_config/0,
-              operator_spaces_config/0, no_space_config/0, nesting_level_config/0,
-              god_modules_config/0, module_naming_convention_config/0,
-              dont_repeat_yourself_config/0, no_call_config/0, no_debug_call_config/0,
-              no_common_caveats_call_config/0, atom_naming_convention_config/0, no_author_config/0,
-              no_import_config/0, no_catch_expressions_config/0, numeric_format_config/0,
-              no_single_clause_case_config/0, consistent_variable_casing_config/0,
-              no_match_in_condition_config/0, behaviour_spelling_config/0,
-              param_pattern_matching_config/0, private_data_type_config/0, no_init_lists_config/0]).
+-export_type([
+    max_anonymous_function_arity_config/0,
+    max_function_arity_config/0,
+    max_function_length_config/0,
+    max_module_length_config/0,
+    function_naming_convention_config/0,
+    variable_naming_convention_config/0,
+    macro_names_config/0,
+    no_macros_config/0,
+    no_types_config/0,
+    no_specs_config/0,
+    no_block_expressions_config/0,
+    no_space_after_pound_config/0,
+    operator_spaces_config/0,
+    no_space_config/0,
+    nesting_level_config/0,
+    god_modules_config/0,
+    module_naming_convention_config/0,
+    dont_repeat_yourself_config/0,
+    no_call_config/0,
+    no_debug_call_config/0,
+    no_common_caveats_call_config/0,
+    atom_naming_convention_config/0,
+    no_author_config/0,
+    no_import_config/0,
+    no_catch_expressions_config/0,
+    numeric_format_config/0,
+    no_single_clause_case_config/0,
+    consistent_variable_casing_config/0,
+    no_match_in_condition_config/0,
+    behaviour_spelling_config/0,
+    param_pattern_matching_config/0,
+    private_data_type_config/0,
+    no_init_lists_config/0
+]).
 
 -define(NO_INIT_LISTS_MSG,
-        "Do not use a list as the parameter for the 'init' callback at position ~p.").
+    "Do not use a list as the parameter for the 'init' callback at position ~p."
+).
 -define(MS_TRANSFORM_INCLUDED_MSG,
-        "Missing inclide library: stdlib/include/ms_transform.hrl when ets:fun2ms/1
-        is used at position ~p.").
+    "Missing inclide library: stdlib/include/ms_transform.hrl when ets:fun2ms/1\n"
+    "        is used at position ~p."
+).
 -define(INVALID_MACRO_NAME_REGEX_MSG,
-        "The macro named ~p on line ~p does not respect the format "
-        "defined by the regular expression '~p'.").
+    "The macro named ~p on line ~p does not respect the format "
+    "defined by the regular expression '~p'."
+).
 -define(MACRO_AS_MODULE_NAME_MSG,
-        "Don't use macros (like ~s on line ~p) as module names.").
+    "Don't use macros (like ~s on line ~p) as module names."
+).
 -define(MACRO_MODULE_NAMES_EXCEPTIONS, ["MODULE"]).
 -define(MACRO_AS_FUNCTION_NAME_MSG,
-        "Don't use macros (like ~s on line ~p) as function names.").
+    "Don't use macros (like ~s on line ~p) as function names."
+).
 -define(NO_MACROS_MSG, "Unexpected macro (~p) used on line ~p.").
 -define(NO_SPECS_MSG, "Unexpected spec for function ~p defined on line ~p.").
 -define(NO_TYPES_MSG, "Unexpected type (~p) defined on line ~p.").
 -define(NO_BLOCK_EXPRESSIONS_MSG,
-        "Unexpected block expression (begin-end) used on line ~p.").
+    "Unexpected block expression (begin-end) used on line ~p."
+).
 -define(MISSING_SPACE_MSG, "Missing space to the ~s of ~p on line ~p").
 -define(UNEXPECTED_SPACE_MSG, "Unexpected space to the ~s of ~p on line ~p").
 -define(NESTING_LEVEL_MSG,
-        "The expression on line ~p and column ~p is nested "
-        "beyond the maximum level of ~p.").
+    "The expression on line ~p and column ~p is nested "
+    "beyond the maximum level of ~p."
+).
 -define(GOD_MODULES_MSG,
-        "This module has too many functions (~p). "
-        "Consider breaking it into a number of modules.").
+    "This module has too many functions (~p). "
+    "Consider breaking it into a number of modules."
+).
 -define(NO_IF_EXPRESSION_MSG,
-        "Replace the 'if' expression on line ~p with a 'case' "
-        "expression or function clauses.").
+    "Replace the 'if' expression on line ~p with a 'case' "
+    "expression or function clauses."
+).
 -define(INVALID_DYNAMIC_CALL_MSG,
-        "Remove the dynamic function call on line ~p. "
-        "Only modules that define callbacks should make dynamic calls.").
+    "Remove the dynamic function call on line ~p. "
+    "Only modules that define callbacks should make dynamic calls."
+).
 -define(USED_IGNORED_VAR_MSG,
-        "Ignored variable is being used on line ~p and "
-        "column ~p.").
+    "Ignored variable is being used on line ~p and "
+    "column ~p."
+).
 -define(NO_BEHAVIOR_INFO,
-        "Use the '-callback' attribute instead of 'behavior_info/1' "
-        "on line ~p.").
+    "Use the '-callback' attribute instead of 'behavior_info/1' "
+    "on line ~p."
+).
 -define(FUNCTION_NAMING_CONVENTION_MSG,
-        "The function ~p's name does not respect the format defined by the "
-        "regular expression '~p'.").
+    "The function ~p's name does not respect the format defined by the "
+    "regular expression '~p'."
+).
 -define(FORBIDDEN_FUNCTION_NAMING_CONVENTION_MSG,
-        "The function ~p's name is written in a forbidden format"
-        "defined by the regular expression '~p'.").
+    "The function ~p's name is written in a forbidden format"
+    "defined by the regular expression '~p'."
+).
 -define(VARIABLE_NAMING_CONVENTION_MSG,
-        "The variable ~p's name, on line ~p does not respect the format "
-        "defined by the regular expression '~p'.").
+    "The variable ~p's name, on line ~p does not respect the format "
+    "defined by the regular expression '~p'."
+).
 -define(FORBIDDEN_VARIABLE_NAMING_CONVENTION_MSG,
-        "The variable ~p's name on line ~p is written in a forbidden the format "
-        "defined by the regular expression '~p'.").
+    "The variable ~p's name on line ~p is written in a forbidden the format "
+    "defined by the regular expression '~p'."
+).
 -define(CONSISTENT_VARIABLE_CASING_MSG,
-        "Variable ~ts (first used in line ~p) is written in different ways within the module: ~p.").
+    "Variable ~ts (first used in line ~p) is written in different ways within the module: ~p."
+).
 -define(MODULE_NAMING_CONVENTION_MSG,
-        "The module ~p's name does not respect the format defined by the "
-        "regular expression '~p'.").
+    "The module ~p's name does not respect the format defined by the "
+    "regular expression '~p'."
+).
 -define(FORBIDDEN_MODULE_NAMING_CONVENTION_MSG,
-        "The module ~p's name is written in a forbidden format defined by the "
-        "regular expression '~p'.").
+    "The module ~p's name is written in a forbidden format defined by the "
+    "regular expression '~p'."
+).
 -define(STATE_RECORD_MISSING_MSG,
-        "This module implements an OTP behavior but is missing "
-        "a 'state' record.").
+    "This module implements an OTP behavior but is missing "
+    "a 'state' record."
+).
 -define(STATE_TYPE_MISSING_MSG,
-        "This module implements an OTP behavior and has a 'state' record "
-        "but is missing a 'state()' type.").
+    "This module implements an OTP behavior and has a 'state' record "
+    "but is missing a 'state()' type."
+).
 -define(NO_SPEC_WITH_RECORDS,
-        "The spec in line ~p uses a record, please define a type for the "
-        "record and use that instead.").
+    "The spec in line ~p uses a record, please define a type for the "
+    "record and use that instead."
+).
 -define(DONT_REPEAT_YOURSELF,
-        "The code in the following (LINE, COL) locations has "
-        "the same structure: ~s.").
+    "The code in the following (LINE, COL) locations has "
+    "the same structure: ~s."
+).
 -define(MAX_MODULE_LENGTH,
-        "The code for module ~p has ~p lines which exceeds the "
-        "maximum of ~p.").
+    "The code for module ~p has ~p lines which exceeds the "
+    "maximum of ~p."
+).
 -define(MAX_ANONYMOUS_FUNCTION_ARITY_MSG,
-        "The arity of the anonymous function defined in line ~p (~w arguments) exceeds the "
-        "maximum of ~p.").
+    "The arity of the anonymous function defined in line ~p (~w arguments) exceeds the "
+    "maximum of ~p."
+).
 -define(MAX_FUNCTION_ARITY_MSG, "The arity of function ~p/~w exceeds the maximum of ~p.").
 -define(MAX_FUNCTION_LENGTH,
-        "The code for function ~p/~w has ~p lines which exceeds the "
-        "maximum of ~p.").
+    "The code for function ~p/~w has ~p lines which exceeds the "
+    "maximum of ~p."
+).
 -define(MAX_FUNCTION_CLAUSE_LENGTH,
-        "The code for the ~ts clause of function ~p/~w has ~p lines which exceeds the "
-        "maximum of ~p.").
+    "The code for the ~ts clause of function ~p/~w has ~p lines which exceeds the "
+    "maximum of ~p."
+).
 -define(NO_CALL_MSG, "The call to ~p:~p/~p on line ~p is in the no_call list.").
 -define(NO_DEBUG_CALL_MSG, "Remove the debug call to ~p:~p/~p on line ~p.").
 -define(NO_COMMON_CAVEATS_CALL_MSG,
-        "The call to ~p:~p/~p on line ~p is in the list of "
-        "Erlang Efficiency Guide common caveats.").
+    "The call to ~p:~p/~p on line ~p is in the list of "
+    "Erlang Efficiency Guide common caveats."
+).
 -define(NO_NESTED_TRY_CATCH, "Nested try...catch block starting at line ~p.").
 -define(NO_SUCCESSIVE_MAPS_MSG,
-        "Found map update after map construction/update at line ~p.").
+    "Found map update after map construction/update at line ~p."
+).
 -define(ATOM_NAMING_CONVENTION_MSG,
-        "Atom ~p's name, on line ~p does not respect the format "
-        "defined by the regular expression '~p'.").
+    "Atom ~p's name, on line ~p does not respect the format "
+    "defined by the regular expression '~p'."
+).
 -define(FORBIDDEN_ATOM_NAMING_CONVENTION_MSG,
-        "Atom ~p on line ~p's name is written in a forbidden format "
-        "defined by the regular expression '~p'.").
+    "Atom ~p on line ~p's name is written in a forbidden format "
+    "defined by the regular expression '~p'."
+).
 -define(NO_THROW_MSG, "Usage of throw/1 on line ~p is not recommended").
 -define(NO_DOLLAR_SPACE_MSG,
-        "'$ ' was found on line ~p. It's use is discouraged. "
-        "Use $\\s, instead.").
+    "'$ ' was found on line ~p. It's use is discouraged. "
+    "Use $\\s, instead."
+).
 -define(NO_AUTHOR_MSG, "Unnecessary author attribute on line ~p").
 -define(NO_IMPORT_MSG, "Usage of the import attribute, on line ~p, is discouraged").
 -define(NO_CATCH_EXPRESSIONS_MSG,
-        "Usage of catch expression on line ~p is not recommended").
+    "Usage of catch expression on line ~p is not recommended"
+).
 -define(NO_SINGLE_CLAUSE_CASE_MSG,
-        "Case statement with a single clause found on line ~p.").
+    "Case statement with a single clause found on line ~p."
+).
 -define(NO_MATCH_IN_CONDITION_MSG,
-        "Case statement with a match in its condition found on line ~p.").
+    "Case statement with a match in its condition found on line ~p."
+).
 -define(NUMERIC_FORMAT_MSG,
-        "Number ~p on line ~p does not respect the format "
-        "defined by the regular expression '~p'.").
+    "Number ~p on line ~p does not respect the format "
+    "defined by the regular expression '~p'."
+).
 -define(BEHAVIOUR_SPELLING_MSG,
-        "The behavior/behaviour in line ~p is misspelt, please use the "
-        "~p spelling.").
+    "The behavior/behaviour in line ~p is misspelt, please use the "
+    "~p spelling."
+).
 -define(PARAM_PATTERN_MATCHING_MSG,
-        "Variable ~ts, used to match a parameter in line ~p, is placed on "
-        "the wrong side of the match. It was expected on the ~p side.").
+    "Variable ~ts, used to match a parameter in line ~p, is placed on "
+    "the wrong side of the match. It was expected on the ~p side."
+).
 -define(ALWAYS_SHORTCIRCUIT_MSG,
-        "Non-shortcircuiting operator (~p) found in line ~p. "
-        "It's recommended to use ~p, instead.").
+    "Non-shortcircuiting operator (~p) found in line ~p. "
+    "It's recommended to use ~p, instead."
+).
 -define(CONSISTENT_GENERIC_TYPE,
-        "Found usage of type ~p/0 on line ~p. Please use ~p/0, instead.").
+    "Found usage of type ~p/0 on line ~p. Please use ~p/0, instead."
+).
 -define(EXPORT_USED_TYPES_MSG,
-        "Type ~p/~p, defined on line ~p, is used by an exported function but not exported itself").
+    "Type ~p/~p, defined on line ~p, is used by an exported function but not exported itself"
+).
 -define(PRIVATE_DATA_TYPES_MSG,
-        "Private data type ~p/~p, defined on line ~p, is exported. Either don't export it or make "
-        "it an opaque type.").
+    "Private data type ~p/~p, defined on line ~p, is exported. Either don't export it or make "
+    "it an opaque type."
+).
 -define(NO_BOOLEAN_IN_COMPARISON,
-        "Comparison uses boolean on line ~p. Using booleans in comparison should be avoided.").
+    "Comparison uses boolean on line ~p. Using booleans in comparison should be avoided."
+).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Default values
@@ -168,30 +273,80 @@
 
 -spec default(Rule :: atom()) -> DefaultRuleConfig :: term().
 default(no_init_lists) ->
-    #{behaviours =>
-          [gen_server, gen_statem, gen_fsm, supervisor, supervisor_bridge, gen_event]};
+    #{
+        behaviours =>
+            [gen_server, gen_statem, gen_fsm, supervisor, supervisor_bridge, gen_event]
+    };
 default(macro_names) ->
     #{regex => "^[A-Z](_?[A-Z0-9]+)*$"};
 default(operator_spaces) ->
-    #{rules =>
-          [{right, "++"}, {left, "++"}, {right, "="}, {left, "="}, {right, "+"}, {left, "+"},
-           {right, "-"}, {left, "-"}, {right, "*"}, {left, "*"}, {right, "/"}, {left, "/"},
-           {right, "=<"}, {left, "=<"}, {right, "<"}, {left, "<"}, {right, ">"}, {left, ">"},
-           {right, ">="}, {left, ">="}, {right, "=="}, {left, "=="}, {right, "=:="}, {left, "=:="},
-           {right, "/="}, {left, "/="}, {right, "=/="}, {left, "=/="}, {right, "--"}, {left, "--"},
-           {right, "=>"}, {left, "=>"}, {right, ":="}, {left, ":="}, {right, "<-"}, {left, "<-"},
-           {right, "<="}, {left, "<="}, {right, "||"}, {left, "||"}, {right, "|"}, {left, "|"},
-           {right, "::"}, {left, "::"}, {right, "->"}, {left, "->"}, {right, ","}, {left, "!"},
-           {right, "!"}]};
+    #{
+        rules =>
+            [
+                {right, "++"},
+                {left, "++"},
+                {right, "="},
+                {left, "="},
+                {right, "+"},
+                {left, "+"},
+                {right, "-"},
+                {left, "-"},
+                {right, "*"},
+                {left, "*"},
+                {right, "/"},
+                {left, "/"},
+                {right, "=<"},
+                {left, "=<"},
+                {right, "<"},
+                {left, "<"},
+                {right, ">"},
+                {left, ">"},
+                {right, ">="},
+                {left, ">="},
+                {right, "=="},
+                {left, "=="},
+                {right, "=:="},
+                {left, "=:="},
+                {right, "/="},
+                {left, "/="},
+                {right, "=/="},
+                {left, "=/="},
+                {right, "--"},
+                {left, "--"},
+                {right, "=>"},
+                {left, "=>"},
+                {right, ":="},
+                {left, ":="},
+                {right, "<-"},
+                {left, "<-"},
+                {right, "<="},
+                {left, "<="},
+                {right, "||"},
+                {left, "||"},
+                {right, "|"},
+                {left, "|"},
+                {right, "::"},
+                {left, "::"},
+                {right, "->"},
+                {left, "->"},
+                {right, ","},
+                {left, "!"},
+                {right, "!"}
+            ]
+    };
 default(no_space) ->
-    #{rules =>
-          [{right, "("},
-           {left, ")"},
-           {left, ","},
-           {left, ":"},
-           {right, ":"},
-           {right, "#"},
-           {right, "?"}]};
+    #{
+        rules =>
+            [
+                {right, "("},
+                {left, ")"},
+                {left, ","},
+                {left, ":"},
+                {right, ":"},
+                {right, "#"},
+                {right, "?"}
+            ]
+    };
 default(nesting_level) ->
     #{level => 4};
 default(god_modules) ->
@@ -205,50 +360,68 @@ default(module_naming_convention) ->
 default(dont_repeat_yourself) ->
     #{min_complexity => 10};
 default(max_module_length) ->
-    #{max_length => 500,
-      count_comments => false,
-      count_whitespace => false,
-      count_docs => false};
+    #{
+        max_length => 500,
+        count_comments => false,
+        count_whitespace => false,
+        count_docs => false
+    };
 default(max_anonymous_function_arity) ->
     #{max_arity => 5};
 default(max_function_arity) ->
     #{max_arity => 8, non_exported_max_arity => 10};
 default(max_function_length) ->
-    #{max_length => 30,
-      count_comments => false,
-      count_whitespace => false};
+    #{
+        max_length => 30,
+        count_comments => false,
+        count_whitespace => false
+    };
 default(max_function_clause_length) ->
-    #{max_length => 30,
-      count_comments => false,
-      count_whitespace => false};
+    #{
+        max_length => 30,
+        count_comments => false,
+        count_whitespace => false
+    };
 default(no_call) ->
     #{no_call_functions => []};
 default(no_debug_call) ->
-    #{debug_functions =>
-          [{ct, pal},
-           {ct, print},
-           {erlang, display, 1},
-           {io, format, 1},
-           {io, format, 2},
-           {io, put_chars, 1},
-           {io, put_chars, 2}]};
+    #{
+        debug_functions =>
+            [
+                {ct, pal},
+                {ct, print},
+                {erlang, display, 1},
+                {io, format, 1},
+                {io, format, 2},
+                {io, put_chars, 1},
+                {io, put_chars, 2}
+            ]
+    };
 default(no_common_caveats_call) ->
-    #{caveat_functions =>
-          [{timer, send_after, 2},
-           {timer, send_after, 3},
-           {timer, send_interval, 2},
-           {timer, send_interval, 3},
-           {erlang, size, 1}]};
+    #{
+        caveat_functions =>
+            [
+                {timer, send_after, 2},
+                {timer, send_after, 3},
+                {timer, send_interval, 2},
+                {timer, send_interval, 3},
+                {erlang, size, 1}
+            ]
+    };
 default(atom_naming_convention) ->
-    #{regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
-      enclosed_atoms => ".*",
-      forbidden_regex => undefined,
-      forbidden_enclosed_regex => undefined};
+    #{
+        regex => "^[a-z](_?[a-z0-9]+)*(_SUITE)?$",
+        enclosed_atoms => ".*",
+        forbidden_regex => undefined,
+        forbidden_enclosed_regex => undefined
+    };
 %% Not restrictive. Those who want more restrictions can set it like "^[^_]*$"
 default(numeric_format) ->
-    #{regex => ".*",
-      int_regex => same,
-      float_regex => same};
+    #{
+        regex => ".*",
+        int_regex => same,
+        float_regex => same
+    };
 default(behaviour_spelling) ->
     #{spelling => behaviour};
 default(param_pattern_matching) ->
@@ -257,33 +430,34 @@ default(consistent_generic_type) ->
     #{preferred_type => term};
 default(private_data_types) ->
     #{apply_to => [record]};
-default(RuleWithEmptyDefault)
-    when RuleWithEmptyDefault == macro_module_names;
-         RuleWithEmptyDefault == no_macros;
-         RuleWithEmptyDefault == no_specs;
-         RuleWithEmptyDefault == no_types;
-         RuleWithEmptyDefault == no_block_expressions;
-         RuleWithEmptyDefault == no_if_expression;
-         RuleWithEmptyDefault == no_nested_try_catch;
-         RuleWithEmptyDefault == no_successive_maps;
-         RuleWithEmptyDefault == invalid_dynamic_call;
-         RuleWithEmptyDefault == used_ignored_variable;
-         RuleWithEmptyDefault == no_behavior_info;
-         RuleWithEmptyDefault == state_record_and_type;
-         RuleWithEmptyDefault == no_spec_with_records;
-         RuleWithEmptyDefault == no_throw;
-         RuleWithEmptyDefault == no_dollar_space;
-         RuleWithEmptyDefault == no_author;
-         RuleWithEmptyDefault == no_import;
-         RuleWithEmptyDefault == no_catch_expressions;
-         RuleWithEmptyDefault == no_single_clause_case;
-         RuleWithEmptyDefault == no_match_in_condition;
-         RuleWithEmptyDefault == always_shortcircuit;
-         RuleWithEmptyDefault == no_space_after_pound;
-         RuleWithEmptyDefault == export_used_types;
-         RuleWithEmptyDefault == consistent_variable_casing;
-         RuleWithEmptyDefault == ms_transform_included;
-         RuleWithEmptyDefault == no_boolean_in_comparison ->
+default(RuleWithEmptyDefault) when
+    RuleWithEmptyDefault == macro_module_names;
+    RuleWithEmptyDefault == no_macros;
+    RuleWithEmptyDefault == no_specs;
+    RuleWithEmptyDefault == no_types;
+    RuleWithEmptyDefault == no_block_expressions;
+    RuleWithEmptyDefault == no_if_expression;
+    RuleWithEmptyDefault == no_nested_try_catch;
+    RuleWithEmptyDefault == no_successive_maps;
+    RuleWithEmptyDefault == invalid_dynamic_call;
+    RuleWithEmptyDefault == used_ignored_variable;
+    RuleWithEmptyDefault == no_behavior_info;
+    RuleWithEmptyDefault == state_record_and_type;
+    RuleWithEmptyDefault == no_spec_with_records;
+    RuleWithEmptyDefault == no_throw;
+    RuleWithEmptyDefault == no_dollar_space;
+    RuleWithEmptyDefault == no_author;
+    RuleWithEmptyDefault == no_import;
+    RuleWithEmptyDefault == no_catch_expressions;
+    RuleWithEmptyDefault == no_single_clause_case;
+    RuleWithEmptyDefault == no_match_in_condition;
+    RuleWithEmptyDefault == always_shortcircuit;
+    RuleWithEmptyDefault == no_space_after_pound;
+    RuleWithEmptyDefault == export_used_types;
+    RuleWithEmptyDefault == consistent_variable_casing;
+    RuleWithEmptyDefault == ms_transform_included;
+    RuleWithEmptyDefault == no_boolean_in_comparison
+->
     #{}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -293,23 +467,29 @@ default(RuleWithEmptyDefault)
 -type empty_rule_config() :: #{ignore => [ignorable()]}.
 -type ignorable() :: module() | {module(), atom()} | {module(), atom(), arity()}.
 -type max_function_length_config() ::
-    #{ignore => [ignorable()],
-      max_length => non_neg_integer(),
-      count_comments => boolean(),
-      count_whitespace => boolean()}.
+    #{
+        ignore => [ignorable()],
+        max_length => non_neg_integer(),
+        count_comments => boolean(),
+        count_whitespace => boolean()
+    }.
 -type max_module_length_config() ::
-    #{ignore => [ignorable()],
-      count_comments => boolean(),
-      count_whitespace => boolean(),
-      max_length => integer()}.
+    #{
+        ignore => [ignorable()],
+        count_comments => boolean(),
+        count_whitespace => boolean(),
+        max_length => integer()
+    }.
 -type function_naming_convention_config() ::
     #{ignore => [ignorable()], regex => string()}.
 -type binary_part() :: {Start :: non_neg_integer(), Length :: integer()}.
 
--spec function_naming_convention(elvis_config:config(),
-                                 elvis_file:file(),
-                                 function_naming_convention_config()) ->
-                                    [elvis_result:item()].
+-spec function_naming_convention(
+    elvis_config:config(),
+    elvis_file:file(),
+    function_naming_convention_config()
+) ->
+    [elvis_result:item()].
 function_naming_convention(Config, Target, RuleConfig) ->
     Regex = option(regex, RuleConfig, function_naming_convention),
     ForbiddenRegex = option(forbidden_regex, RuleConfig, function_naming_convention),
@@ -337,9 +517,14 @@ errors_for_function_names(Regex, ForbiddenRegex, [FunctionName | RemainingFuncNa
                             Msg = ?FORBIDDEN_FUNCTION_NAMING_CONVENTION_MSG,
                             Info = [FunctionNameStr, Regex],
                             Result = elvis_result:new(item, Msg, Info, 1),
-                            [Result | errors_for_function_names(Regex,
-                                                                ForbiddenRegex,
-                                                                RemainingFuncNames)];
+                            [
+                                Result
+                                | errors_for_function_names(
+                                    Regex,
+                                    ForbiddenRegex,
+                                    RemainingFuncNames
+                                )
+                            ];
                         nomatch ->
                             errors_for_function_names(Regex, ForbiddenRegex, RemainingFuncNames)
                     end
@@ -348,26 +533,32 @@ errors_for_function_names(Regex, ForbiddenRegex, [FunctionName | RemainingFuncNa
 
 -type consistent_variable_casing_config() :: #{ignore => [ignorable()]}.
 
--spec consistent_variable_casing(elvis_config:config(),
-                                 elvis_file:file(),
-                                 consistent_variable_casing_config()) ->
-                                    [elvis_result:item()].
+-spec consistent_variable_casing(
+    elvis_config:config(),
+    elvis_file:file(),
+    consistent_variable_casing_config()
+) ->
+    [elvis_result:item()].
 %% @todo Use maps:groups_from_list/2 when we specify OTP25 as the minimum OTP version
 consistent_variable_casing(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Vars = elvis_code:find(fun is_var/1, Root, #{traverse => all, mode => zipper}),
     Grouped =
         maps:to_list(
-            lists:foldr(fun(Var, Acc) ->
-                           VarName = canonical_variable_name(Var),
-                           maps:update_with(
-                               string:uppercase(VarName),
-                               fun(Locations) -> [#{name => VarName, var => Var} | Locations] end,
-                               [#{name => VarName, var => Var}],
-                               Acc)
-                        end,
-                        #{},
-                        Vars)),
+            lists:foldr(
+                fun(Var, Acc) ->
+                    VarName = canonical_variable_name(Var),
+                    maps:update_with(
+                        string:uppercase(VarName),
+                        fun(Locations) -> [#{name => VarName, var => Var} | Locations] end,
+                        [#{name => VarName, var => Var}],
+                        Acc
+                    )
+                end,
+                #{},
+                Vars
+            )
+        ),
     lists:flatmap(fun check_variable_casing_consistency/1, Grouped).
 
 canonical_variable_name(Var) ->
@@ -378,8 +569,7 @@ canonical_variable_name(Var) ->
             VarNameStr
     end.
 
-check_variable_casing_consistency({_,
-                                   [#{name := FirstName, var := FirstVar} | Others]}) ->
+check_variable_casing_consistency({_, [#{name := FirstName, var := FirstVar} | Others]}) ->
     case lists:usort([OtherName || #{name := OtherName} <- Others, OtherName /= FirstName]) of
         [] ->
             [];
@@ -392,10 +582,12 @@ check_variable_casing_consistency({_,
 -type variable_naming_convention_config() ::
     #{ignore => [ignorable()], regex => string()}.
 
--spec variable_naming_convention(elvis_config:config(),
-                                 elvis_file:file(),
-                                 variable_naming_convention_config()) ->
-                                    [elvis_result:item()].
+-spec variable_naming_convention(
+    elvis_config:config(),
+    elvis_file:file(),
+    variable_naming_convention_config()
+) ->
+    [elvis_result:item()].
 variable_naming_convention(Config, Target, RuleConfig) ->
     Regex = option(regex, RuleConfig, variable_naming_convention),
     ForbiddenRegex = option(forbidden_regex, RuleConfig, variable_naming_convention),
@@ -406,7 +598,7 @@ variable_naming_convention(Config, Target, RuleConfig) ->
 -type macro_names_config() :: #{ignore => [ignorable()], regex => string()}.
 
 -spec macro_names(elvis_config:config(), elvis_file:file(), macro_names_config()) ->
-                     [elvis_result:item()].
+    [elvis_result:item()].
 macro_names(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Regexp = option(regex, RuleConfig, macro_names),
@@ -415,7 +607,7 @@ macro_names(Config, Target, RuleConfig) ->
     check_macro_names(Regexp, MacroNodes, _ResultsIn = []).
 
 -spec macro_module_names(elvis_config:config(), elvis_file:file(), empty_rule_config()) ->
-                            [elvis_result:item()].
+    [elvis_result:item()].
 macro_module_names(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Calls = elvis_code:find(fun is_call/1, Root),
@@ -425,34 +617,44 @@ macro_module_names(Config, Target, RuleConfig) ->
 check_no_macro_calls(Calls) ->
     TypeFun =
         fun(Call) ->
-           FunctionSpec = ktn_code:node_attr(function, Call),
-           ModuleAttr = ktn_code:node_attr(module, FunctionSpec),
-           FuncAttr = ktn_code:node_attr(function, FunctionSpec),
-           M = ktn_code:type(ModuleAttr),
-           MN = ktn_code:attr(name, ModuleAttr),
-           F = ktn_code:type(FuncAttr),
-           FN = ktn_code:attr(name, FuncAttr),
-           #{call => Call,
-             module_type => M,
-             func_type => F,
-             module_name => MN,
-             func_name => FN}
+            FunctionSpec = ktn_code:node_attr(function, Call),
+            ModuleAttr = ktn_code:node_attr(module, FunctionSpec),
+            FuncAttr = ktn_code:node_attr(function, FunctionSpec),
+            M = ktn_code:type(ModuleAttr),
+            MN = ktn_code:attr(name, ModuleAttr),
+            F = ktn_code:type(FuncAttr),
+            FN = ktn_code:attr(name, FuncAttr),
+            #{
+                call => Call,
+                module_type => M,
+                func_type => F,
+                module_name => MN,
+                func_name => FN
+            }
         end,
     CallsWithTypes = lists:map(TypeFun, Calls),
 
     MacroInM =
-        [{?MACRO_AS_MODULE_NAME_MSG, MN, ktn_code:attr(location, Call)}
-         || #{module_type := macro,
-              call := Call,
-              module_name := MN}
-                <- CallsWithTypes,
-            not lists:member(MN, ?MACRO_MODULE_NAMES_EXCEPTIONS)],
+        [
+            {?MACRO_AS_MODULE_NAME_MSG, MN, ktn_code:attr(location, Call)}
+         || #{
+                module_type := macro,
+                call := Call,
+                module_name := MN
+            } <-
+                CallsWithTypes,
+            not lists:member(MN, ?MACRO_MODULE_NAMES_EXCEPTIONS)
+        ],
     MacroInF =
-        [{?MACRO_AS_FUNCTION_NAME_MSG, FN, ktn_code:attr(location, Call)}
-         || #{func_type := macro,
-              call := Call,
-              func_name := FN}
-                <- CallsWithTypes],
+        [
+            {?MACRO_AS_FUNCTION_NAME_MSG, FN, ktn_code:attr(location, Call)}
+         || #{
+                func_type := macro,
+                call := Call,
+                func_name := FN
+            } <-
+                CallsWithTypes
+        ],
 
     ResultFun =
         fun({Msg, Subject, {Line, _}}) -> elvis_result:new(item, Msg, [Subject, Line], Line) end,
@@ -461,7 +663,7 @@ check_no_macro_calls(Calls) ->
 -type no_macros_config() :: #{allow => [atom()], ignore => [ignorable()]}.
 
 -spec no_macros(elvis_config:config(), elvis_file:file(), no_macros_config()) ->
-                   [elvis_result:item()].
+    [elvis_result:item()].
 no_macros(ElvisConfig, RuleTarget, RuleConfig) ->
     TreeRootNode = get_root(ElvisConfig, RuleTarget, RuleConfig),
     AllowedMacros = maps:get(allow, RuleConfig, []) ++ eep_predef_macros() ++ logger_macros(),
@@ -469,18 +671,20 @@ no_macros(ElvisConfig, RuleTarget, RuleConfig) ->
     MacroNodes =
         elvis_code:find(fun is_macro_node/1, TreeRootNode, #{traverse => all, mode => node}),
 
-    lists:foldl(fun(MacroNode, Acc) ->
-                   Macro = list_to_atom(ktn_code:attr(name, MacroNode)),
-                   case lists:member(Macro, AllowedMacros) of
-                       true ->
-                           Acc;
-                       false ->
-                           {Line, _Col} = ktn_code:attr(location, MacroNode),
-                           [elvis_result:new(item, ?NO_MACROS_MSG, [Macro, Line], Line) | Acc]
-                   end
-                end,
-                [],
-                MacroNodes).
+    lists:foldl(
+        fun(MacroNode, Acc) ->
+            Macro = list_to_atom(ktn_code:attr(name, MacroNode)),
+            case lists:member(Macro, AllowedMacros) of
+                true ->
+                    Acc;
+                false ->
+                    {Line, _Col} = ktn_code:attr(location, MacroNode),
+                    [elvis_result:new(item, ?NO_MACROS_MSG, [Macro, Line], Line) | Acc]
+            end
+        end,
+        [],
+        MacroNodes
+    ).
 
 is_macro_node(Node) ->
     ktn_code:type(Node) =:= macro.
@@ -488,19 +692,21 @@ is_macro_node(Node) ->
 -type no_types_config() :: #{allow => [atom()], ignore => [ignorable()]}.
 
 -spec no_types(elvis_config:config(), elvis_file:file(), no_types_config()) ->
-                  [elvis_result:item()].
+    [elvis_result:item()].
 no_types(ElvisConfig, RuleTarget, RuleConfig) ->
     TreeRootNode = get_root(ElvisConfig, RuleTarget, RuleConfig),
     TypeNodes =
         elvis_code:find(fun is_type_attribute/1, TreeRootNode, #{traverse => all, mode => node}),
 
-    lists:foldl(fun(TypeNode, Acc) ->
-                   Type = ktn_code:attr(name, TypeNode),
-                   {Line, _Col} = ktn_code:attr(location, TypeNode),
-                   [elvis_result:new(item, ?NO_TYPES_MSG, [Type, Line], Line) | Acc]
-                end,
-                [],
-                TypeNodes).
+    lists:foldl(
+        fun(TypeNode, Acc) ->
+            Type = ktn_code:attr(name, TypeNode),
+            {Line, _Col} = ktn_code:attr(location, TypeNode),
+            [elvis_result:new(item, ?NO_TYPES_MSG, [Type, Line], Line) | Acc]
+        end,
+        [],
+        TypeNodes
+    ).
 
 is_type_attribute(Node) ->
     ktn_code:type(Node) =:= type_attr.
@@ -508,77 +714,89 @@ is_type_attribute(Node) ->
 -type no_specs_config() :: #{allow => [atom()], ignore => [ignorable()]}.
 
 -spec no_specs(elvis_config:config(), elvis_file:file(), no_specs_config()) ->
-                  [elvis_result:item()].
+    [elvis_result:item()].
 no_specs(ElvisConfig, RuleTarget, RuleConfig) ->
     TreeRootNode = get_root(ElvisConfig, RuleTarget, RuleConfig),
     SpecNodes =
         elvis_code:find(fun is_spec_attribute/1, TreeRootNode, #{traverse => all, mode => node}),
 
-    lists:foldl(fun(SpecNode, Acc) ->
-                   FunctionName = ktn_code:attr(name, SpecNode),
-                   {Line, _Col} = ktn_code:attr(location, SpecNode),
-                   [elvis_result:new(item, ?NO_SPECS_MSG, [FunctionName, Line], Line) | Acc]
-                end,
-                [],
-                SpecNodes).
+    lists:foldl(
+        fun(SpecNode, Acc) ->
+            FunctionName = ktn_code:attr(name, SpecNode),
+            {Line, _Col} = ktn_code:attr(location, SpecNode),
+            [elvis_result:new(item, ?NO_SPECS_MSG, [FunctionName, Line], Line) | Acc]
+        end,
+        [],
+        SpecNodes
+    ).
 
 is_spec_attribute(Node) ->
     ktn_code:type(Node) =:= spec.
 
 -type no_block_expressions_config() :: #{ignore => [ignorable()]}.
 
--spec no_block_expressions(elvis_config:config(),
-                           elvis_file:file(),
-                           no_block_expressions_config()) ->
-                              [elvis_result:item()].
+-spec no_block_expressions(
+    elvis_config:config(),
+    elvis_file:file(),
+    no_block_expressions_config()
+) ->
+    [elvis_result:item()].
 no_block_expressions(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Tokens = ktn_code:attr(tokens, Root),
     BeginNodes = lists:filter(fun is_begin_node/1, Tokens),
-    lists:foldl(fun(BeginNode, Acc) ->
-                   {Line, _Col} = ktn_code:attr(location, BeginNode),
-                   [elvis_result:new(item, ?NO_BLOCK_EXPRESSIONS_MSG, [Line], Line) | Acc]
-                end,
-                [],
-                BeginNodes).
+    lists:foldl(
+        fun(BeginNode, Acc) ->
+            {Line, _Col} = ktn_code:attr(location, BeginNode),
+            [elvis_result:new(item, ?NO_BLOCK_EXPRESSIONS_MSG, [Line], Line) | Acc]
+        end,
+        [],
+        BeginNodes
+    ).
 
 is_begin_node(Node) ->
     ktn_code:type(Node) =:= 'begin'.
 
 eep_predef_macros() ->
     % From unexported epp:predef_macros/1
-    ['BASE_MODULE',
-     'BASE_MODULE_STRING',
-     'BEAM',
-     'FEATURE_AVAILABLE',
-     'FEATURE_ENABLED',
-     'FILE',
-     'FUNCTION_ARITY',
-     'FUNCTION_NAME',
-     'LINE',
-     'MACHINE',
-     'MODULE',
-     'MODULE_STRING',
-     'OTP_RELEASE'].
+    [
+        'BASE_MODULE',
+        'BASE_MODULE_STRING',
+        'BEAM',
+        'FEATURE_AVAILABLE',
+        'FEATURE_ENABLED',
+        'FILE',
+        'FUNCTION_ARITY',
+        'FUNCTION_NAME',
+        'LINE',
+        'MACHINE',
+        'MODULE',
+        'MODULE_STRING',
+        'OTP_RELEASE'
+    ].
 
 logger_macros() ->
     % From logger.hrl
-    ['LOG',
-     'LOG_ALERT',
-     'LOG_CRITICAL',
-     'LOG_DEBUG',
-     'LOG_EMERGENCY',
-     'LOG_ERROR',
-     'LOG_INFO',
-     'LOG_NOTICE',
-     'LOG_WARNING'].
+    [
+        'LOG',
+        'LOG_ALERT',
+        'LOG_CRITICAL',
+        'LOG_DEBUG',
+        'LOG_EMERGENCY',
+        'LOG_ERROR',
+        'LOG_INFO',
+        'LOG_NOTICE',
+        'LOG_WARNING'
+    ].
 
 -type no_space_after_pound_config() :: #{ignore => [ignorable()]}.
 
--spec no_space_after_pound(elvis_config:config(),
-                           elvis_file:file(),
-                           no_space_after_pound_config()) ->
-                              [elvis_result:item()].
+-spec no_space_after_pound(
+    elvis_config:config(),
+    elvis_file:file(),
+    no_space_after_pound_config()
+) ->
+    [elvis_result:item()].
 no_space_after_pound(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Tokens = ktn_code:attr(tokens, Root),
@@ -592,10 +810,12 @@ no_space_after_pound(Config, Target, RuleConfig) ->
 
 -define(PUNCTUATION_SYMBOLS, [',', ';', dot, '->', ':', '::', '|', '||']).
 
--spec operator_spaces(elvis_config:config(),
-                      elvis_file:file(),
-                      operator_spaces_config()) ->
-                         [elvis_result:item()].
+-spec operator_spaces(
+    elvis_config:config(),
+    elvis_file:file(),
+    operator_spaces_config()
+) ->
+    [elvis_result:item()].
 operator_spaces(Config, Target, RuleConfig) ->
     Rules = option(rules, RuleConfig, operator_spaces),
     {Src, #{encoding := Encoding}} = elvis_file:src(Target),
@@ -623,7 +843,7 @@ is_operator_node(Node) ->
     #{ignore => [ignorable()], rules => [{right | left, string()}]}.
 
 -spec no_space(elvis_config:config(), elvis_file:file(), no_space_config()) ->
-                  [elvis_result:item()].
+    [elvis_result:item()].
 no_space(Config, Target, RuleConfig) ->
     Rules = option(rules, RuleConfig, no_space),
     Root = get_root(Config, Target, RuleConfig),
@@ -632,16 +852,22 @@ no_space(Config, Target, RuleConfig) ->
     {Src, #{encoding := Encoding}} = elvis_file:src(Target),
     Lines = elvis_utils:split_all_lines(Src),
     AllSpaceUntilText =
-        [{Text,
-          re:compile("^[ ]+"
-                     ++ re:replace(Text,
-                                   "(\\.|\\[|\\]|\\^|\\$|\\+|\\*|\\?|\\{|\\}|\\(|\\)|\\||\\\\)",
-                                   "\\\\\\1",
-                                   [{return, list}, global]))}
-         || {left, Text} <- Rules],
+        [
+            {Text,
+                re:compile(
+                    "^[ ]+" ++
+                        re:replace(
+                            Text,
+                            "(\\.|\\[|\\]|\\^|\\$|\\+|\\*|\\?|\\{|\\}|\\(|\\)|\\||\\\\)",
+                            "\\\\\\1",
+                            [{return, list}, global]
+                        )
+                )}
+         || {left, Text} <- Rules
+        ],
     FlatMap =
         fun(Rule) ->
-           check_spaces(Lines, TextNodes, Rule, Encoding, {should_not_have, AllSpaceUntilText})
+            check_spaces(Lines, TextNodes, Rule, Encoding, {should_not_have, AllSpaceUntilText})
         end,
     lists:flatmap(FlatMap, Rules).
 
@@ -657,7 +883,7 @@ is_punctuation_token(Node) ->
 -type nesting_level_config() :: #{ignore => [ignorable()], level => integer()}.
 
 -spec nesting_level(elvis_config:config(), elvis_file:file(), nesting_level_config()) ->
-                       [elvis_result:item()].
+    [elvis_result:item()].
 nesting_level(Config, Target, RuleConfig) ->
     Level = option(level, RuleConfig, nesting_level),
 
@@ -668,7 +894,7 @@ nesting_level(Config, Target, RuleConfig) ->
 -type god_modules_config() :: #{ignore => [ignorable()], limit => integer()}.
 
 -spec god_modules(elvis_config:config(), elvis_file:file(), god_modules_config()) ->
-                     [elvis_result:item()].
+    [elvis_result:item()].
 god_modules(Config, Target, RuleConfig) ->
     Limit = option(limit, RuleConfig, god_modules),
 
@@ -685,7 +911,7 @@ god_modules(Config, Target, RuleConfig) ->
     end.
 
 -spec no_if_expression(elvis_config:config(), elvis_file:file(), empty_rule_config()) ->
-                          [elvis_result:item()].
+    [elvis_result:item()].
 no_if_expression(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Predicate = fun(Node) -> ktn_code:type(Node) == 'if' end,
@@ -697,10 +923,12 @@ no_if_expression(Config, Target, RuleConfig) ->
             lists:map(ResultFun, IfExprs)
     end.
 
--spec invalid_dynamic_call(elvis_config:config(),
-                           elvis_file:file(),
-                           empty_rule_config()) ->
-                              [elvis_result:item()].
+-spec invalid_dynamic_call(
+    elvis_config:config(),
+    elvis_file:file(),
+    empty_rule_config()
+) ->
+    [elvis_result:item()].
 invalid_dynamic_call(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
 
@@ -712,10 +940,12 @@ invalid_dynamic_call(Config, Target, RuleConfig) ->
             []
     end.
 
--spec used_ignored_variable(elvis_config:config(),
-                            elvis_file:file(),
-                            empty_rule_config()) ->
-                               [elvis_result:item()].
+-spec used_ignored_variable(
+    elvis_config:config(),
+    elvis_file:file(),
+    empty_rule_config()
+) ->
+    [elvis_result:item()].
 used_ignored_variable(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     ResultFun = result_node_line_col_fun(?USED_IGNORED_VAR_MSG),
@@ -728,20 +958,20 @@ used_ignored_variable(Config, Target, RuleConfig) ->
     end.
 
 -spec no_behavior_info(elvis_config:config(), elvis_file:file(), empty_rule_config()) ->
-                          [elvis_result:item()].
+    [elvis_result:item()].
 no_behavior_info(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Children = ktn_code:content(Root),
 
     FilterFun =
         fun(Node) ->
-           case ktn_code:type(Node) of
-               function ->
-                   Name = ktn_code:attr(name, Node),
-                   lists:member(Name, [behavior_info, behaviour_info]);
-               _ ->
-                   false
-           end
+            case ktn_code:type(Node) of
+                function ->
+                    Name = ktn_code:attr(name, Node),
+                    lists:member(Name, [behavior_info, behaviour_info]);
+                _ ->
+                    false
+            end
         end,
 
     ResultFun = result_node_line_fun(?NO_BEHAVIOR_INFO),
@@ -755,10 +985,12 @@ no_behavior_info(Config, Target, RuleConfig) ->
 
 -type module_naming_convention_config() :: #{ignore => [ignorable()], regex => string()}.
 
--spec module_naming_convention(elvis_config:config(),
-                               elvis_file:file(),
-                               module_naming_convention_config()) ->
-                                  [elvis_result:item()].
+-spec module_naming_convention(
+    elvis_config:config(),
+    elvis_file:file(),
+    module_naming_convention_config()
+) ->
+    [elvis_result:item()].
 module_naming_convention(Config, Target, RuleConfig) ->
     Regex = option(regex, RuleConfig, module_naming_convention),
     ForbiddenRegex = option(forbidden_regex, RuleConfig, module_naming_convention),
@@ -781,9 +1013,11 @@ module_naming_convention(Config, Target, RuleConfig) ->
                         undefined ->
                             [];
                         ForbiddenRegex ->
-                            is_forbidden_module_name(ModuleNameStr,
-                                                     ForbiddenRegex,
-                                                     ?FORBIDDEN_MODULE_NAMING_CONVENTION_MSG)
+                            is_forbidden_module_name(
+                                ModuleNameStr,
+                                ForbiddenRegex,
+                                ?FORBIDDEN_MODULE_NAMING_CONVENTION_MSG
+                            )
                     end
             end;
         true ->
@@ -801,10 +1035,12 @@ is_forbidden_module_name(Target, Regex, Message) ->
             []
     end.
 
--spec state_record_and_type(elvis_config:config(),
-                            elvis_file:file(),
-                            empty_rule_config()) ->
-                               [elvis_result:item()].
+-spec state_record_and_type(
+    elvis_config:config(),
+    elvis_file:file(),
+    empty_rule_config()
+) ->
+    [elvis_result:item()].
 state_record_and_type(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     case is_otp_module(Root) of
@@ -825,10 +1061,12 @@ state_record_and_type(Config, Target, RuleConfig) ->
             []
     end.
 
--spec no_spec_with_records(elvis_config:config(),
-                           elvis_file:file(),
-                           empty_rule_config()) ->
-                              [elvis_result:item()].
+-spec no_spec_with_records(
+    elvis_config:config(),
+    elvis_file:file(),
+    empty_rule_config()
+) ->
+    [elvis_result:item()].
 no_spec_with_records(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     case elvis_code:find(fun spec_includes_record/1, Root) of
@@ -842,10 +1080,12 @@ no_spec_with_records(Config, Target, RuleConfig) ->
 -type dont_repeat_yourself_config() ::
     #{ignore => [ignorable()], min_complexity => non_neg_integer()}.
 
--spec dont_repeat_yourself(elvis_config:config(),
-                           elvis_file:file(),
-                           dont_repeat_yourself_config()) ->
-                              [elvis_result:item()].
+-spec dont_repeat_yourself(
+    elvis_config:config(),
+    elvis_file:file(),
+    dont_repeat_yourself_config()
+) ->
+    [elvis_result:item()].
 dont_repeat_yourself(Config, Target, RuleConfig) ->
     MinComplexity = option(min_complexity, RuleConfig, dont_repeat_yourself),
 
@@ -854,25 +1094,28 @@ dont_repeat_yourself(Config, Target, RuleConfig) ->
     Nodes = find_repeated_nodes(Root, MinComplexity),
 
     LocationCat =
-        fun ({Line, Col}, "") ->
+        fun
+            ({Line, Col}, "") ->
                 io_lib:format("(~p, ~p)", [Line, Col]);
             ({Line, Col}, Str) ->
                 io_lib:format("~s, (~p, ~p)", [Str, Line, Col])
         end,
     ResultFun =
         fun([{Line, _} | _] = Locations) ->
-           LocationsStr = lists:foldl(LocationCat, "", Locations),
-           Info = [LocationsStr],
-           Msg = ?DONT_REPEAT_YOURSELF,
-           elvis_result:new(item, Msg, Info, Line)
+            LocationsStr = lists:foldl(LocationCat, "", Locations),
+            Info = [LocationsStr],
+            Msg = ?DONT_REPEAT_YOURSELF,
+            elvis_result:new(item, Msg, Info, Line)
         end,
 
     lists:map(ResultFun, Nodes).
 
--spec max_module_length(elvis_config:config(),
-                        elvis_file:file(),
-                        max_module_length_config()) ->
-                           [elvis_result:item()].
+-spec max_module_length(
+    elvis_config:config(),
+    elvis_file:file(),
+    max_module_length_config()
+) ->
+    [elvis_result:item()].
 max_module_length(Config, Target, RuleConfig) ->
     MaxLength = option(max_length, RuleConfig, max_module_length),
     CountComments = option(count_comments, RuleConfig, max_module_length),
@@ -891,8 +1134,8 @@ max_module_length(Config, Target, RuleConfig) ->
 
     FilterFun =
         fun(Line) ->
-           (CountComments orelse not line_is_comment(Line))
-           andalso (CountWhitespace orelse not line_is_whitespace(Line))
+            (CountComments orelse not line_is_comment(Line)) andalso
+                (CountWhitespace orelse not line_is_whitespace(Line))
         end,
     Lines =
         case elvis_utils:split_all_lines(Src, [trim]) of
@@ -922,79 +1165,93 @@ max_module_length(Config, Target, RuleConfig) ->
 
 -type max_anonymous_function_arity_config() :: #{max_arity => non_neg_integer()}.
 
--spec max_anonymous_function_arity(elvis_config:config(),
-                                   elvis_file:file(),
-                                   max_anonymous_function_arity_config()) ->
-                                      [elvis_result:item()].
+-spec max_anonymous_function_arity(
+    elvis_config:config(),
+    elvis_file:file(),
+    max_anonymous_function_arity_config()
+) ->
+    [elvis_result:item()].
 max_anonymous_function_arity(Config, Target, RuleConfig) ->
     MaxArity = option(max_arity, RuleConfig, max_anonymous_function_arity),
     Root = get_root(Config, Target, RuleConfig),
     IsClause = fun(Node) -> ktn_code:type(Node) == clause end,
     IsFun =
         fun(Node) ->
-           %% Not having clauses means it's something like fun mod:f/10 and we don't want
-           %% this rule to raise warnings for those. max_function_arity should take care of them.
-           ktn_code:type(Node) == 'fun' andalso [] /= elvis_code:find(IsClause, Node)
+            %% Not having clauses means it's something like fun mod:f/10 and we don't want
+            %% this rule to raise warnings for those. max_function_arity should take care of them.
+            ktn_code:type(Node) == 'fun' andalso [] /= elvis_code:find(IsClause, Node)
         end,
     Funs = elvis_code:find(IsFun, Root),
-    lists:filtermap(fun(Fun) ->
-                       [FirstClause | _] = elvis_code:find(IsClause, Fun),
-                       case length(ktn_code:node_attr(pattern, FirstClause)) of
-                           Arity when Arity =< MaxArity ->
-                               false;
-                           Arity ->
-                               {Line, _} = ktn_code:attr(location, Fun),
-                               Info = [Line, Arity, MaxArity],
-                               {true,
-                                elvis_result:new(item,
-                                                 ?MAX_ANONYMOUS_FUNCTION_ARITY_MSG,
-                                                 Info,
-                                                 Line)}
-                       end
-                    end,
-                    Funs).
+    lists:filtermap(
+        fun(Fun) ->
+            [FirstClause | _] = elvis_code:find(IsClause, Fun),
+            case length(ktn_code:node_attr(pattern, FirstClause)) of
+                Arity when Arity =< MaxArity ->
+                    false;
+                Arity ->
+                    {Line, _} = ktn_code:attr(location, Fun),
+                    Info = [Line, Arity, MaxArity],
+                    {true,
+                        elvis_result:new(
+                            item,
+                            ?MAX_ANONYMOUS_FUNCTION_ARITY_MSG,
+                            Info,
+                            Line
+                        )}
+            end
+        end,
+        Funs
+    ).
 
 -type max_function_arity_config() ::
     #{max_arity => non_neg_integer(), non_exported_max_arity => pos_integer()}.
 
--spec max_function_arity(elvis_config:config(),
-                         elvis_file:file(),
-                         max_function_arity_config()) ->
-                            [elvis_result:item()].
+-spec max_function_arity(
+    elvis_config:config(),
+    elvis_file:file(),
+    max_function_arity_config()
+) ->
+    [elvis_result:item()].
 max_function_arity(Config, Target, RuleConfig) ->
     ExportedMaxArity = option(max_arity, RuleConfig, max_function_arity),
     NonExportedMaxArity =
-        specific_or_default(option(non_exported_max_arity, RuleConfig, max_function_arity),
-                            ExportedMaxArity),
+        specific_or_default(
+            option(non_exported_max_arity, RuleConfig, max_function_arity),
+            ExportedMaxArity
+        ),
     Root = get_root(Config, Target, RuleConfig),
     IsFunction = fun(Node) -> ktn_code:type(Node) == function end,
     Functions = elvis_code:find(IsFunction, Root),
-    lists:filtermap(fun(#{attrs := #{arity := Arity, name := Name}} = Function) ->
-                       IsExported =
-                           lists:member({Name, Arity}, elvis_code:exported_functions(Root)),
-                       MaxArity =
-                           case IsExported of
-                               true ->
-                                   ExportedMaxArity;
-                               false ->
-                                   NonExportedMaxArity
-                           end,
-                       case ktn_code:attr(arity, Function) of
-                           Arity when Arity =< MaxArity ->
-                               false;
-                           Arity ->
-                               Name = ktn_code:attr(name, Function),
-                               {Line, _} = ktn_code:attr(location, Function),
-                               Info = [Name, Arity, MaxArity],
-                               {true, elvis_result:new(item, ?MAX_FUNCTION_ARITY_MSG, Info, Line)}
-                       end
-                    end,
-                    Functions).
+    lists:filtermap(
+        fun(#{attrs := #{arity := Arity, name := Name}} = Function) ->
+            IsExported =
+                lists:member({Name, Arity}, elvis_code:exported_functions(Root)),
+            MaxArity =
+                case IsExported of
+                    true ->
+                        ExportedMaxArity;
+                    false ->
+                        NonExportedMaxArity
+                end,
+            case ktn_code:attr(arity, Function) of
+                Arity when Arity =< MaxArity ->
+                    false;
+                Arity ->
+                    Name = ktn_code:attr(name, Function),
+                    {Line, _} = ktn_code:attr(location, Function),
+                    Info = [Name, Arity, MaxArity],
+                    {true, elvis_result:new(item, ?MAX_FUNCTION_ARITY_MSG, Info, Line)}
+            end
+        end,
+        Functions
+    ).
 
--spec max_function_clause_length(elvis_config:config(),
-                                 elvis_file:file(),
-                                 max_function_length_config()) ->
-                                    [elvis_result:item()].
+-spec max_function_clause_length(
+    elvis_config:config(),
+    elvis_file:file(),
+    max_function_length_config()
+) ->
+    [elvis_result:item()].
 max_function_clause_length(Config, Target, RuleConfig) ->
     MaxLength = option(max_length, RuleConfig, max_function_length),
     CountComments = option(count_comments, RuleConfig, max_function_length),
@@ -1010,49 +1267,53 @@ max_function_clause_length(Config, Target, RuleConfig) ->
     % clause
     FilterClause =
         fun(Line) ->
-           (CountComments orelse not line_is_comment(Line))
-           andalso (CountWhitespace orelse not line_is_whitespace(Line))
+            (CountComments orelse not line_is_comment(Line)) andalso
+                (CountWhitespace orelse not line_is_whitespace(Line))
         end,
 
     PairClause =
         fun(ClauseNode, {Result, PrevAccNum}) ->
-           {Min, Max} = node_line_limits(ClauseNode),
-           FunLines = lists:sublist(Lines, Min, Max - Min + 1),
-           FilteredLines = lists:filter(FilterClause, FunLines),
-           L = length(FilteredLines),
-           AccNum = PrevAccNum + 1,
-           ClauseNumber = parse_clause_num(AccNum),
-           {[{Min, ClauseNumber, L} | Result], AccNum}
+            {Min, Max} = node_line_limits(ClauseNode),
+            FunLines = lists:sublist(Lines, Min, Max - Min + 1),
+            FilteredLines = lists:filter(FilterClause, FunLines),
+            L = length(FilteredLines),
+            AccNum = PrevAccNum + 1,
+            ClauseNumber = parse_clause_num(AccNum),
+            {[{Min, ClauseNumber, L} | Result], AccNum}
         end,
 
     % fun
     PairFun =
         fun(FunctionNode) ->
-           Name = ktn_code:attr(name, FunctionNode),
-           Arity = ktn_code:attr(arity, FunctionNode),
+            Name = ktn_code:attr(name, FunctionNode),
+            Arity = ktn_code:attr(arity, FunctionNode),
 
-           IsClause = fun(Node) -> ktn_code:type(Node) == clause end,
-           Clauses = elvis_code:find(IsClause, FunctionNode),
+            IsClause = fun(Node) -> ktn_code:type(Node) == clause end,
+            Clauses = elvis_code:find(IsClause, FunctionNode),
 
-           {ClauseLenInfos, _} = lists:foldl(PairClause, {[], 0}, Clauses),
+            {ClauseLenInfos, _} = lists:foldl(PairClause, {[], 0}, Clauses),
 
-           [{Name, Arity, Min, StringClauseNumber, L}
-            || {Min, StringClauseNumber, L} <- ClauseLenInfos]
+            [
+                {Name, Arity, Min, StringClauseNumber, L}
+             || {Min, StringClauseNumber, L} <- ClauseLenInfos
+            ]
         end,
 
     ClauseLenInfos =
         lists:reverse(
             lists:append(
-                lists:map(PairFun, Functions0))),
+                lists:map(PairFun, Functions0)
+            )
+        ),
 
     MaxLengthPred = fun({_, _, _, _, L}) -> L > MaxLength end,
     ClauseLenMaxPairs = lists:filter(MaxLengthPred, ClauseLenInfos),
 
     ResultFun =
         fun({Name, Arity, StartPos, ClauseNumber, L}) ->
-           Info = [ClauseNumber, Name, Arity, L, MaxLength],
-           Msg = ?MAX_FUNCTION_CLAUSE_LENGTH,
-           elvis_result:new(item, Msg, Info, StartPos)
+            Info = [ClauseNumber, Name, Arity, L, MaxLength],
+            Msg = ?MAX_FUNCTION_CLAUSE_LENGTH,
+            elvis_result:new(item, Msg, Info, StartPos)
         end,
     lists:map(ResultFun, ClauseLenMaxPairs).
 
@@ -1067,10 +1328,12 @@ parse_clause_num(Num) when Num rem 10 == 3 ->
 parse_clause_num(Num) ->
     integer_to_list(Num) ++ "th".
 
--spec max_function_length(elvis_config:config(),
-                          elvis_file:file(),
-                          max_function_length_config()) ->
-                             [elvis_result:item()].
+-spec max_function_length(
+    elvis_config:config(),
+    elvis_file:file(),
+    max_function_length_config()
+) ->
+    [elvis_result:item()].
 max_function_length(Config, Target, RuleConfig) ->
     MaxLength = option(max_length, RuleConfig, max_function_length),
     CountComments = option(count_comments, RuleConfig, max_function_length),
@@ -1084,19 +1347,19 @@ max_function_length(Config, Target, RuleConfig) ->
     Functions0 = elvis_code:find(IsFunction, Root),
     FilterFun =
         fun(Line) ->
-           (CountComments orelse not line_is_comment(Line))
-           andalso (CountWhitespace orelse not line_is_whitespace(Line))
+            (CountComments orelse not line_is_comment(Line)) andalso
+                (CountWhitespace orelse not line_is_whitespace(Line))
         end,
 
     PairFun =
         fun(FunctionNode) ->
-           Name = ktn_code:attr(name, FunctionNode),
-           Arity = ktn_code:attr(arity, FunctionNode),
-           {Min, Max} = node_line_limits(FunctionNode),
-           FunLines = lists:sublist(Lines, Min, Max - Min + 1),
-           FilteredLines = lists:filter(FilterFun, FunLines),
-           L = length(FilteredLines),
-           {Name, Arity, Min, L}
+            Name = ktn_code:attr(name, FunctionNode),
+            Arity = ktn_code:attr(arity, FunctionNode),
+            {Min, Max} = node_line_limits(FunctionNode),
+            FunLines = lists:sublist(Lines, Min, Max - Min + 1),
+            FilteredLines = lists:filter(FilterFun, FunLines),
+            L = length(FilteredLines),
+            {Name, Arity, Min, L}
         end,
     FunLenInfos = lists:map(PairFun, Functions0),
     MaxLengthPred = fun({_, _, _, L}) -> L > MaxLength end,
@@ -1104,9 +1367,9 @@ max_function_length(Config, Target, RuleConfig) ->
 
     ResultFun =
         fun({Name, Arity, StartPos, L}) ->
-           Info = [Name, Arity, L, MaxLength],
-           Msg = ?MAX_FUNCTION_LENGTH,
-           elvis_result:new(item, Msg, Info, StartPos)
+            Info = [Name, Arity, L, MaxLength],
+            Msg = ?MAX_FUNCTION_LENGTH,
+            elvis_result:new(item, Msg, Info, StartPos)
         end,
     lists:map(ResultFun, FunLenMaxPairs).
 
@@ -1115,7 +1378,7 @@ max_function_length(Config, Target, RuleConfig) ->
     #{ignore => [ignorable()], no_call_functions => [function_spec()]}.
 
 -spec no_call(elvis_config:config(), elvis_file:file(), no_call_config()) ->
-                 [elvis_result:item()].
+    [elvis_result:item()].
 no_call(Config, Target, RuleConfig) ->
     DefaultFns = option(no_call_functions, RuleConfig, no_call),
     no_call_common(Config, Target, DefaultFns, ?NO_CALL_MSG, RuleConfig).
@@ -1124,7 +1387,7 @@ no_call(Config, Target, RuleConfig) ->
     #{ignore => [ignorable()], debug_functions => [function_spec()]}.
 
 -spec no_debug_call(elvis_config:config(), elvis_file:file(), no_debug_call_config()) ->
-                       [elvis_result:item()].
+    [elvis_result:item()].
 no_debug_call(Config, Target, RuleConfig) ->
     DefaultFns = option(debug_functions, RuleConfig, no_debug_call),
     no_call_common(Config, Target, DefaultFns, ?NO_DEBUG_CALL_MSG, RuleConfig).
@@ -1132,10 +1395,12 @@ no_debug_call(Config, Target, RuleConfig) ->
 -type no_common_caveats_call_config() ::
     #{ignore => [ignorable()], caveat_functions => [function_spec()]}.
 
--spec no_common_caveats_call(elvis_config:config(),
-                             elvis_file:file(),
-                             no_common_caveats_call_config()) ->
-                                [elvis_result:item()].
+-spec no_common_caveats_call(
+    elvis_config:config(),
+    elvis_file:file(),
+    no_common_caveats_call_config()
+) ->
+    [elvis_result:item()].
 no_common_caveats_call(Config, Target, RuleConfig) ->
     DefaultFns = option(caveat_functions, RuleConfig, no_common_caveats_call),
     no_call_common(Config, Target, DefaultFns, ?NO_COMMON_CAVEATS_CALL_MSG, RuleConfig).
@@ -1145,8 +1410,8 @@ node_line_limits(FunctionNode) ->
     Zipper = elvis_code:code_zipper(FunctionNode),
     LineFun =
         fun(N) ->
-           {L, _} = ktn_code:attr(location, N),
-           L
+            {L, _} = ktn_code:attr(location, N),
+            L
         end,
     % The first number in `lineNums' list is the location of the first
     % line of the function. That's why we use it for the `Min' value.
@@ -1157,13 +1422,17 @@ node_line_limits(FunctionNode) ->
     % macros because most of the time macros are defined at the beginning of
     % the module, but your function's first line could be in the middle or
     % even at the end of the module.
-    [Min | _] = LineNums, % Min = first function's line
+
+    % Min = first function's line
+    [Min | _] = LineNums,
     {Min, Max}.
 
--spec no_nested_try_catch(elvis_config:config(),
-                          elvis_file:file(),
-                          empty_rule_config()) ->
-                             [elvis_result:item()].
+-spec no_nested_try_catch(
+    elvis_config:config(),
+    elvis_file:file(),
+    empty_rule_config()
+) ->
+    [elvis_result:item()].
 no_nested_try_catch(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Predicate = fun(Node) -> ktn_code:type(Node) == 'try' end,
@@ -1176,7 +1445,7 @@ no_nested_try_catch(Config, Target, RuleConfig) ->
     end.
 
 -spec no_successive_maps(elvis_config:config(), elvis_file:file(), empty_rule_config()) ->
-                            [elvis_result:item()].
+    [elvis_result:item()].
 no_successive_maps(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Predicate = fun(Node) -> ktn_code:type(Node) == map end,
@@ -1190,14 +1459,18 @@ no_successive_maps(Config, Target, RuleConfig) ->
     end.
 
 -type atom_naming_convention_config() ::
-    #{ignore => [ignorable()],
-      regex => string(),
-      enclosed_atoms => same | string()}.
+    #{
+        ignore => [ignorable()],
+        regex => string(),
+        enclosed_atoms => same | string()
+    }.
 
--spec atom_naming_convention(elvis_config:config(),
-                             elvis_file:file(),
-                             atom_naming_convention_config()) ->
-                                [elvis_result:item()].
+-spec atom_naming_convention(
+    elvis_config:config(),
+    elvis_file:file(),
+    atom_naming_convention_config()
+) ->
+    [elvis_result:item()].
 atom_naming_convention(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Regex = option(regex, RuleConfig, atom_naming_convention),
@@ -1205,20 +1478,24 @@ atom_naming_convention(Config, Target, RuleConfig) ->
     RegexEnclosed =
         specific_or_default(option(enclosed_atoms, RuleConfig, atom_naming_convention), Regex),
     ForbiddenEnclosedRegex =
-        specific_or_default(option(forbidden_enclosed_regex, RuleConfig, atom_naming_convention),
-                            ForbiddenRegex),
+        specific_or_default(
+            option(forbidden_enclosed_regex, RuleConfig, atom_naming_convention),
+            ForbiddenRegex
+        ),
     AtomNodes = elvis_code:find(fun is_atom_node/1, Root, #{traverse => all, mode => zipper}),
-    check_atom_names(Regex,
-                     ForbiddenRegex,
-                     RegexEnclosed,
-                     ForbiddenEnclosedRegex,
-                     AtomNodes,
-                     []).
+    check_atom_names(
+        Regex,
+        ForbiddenRegex,
+        RegexEnclosed,
+        ForbiddenEnclosedRegex,
+        AtomNodes,
+        []
+    ).
 
 -type no_init_lists_config() :: #{behaviours => [atom()]}.
 
 -spec no_init_lists(elvis_config:config(), elvis_file:file(), no_init_lists_config()) ->
-                       [elvis_result:item()].
+    [elvis_result:item()].
 no_init_lists(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
 
@@ -1227,9 +1504,9 @@ no_init_lists(Config, Target, RuleConfig) ->
             true ->
                 IsInit1Function =
                     fun(Node) ->
-                       ktn_code:type(Node) == function
-                       andalso ktn_code:attr(name, Node) == init
-                       andalso ktn_code:attr(arity, Node) == 1
+                        ktn_code:type(Node) == function andalso
+                            ktn_code:attr(name, Node) == init andalso
+                            ktn_code:attr(arity, Node) == 1
                     end,
 
                 case elvis_code:find(IsInit1Function, Root) of
@@ -1252,9 +1529,9 @@ no_init_lists(Config, Target, RuleConfig) ->
 
     ResultFun =
         fun(Location) ->
-           Info = [Location],
-           Msg = ?NO_INIT_LISTS_MSG,
-           elvis_result:new(item, Msg, Info, Location)
+            Info = [Location],
+            Msg = ?NO_INIT_LISTS_MSG,
+            elvis_result:new(item, Msg, Info, Location)
         end,
 
     lists:map(ResultFun, ListInitClauses).
@@ -1263,12 +1540,17 @@ is_relevant_behaviour(Root, RuleConfig) ->
     ConfigBehaviors = option(behaviours, RuleConfig, no_init_lists),
     IsBehaviour = fun(Node) -> ktn_code:type(Node) == behaviour end,
     Behaviours = elvis_code:find(IsBehaviour, Root),
-    lists:any(fun(Elem) -> Elem end,
-              lists:map(fun(BehaviourNode) ->
-                           lists:member(
-                               ktn_code:attr(value, BehaviourNode), ConfigBehaviors)
-                        end,
-                        Behaviours)).
+    lists:any(
+        fun(Elem) -> Elem end,
+        lists:map(
+            fun(BehaviourNode) ->
+                lists:member(
+                    ktn_code:attr(value, BehaviourNode), ConfigBehaviors
+                )
+            end,
+            Behaviours
+        )
+    ).
 
 filter_list_clause_location(Clause) ->
     [Attribute] = ktn_code:node_attr(pattern, Clause),
@@ -1288,10 +1570,12 @@ is_list_node(#{type := match, content := Content}) ->
 is_list_node(_) ->
     false.
 
--spec ms_transform_included(elvis_config:config(),
-                            elvis_file:file(),
-                            empty_rule_config()) ->
-                               [elvis_result:item()].
+-spec ms_transform_included(
+    elvis_config:config(),
+    elvis_file:file(),
+    empty_rule_config()
+) ->
+    [elvis_result:item()].
 ms_transform_included(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
 
@@ -1301,9 +1585,9 @@ ms_transform_included(Config, Target, RuleConfig) ->
 
     ResultFun =
         fun(Location) ->
-           Info = [Location],
-           Msg = ?MS_TRANSFORM_INCLUDED_MSG,
-           elvis_result:new(item, Msg, Info, Location)
+            Info = [Location],
+            Msg = ?MS_TRANSFORM_INCLUDED_MSG,
+            elvis_result:new(item, Msg, Info, Location)
         end,
 
     case IsIncluded of
@@ -1313,36 +1597,40 @@ ms_transform_included(Config, Target, RuleConfig) ->
             lists:map(ResultFun, FunctionCalls)
     end.
 
--spec no_boolean_in_comparison(elvis_config:config(),
-                               elvis_file:file(),
-                               empty_rule_config()) ->
-                                  [elvis_result:item()].
+-spec no_boolean_in_comparison(
+    elvis_config:config(),
+    elvis_file:file(),
+    empty_rule_config()
+) ->
+    [elvis_result:item()].
 no_boolean_in_comparison(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
 
     IsBoolean =
         fun(Node) ->
-           lists:member(
-               ktn_code:attr(value, Node), [true, false])
+            lists:member(
+                ktn_code:attr(value, Node), [true, false]
+            )
         end,
 
     IsComparisonWithBoolean =
         fun(Node) ->
-           Content = ktn_code:content(Node),
-           ktn_code:type(Node) == op
-           andalso '==' =:= ktn_code:attr(operation, Node)
-           andalso lists:any(IsBoolean, Content)
+            Content = ktn_code:content(Node),
+            ktn_code:type(Node) == op andalso
+                '==' =:= ktn_code:attr(operation, Node) andalso
+                lists:any(IsBoolean, Content)
         end,
     ComparisonsWithBoolean =
         lists:uniq(
-            elvis_code:find(IsComparisonWithBoolean, Root, #{traverse => all})),
+            elvis_code:find(IsComparisonWithBoolean, Root, #{traverse => all})
+        ),
 
     ResultFun =
         fun(Node) ->
-           {Line, _} = ktn_code:attr(location, Node),
-           Info = [Line],
-           Msg = ?NO_BOOLEAN_IN_COMPARISON,
-           elvis_result:new(item, Msg, Info, Line)
+            {Line, _} = ktn_code:attr(location, Node),
+            Info = [Line],
+            Msg = ?NO_BOOLEAN_IN_COMPARISON,
+            elvis_result:new(item, Msg, Info, Line)
         end,
 
     lists:map(ResultFun, ComparisonsWithBoolean).
@@ -1368,52 +1656,57 @@ is_ets_fun2ms(Node) ->
 -spec has_include_ms_transform(ktn_code:tree_node()) -> boolean().
 has_include_ms_transform(Root) ->
     Fun = fun(Node) ->
-             ktn_code:type(Node) == include_lib
-             andalso ktn_code:attr(value, Node) == "stdlib/include/ms_transform.hrl"
-          end,
+        ktn_code:type(Node) == include_lib andalso
+            ktn_code:attr(value, Node) == "stdlib/include/ms_transform.hrl"
+    end,
 
     [] /= elvis_code:find(Fun, Root).
 
 -spec no_throw(elvis_config:config(), elvis_file:file(), empty_rule_config()) ->
-                  [elvis_result:item()].
+    [elvis_result:item()].
 no_throw(Config, Target, RuleConfig) ->
     Zipper =
-        fun(Node) -> lists:any(fun(T) -> is_call(Node, T) end, [{throw, 1}, {erlang, throw, 1}])
+        fun(Node) ->
+            lists:any(fun(T) -> is_call(Node, T) end, [{throw, 1}, {erlang, throw, 1}])
         end,
     Root = get_root(Config, Target, RuleConfig),
     ThrowNodes = elvis_code:find(Zipper, Root),
-    lists:foldl(fun(ThrowNode, AccIn) ->
-                   {Line, _} = ktn_code:attr(location, ThrowNode),
-                   [elvis_result:new(item, ?NO_THROW_MSG, [Line], Line) | AccIn]
-                end,
-                [],
-                ThrowNodes).
+    lists:foldl(
+        fun(ThrowNode, AccIn) ->
+            {Line, _} = ktn_code:attr(location, ThrowNode),
+            [elvis_result:new(item, ?NO_THROW_MSG, [Line], Line) | AccIn]
+        end,
+        [],
+        ThrowNodes
+    ).
 
 -spec no_dollar_space(elvis_config:config(), elvis_file:file(), empty_rule_config()) ->
-                         [elvis_result:item()].
+    [elvis_result:item()].
 no_dollar_space(Config, Target, RuleConfig) ->
     IsDollarSpace =
         fun(Node) -> ktn_code:type(Node) == char andalso ktn_code:attr(text, Node) == "$ " end,
     Root = get_root(Config, Target, RuleConfig),
     Opts = #{mode => node, traverse => all},
     DollarSpaceNodes = elvis_code:find(IsDollarSpace, Root, Opts),
-    lists:map(fun(ThrowNode) ->
-                 {Line, _} = ktn_code:attr(location, ThrowNode),
-                 elvis_result:new(item, ?NO_DOLLAR_SPACE_MSG, [Line], Line)
-              end,
-              DollarSpaceNodes).
+    lists:map(
+        fun(ThrowNode) ->
+            {Line, _} = ktn_code:attr(location, ThrowNode),
+            elvis_result:new(item, ?NO_DOLLAR_SPACE_MSG, [Line], Line)
+        end,
+        DollarSpaceNodes
+    ).
 
 -type no_author_config() :: #{ignore => [ignorable()]}.
 
 -spec no_author(elvis_config:config(), elvis_file:file(), no_author_config()) ->
-                   [elvis_result:item()].
+    [elvis_result:item()].
 no_author(Config, Target, RuleConfig) ->
     no_attribute(author, ?NO_AUTHOR_MSG, Config, Target, RuleConfig).
 
 -type no_import_config() :: #{ignore => [ignorable()]}.
 
 -spec no_import(elvis_config:config(), elvis_file:file(), no_import_config()) ->
-                   [elvis_result:item()].
+    [elvis_result:item()].
 no_import(Config, Target, RuleConfig) ->
     no_attribute(import, ?NO_IMPORT_MSG, Config, Target, RuleConfig).
 
@@ -1421,84 +1714,102 @@ no_attribute(Attribute, Msg, Config, Target, RuleConfig) ->
     Zipper = fun(Node) -> ktn_code:type(Node) =:= Attribute end,
     Root = get_root(Config, Target, RuleConfig),
     Nodes = elvis_code:find(Zipper, Root),
-    lists:map(fun(Node) ->
-                 {Line, _} = ktn_code:attr(location, Node),
-                 elvis_result:new(item, Msg, [Line], Line)
-              end,
-              Nodes).
+    lists:map(
+        fun(Node) ->
+            {Line, _} = ktn_code:attr(location, Node),
+            elvis_result:new(item, Msg, [Line], Line)
+        end,
+        Nodes
+    ).
 
 -type no_catch_expressions_config() :: #{ignore => [ignorable()]}.
 
--spec no_catch_expressions(elvis_config:config(),
-                           elvis_file:file(),
-                           no_catch_expressions_config()) ->
-                              [elvis_result:item()].
+-spec no_catch_expressions(
+    elvis_config:config(),
+    elvis_file:file(),
+    no_catch_expressions_config()
+) ->
+    [elvis_result:item()].
 no_catch_expressions(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     CatchNodes = elvis_code:find(fun is_catch_node/1, Root),
-    lists:foldl(fun(CatchNode, Acc) ->
-                   {Line, _Col} = ktn_code:attr(location, CatchNode),
-                   [elvis_result:new(item, ?NO_CATCH_EXPRESSIONS_MSG, [Line], Line) | Acc]
-                end,
-                [],
-                CatchNodes).
+    lists:foldl(
+        fun(CatchNode, Acc) ->
+            {Line, _Col} = ktn_code:attr(location, CatchNode),
+            [elvis_result:new(item, ?NO_CATCH_EXPRESSIONS_MSG, [Line], Line) | Acc]
+        end,
+        [],
+        CatchNodes
+    ).
 
 is_catch_node(Node) ->
     ktn_code:type(Node) =:= 'catch'.
 
 -type no_single_clause_case_config() :: #{ignore => [ignorable()]}.
 
--spec no_single_clause_case(elvis_config:config(),
-                            elvis_file:file(),
-                            no_single_clause_case_config()) ->
-                               [elvis_result:item()].
+-spec no_single_clause_case(
+    elvis_config:config(),
+    elvis_file:file(),
+    no_single_clause_case_config()
+) ->
+    [elvis_result:item()].
 no_single_clause_case(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     CaseNodes = elvis_code:find(fun is_single_clause_case_statement/1, Root),
-    lists:map(fun(CaseNode) ->
-                 {Line, _Col} = ktn_code:attr(location, CaseNode),
-                 elvis_result:new(item, ?NO_SINGLE_CLAUSE_CASE_MSG, [Line], Line)
-              end,
-              CaseNodes).
+    lists:map(
+        fun(CaseNode) ->
+            {Line, _Col} = ktn_code:attr(location, CaseNode),
+            elvis_result:new(item, ?NO_SINGLE_CLAUSE_CASE_MSG, [Line], Line)
+        end,
+        CaseNodes
+    ).
 
 is_single_clause_case_statement(Node) ->
-    ktn_code:type(Node) == 'case'
-    andalso length([Clause
-                    || SubNode <- ktn_code:content(Node),
-                       ktn_code:type(SubNode) == case_clauses,
-                       Clause <- ktn_code:content(SubNode)])
-            == 1.
+    ktn_code:type(Node) == 'case' andalso
+        length([
+            Clause
+         || SubNode <- ktn_code:content(Node),
+            ktn_code:type(SubNode) == case_clauses,
+            Clause <- ktn_code:content(SubNode)
+        ]) ==
+            1.
 
 -type no_match_in_condition_config() :: #{ignore => [ignorable()]}.
 
--spec no_match_in_condition(elvis_config:config(),
-                            elvis_file:file(),
-                            no_match_in_condition_config()) ->
-                               [elvis_result:item()].
+-spec no_match_in_condition(
+    elvis_config:config(),
+    elvis_file:file(),
+    no_match_in_condition_config()
+) ->
+    [elvis_result:item()].
 no_match_in_condition(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     CaseNodes = elvis_code:find(fun is_match_in_condition/1, Root),
-    lists:map(fun(CaseNode) ->
-                 {Line, _Col} = ktn_code:attr(location, CaseNode),
-                 elvis_result:new(item, ?NO_MATCH_IN_CONDITION_MSG, [Line], Line)
-              end,
-              CaseNodes).
+    lists:map(
+        fun(CaseNode) ->
+            {Line, _Col} = ktn_code:attr(location, CaseNode),
+            elvis_result:new(item, ?NO_MATCH_IN_CONDITION_MSG, [Line], Line)
+        end,
+        CaseNodes
+    ).
 
 is_match_in_condition(Node) ->
-    (ktn_code:type(Node) == case_expr orelse ktn_code:type(Node) == block)
-    andalso lists:any(fun is_match/1, ktn_code:content(Node)).
+    (ktn_code:type(Node) == case_expr orelse ktn_code:type(Node) == block) andalso
+        lists:any(fun is_match/1, ktn_code:content(Node)).
 
 is_match(Node) ->
     ktn_code:type(Node) == match orelse ktn_code:type(Node) == maybe_match.
 
 -type numeric_format_config() ::
-    #{ignore => [ignorable()],
-      regex => string(),
-      int_regex => same | string(),
-      float_regex => same | string()}.
+    #{
+        ignore => [ignorable()],
+        regex => string(),
+        int_regex => same | string(),
+        float_regex => same | string()
+    }.
 
 -spec numeric_format(elvis_config:config(), elvis_file:file(), numeric_format_config()) ->
-                        [elvis_result:item()].
+    [elvis_result:item()].
 numeric_format(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
     Regex = option(regex, RuleConfig, numeric_format),
@@ -1506,24 +1817,28 @@ numeric_format(Config, Target, RuleConfig) ->
     FloatRegex = specific_or_default(option(float_regex, RuleConfig, numeric_format), Regex),
     IntNodes = elvis_code:find(fun is_integer_node/1, Root, #{traverse => all, mode => node}),
     FloatNodes = elvis_code:find(fun is_float_node/1, Root, #{traverse => all, mode => node}),
-    check_numeric_format(IntRegex,
-                         IntNodes,
-                         check_numeric_format(FloatRegex, FloatNodes, [])).
+    check_numeric_format(
+        IntRegex,
+        IntNodes,
+        check_numeric_format(FloatRegex, FloatNodes, [])
+    ).
 
 -type behaviour_spelling_config() ::
     #{ignore => [ignorable()], spelling => behaviour | behavior}.
 
--spec behaviour_spelling(elvis_config:config(),
-                         elvis_file:file(),
-                         behaviour_spelling_config()) ->
-                            [elvis_result:item()].
+-spec behaviour_spelling(
+    elvis_config:config(),
+    elvis_file:file(),
+    behaviour_spelling_config()
+) ->
+    [elvis_result:item()].
 behaviour_spelling(Config, Target, RuleConfig) ->
     Spelling = option(spelling, RuleConfig, behaviour_spelling),
     Root = get_root(Config, Target, RuleConfig),
     Predicate =
         fun(Node) ->
-           NodeType = ktn_code:type(Node),
-           lists:member(NodeType, [behaviour, behavior]) andalso NodeType /= Spelling
+            NodeType = ktn_code:type(Node),
+            lists:member(NodeType, [behaviour, behavior]) andalso NodeType /= Spelling
         end,
     case elvis_code:find(Predicate, Root) of
         [] ->
@@ -1531,74 +1846,85 @@ behaviour_spelling(Config, Target, RuleConfig) ->
         InconsistentBehaviorNodes ->
             ResultFun =
                 fun(Node) ->
-                   {Line, _} = ktn_code:attr(location, Node),
-                   Info = [Line, Spelling],
-                   elvis_result:new(item, ?BEHAVIOUR_SPELLING_MSG, Info, Line)
+                    {Line, _} = ktn_code:attr(location, Node),
+                    Info = [Line, Spelling],
+                    elvis_result:new(item, ?BEHAVIOUR_SPELLING_MSG, Info, Line)
                 end,
             lists:map(ResultFun, InconsistentBehaviorNodes)
     end.
 
 -type param_pattern_matching_config() :: #{ignore => [ignorable()], side => left | right}.
 
--spec param_pattern_matching(elvis_config:config(),
-                             elvis_file:file(),
-                             param_pattern_matching_config()) ->
-                                [elvis_result:item()].
+-spec param_pattern_matching(
+    elvis_config:config(),
+    elvis_file:file(),
+    param_pattern_matching_config()
+) ->
+    [elvis_result:item()].
 param_pattern_matching(Config, Target, RuleConfig) ->
     Side = option(side, RuleConfig, param_pattern_matching),
     Root = get_root(Config, Target, RuleConfig),
 
     FunctionClausePatterns =
-        lists:flatmap(fun(Clause) -> ktn_code:node_attr(pattern, Clause) end,
-                      elvis_code:find(fun is_function_clause/1,
-                                      Root,
-                                      #{mode => zipper, traverse => all})),
+        lists:flatmap(
+            fun(Clause) -> ktn_code:node_attr(pattern, Clause) end,
+            elvis_code:find(
+                fun is_function_clause/1,
+                Root,
+                #{mode => zipper, traverse => all}
+            )
+        ),
 
     MatchesInFunctionClauses =
         lists:filter(fun(Pattern) -> ktn_code:type(Pattern) == match end, FunctionClausePatterns),
 
-    lists:filtermap(fun(Match) ->
-                       case lists:map(fun ktn_code:type/1, ktn_code:content(Match)) of
-                           [var, var] ->
-                               false;
-                           [var, _] when Side == right ->
-                               {Line, _} = ktn_code:attr(location, Match),
-                               [Var, _] = ktn_code:content(Match),
-                               VarName = ktn_code:attr(name, Var),
-                               Info = [VarName, Line, Side],
-                               {true,
-                                elvis_result:new(item, ?PARAM_PATTERN_MATCHING_MSG, Info, Line)};
-                           [_, var] when Side == left ->
-                               {Line, _} = ktn_code:attr(location, Match),
-                               [_, Var] = ktn_code:content(Match),
-                               VarName = ktn_code:attr(name, Var),
-                               Info = [VarName, Line, Side],
-                               {true,
-                                elvis_result:new(item, ?PARAM_PATTERN_MATCHING_MSG, Info, Line)};
-                           _ ->
-                               false
-                       end
-                    end,
-                    MatchesInFunctionClauses).
+    lists:filtermap(
+        fun(Match) ->
+            case lists:map(fun ktn_code:type/1, ktn_code:content(Match)) of
+                [var, var] ->
+                    false;
+                [var, _] when Side == right ->
+                    {Line, _} = ktn_code:attr(location, Match),
+                    [Var, _] = ktn_code:content(Match),
+                    VarName = ktn_code:attr(name, Var),
+                    Info = [VarName, Line, Side],
+                    {true, elvis_result:new(item, ?PARAM_PATTERN_MATCHING_MSG, Info, Line)};
+                [_, var] when Side == left ->
+                    {Line, _} = ktn_code:attr(location, Match),
+                    [_, Var] = ktn_code:content(Match),
+                    VarName = ktn_code:attr(name, Var),
+                    Info = [VarName, Line, Side],
+                    {true, elvis_result:new(item, ?PARAM_PATTERN_MATCHING_MSG, Info, Line)};
+                _ ->
+                    false
+            end
+        end,
+        MatchesInFunctionClauses
+    ).
 
 is_function_clause(Zipper) ->
     is_clause(Zipper) andalso is_function_or_fun(zipper:up(Zipper)).
 
 is_clause(Zipper) ->
     ktn_code:type(
-        zipper:node(Zipper))
-    == clause.
+        zipper:node(Zipper)
+    ) ==
+        clause.
 
 is_function_or_fun(Zipper) ->
     lists:member(
         ktn_code:type(
-            zipper:node(Zipper)),
-        [function, 'fun']).
+            zipper:node(Zipper)
+        ),
+        [function, 'fun']
+    ).
 
--spec consistent_generic_type(elvis_config:config(),
-                              elvis_file:file(),
-                              empty_rule_config()) ->
-                                 [elvis_result:item()].
+-spec consistent_generic_type(
+    elvis_config:config(),
+    elvis_file:file(),
+    empty_rule_config()
+) ->
+    [elvis_result:item()].
 consistent_generic_type(Config, Target, RuleConfig) ->
     TypePreference = option(preferred_type, RuleConfig, consistent_generic_type),
     Root = get_root(Config, Target, RuleConfig),
@@ -1611,18 +1937,21 @@ consistent_generic_type(Config, Target, RuleConfig) ->
             lists:map(ResultFun, InconsistentTypeNodes)
     end.
 
--spec always_shortcircuit(elvis_config:config(),
-                          elvis_file:file(),
-                          empty_rule_config()) ->
-                             [elvis_result:item()].
+-spec always_shortcircuit(
+    elvis_config:config(),
+    elvis_file:file(),
+    empty_rule_config()
+) ->
+    [elvis_result:item()].
 always_shortcircuit(Config, Target, RuleConfig) ->
     Operators = #{'and' => 'andalso', 'or' => 'orelse'},
     Root = get_root(Config, Target, RuleConfig),
     Predicate =
         fun(Node) ->
-           is_operator_node(Node)
-           andalso lists:member(
-                       ktn_code:attr(operation, Node), maps:keys(Operators))
+            is_operator_node(Node) andalso
+                lists:member(
+                    ktn_code:attr(operation, Node), maps:keys(Operators)
+                )
         end,
     case elvis_code:find(Predicate, Root, #{traverse => all}) of
         [] ->
@@ -1630,17 +1959,17 @@ always_shortcircuit(Config, Target, RuleConfig) ->
         BadOperators ->
             ResultFun =
                 fun(Node) ->
-                   {Line, _} = ktn_code:attr(location, Node),
-                   BadOperator = ktn_code:attr(operation, Node),
-                   GoodOperator = maps:get(BadOperator, Operators),
-                   Info = [BadOperator, Line, GoodOperator],
-                   elvis_result:new(item, ?ALWAYS_SHORTCIRCUIT_MSG, Info, Line)
+                    {Line, _} = ktn_code:attr(location, Node),
+                    BadOperator = ktn_code:attr(operation, Node),
+                    GoodOperator = maps:get(BadOperator, Operators),
+                    Info = [BadOperator, Line, GoodOperator],
+                    elvis_result:new(item, ?ALWAYS_SHORTCIRCUIT_MSG, Info, Line)
                 end,
             lists:map(ResultFun, BadOperators)
     end.
 
 -spec export_used_types(elvis_config:config(), elvis_file:file(), empty_rule_config()) ->
-                           [elvis_result:item()].
+    [elvis_result:item()].
 export_used_types(Config, Target, RuleConfig) ->
     TreeRootNode = get_root(Config, Target, RuleConfig),
     ExportedFunctions = elvis_code:exported_functions(TreeRootNode),
@@ -1648,35 +1977,48 @@ export_used_types(Config, Target, RuleConfig) ->
     SpecNodes =
         elvis_code:find(fun is_spec_attribute/1, TreeRootNode, #{traverse => all, mode => node}),
     ExportedSpecs =
-        lists:filter(fun(#{attrs := #{arity := Arity, name := Name}}) ->
-                        lists:member({Name, Arity}, ExportedFunctions)
-                     end,
-                     SpecNodes),
+        lists:filter(
+            fun(#{attrs := #{arity := Arity, name := Name}}) ->
+                lists:member({Name, Arity}, ExportedFunctions)
+            end,
+            SpecNodes
+        ),
     UsedTypes =
         lists:usort(
-            lists:flatmap(fun(Spec) ->
-                             Types =
-                                 elvis_code:find(fun(Node) -> ktn_code:type(Node) =:= user_type end,
-                                                 Spec,
-                                                 #{mode => node, traverse => all}),
-                             % yes, on a -type line, the arity is based on `args`, but on
-                             % a -spec line, it's based on `content`
-                             [{Name, length(Vars)}
-                              || #{attrs := #{name := Name}, content := Vars} <- Types]
-                          end,
-                          ExportedSpecs)),
+            lists:flatmap(
+                fun(Spec) ->
+                    Types =
+                        elvis_code:find(
+                            fun(Node) -> ktn_code:type(Node) =:= user_type end,
+                            Spec,
+                            #{mode => node, traverse => all}
+                        ),
+                    % yes, on a -type line, the arity is based on `args`, but on
+                    % a -spec line, it's based on `content`
+                    [
+                        {Name, length(Vars)}
+                     || #{attrs := #{name := Name}, content := Vars} <- Types
+                    ]
+                end,
+                ExportedSpecs
+            )
+        ),
     UnexportedUsedTypes = lists:subtract(UsedTypes, ExportedTypes),
     LineNumbers = map_type_declarations_to_line_numbers(TreeRootNode),
 
     % Report
-    lists:map(fun({Name, Arity} = Info) ->
-                 Line = maps:get(Info, LineNumbers, unknown),
-                 elvis_result:new(item, ?EXPORT_USED_TYPES_MSG, [Name, Arity, Line], Line)
-              end,
-              UnexportedUsedTypes).
+    lists:map(
+        fun({Name, Arity} = Info) ->
+            Line = maps:get(Info, LineNumbers, unknown),
+            elvis_result:new(item, ?EXPORT_USED_TYPES_MSG, [Name, Arity, Line], Line)
+        end,
+        UnexportedUsedTypes
+    ).
 
-get_type_of_type(#{type := type_attr,
-                   node_attrs := #{type := #{attrs := #{name := TypeOfType}}}}) ->
+get_type_of_type(#{
+    type := type_attr,
+    node_attrs := #{type := #{attrs := #{name := TypeOfType}}}
+}) ->
     TypeOfType;
 get_type_of_type(_) ->
     undefined.
@@ -1684,10 +2026,12 @@ get_type_of_type(_) ->
 -type data_type() :: record | map | tuple.
 -type private_data_type_config() :: #{apply_to => [data_type()]}.
 
--spec private_data_types(elvis_config:config(),
-                         elvis_file:file(),
-                         private_data_type_config()) ->
-                            [elvis_result:item()].
+-spec private_data_types(
+    elvis_config:config(),
+    elvis_file:file(),
+    private_data_type_config()
+) ->
+    [elvis_result:item()].
 private_data_types(Config, Target, RuleConfig) ->
     TypesToCheck = option(apply_to, RuleConfig, private_data_types),
     TreeRootNode = get_root(Config, Target, RuleConfig),
@@ -1696,17 +2040,21 @@ private_data_types(Config, Target, RuleConfig) ->
 
     PublicDataTypes = public_data_types(TypesToCheck, TreeRootNode, ExportedTypes),
 
-    lists:map(fun({Name, Arity} = Info) ->
-                 Line = maps:get(Info, LineNumbers, unknown),
-                 elvis_result:new(item, ?PRIVATE_DATA_TYPES_MSG, [Name, Arity, Line], Line)
-              end,
-              PublicDataTypes).
+    lists:map(
+        fun({Name, Arity} = Info) ->
+            Line = maps:get(Info, LineNumbers, unknown),
+            elvis_result:new(item, ?PRIVATE_DATA_TYPES_MSG, [Name, Arity, Line], Line)
+        end,
+        PublicDataTypes
+    ).
 
 public_data_types(TypesToCheck, TreeRootNode, ExportedTypes) ->
     Fun = fun(Node) -> lists:member(get_type_of_type(Node), TypesToCheck) end,
     Types =
-        [name_arity_from_type_line(Node)
-         || Node <- elvis_code:find(Fun, TreeRootNode, #{traverse => all, mode => node})],
+        [
+            name_arity_from_type_line(Node)
+         || Node <- elvis_code:find(Fun, TreeRootNode, #{traverse => all, mode => node})
+        ],
     lists:filter(fun({Name, Arity}) -> lists:member({Name, Arity}, ExportedTypes) end, Types).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1720,19 +2068,26 @@ name_arity_from_type_line(#{attrs := #{name := Name}, node_attrs := #{args := Ar
 
 %% @private
 -spec map_type_declarations_to_line_numbers(ktn_code:tree_node()) ->
-                                               #{{atom(), number()} => number()}.
+    #{{atom(), number()} => number()}.
 map_type_declarations_to_line_numbers(TreeRootNode) ->
     AllTypes =
         elvis_code:find(fun is_type_attribute/1, TreeRootNode, #{traverse => all, mode => node}),
-    lists:foldl(fun (#{attrs := #{location := {Line, _}, name := Name},
-                       node_attrs := #{args := Args}},
-                     Acc) ->
-                        maps:put({Name, length(Args)}, Line, Acc);
-                    (_, Acc) ->
-                        Acc
-                end,
-                #{},
-                AllTypes).
+    lists:foldl(
+        fun
+            (
+                #{
+                    attrs := #{location := {Line, _}, name := Name},
+                    node_attrs := #{args := Args}
+                },
+                Acc
+            ) ->
+                maps:put({Name, length(Args)}, Line, Acc);
+            (_, Acc) ->
+                Acc
+        end,
+        #{},
+        AllTypes
+    ).
 
 %% @private
 specific_or_default(same, Regex) ->
@@ -1753,10 +2108,12 @@ check_numeric_format(Regex, [NumNode | RemainingNumNodes], AccIn) ->
                     nomatch ->
                         {Line, _} = ktn_code:attr(location, NumNode),
                         Result =
-                            elvis_result:new(item,
-                                             ?NUMERIC_FORMAT_MSG,
-                                             [Number, Line, Regex],
-                                             Line),
+                            elvis_result:new(
+                                item,
+                                ?NUMERIC_FORMAT_MSG,
+                                [Number, Line, Regex],
+                                Line
+                            ),
                         [Result | AccIn];
                     {match, _} ->
                         AccIn
@@ -1787,12 +2144,14 @@ is_exception_or_non_reversible(_) ->
 %% @private
 check_atom_names(_Regex, _, _RegexEnclosed, _, [] = _AtomNodes, Acc) ->
     Acc;
-check_atom_names(Regex,
-                 ForbiddenRegexNormal,
-                 RegexEnclosed,
-                 ForbiddenRegexEnclosed,
-                 [AtomNode | RemainingAtomNodes],
-                 AccIn) ->
+check_atom_names(
+    Regex,
+    ForbiddenRegexNormal,
+    RegexEnclosed,
+    ForbiddenRegexEnclosed,
+    [AtomNode | RemainingAtomNodes],
+    AccIn
+) ->
     AtomName0 = ktn_code:attr(text, AtomNode),
     ValueAtomName = ktn_code:attr(value, AtomNode),
     {IsEnclosed, AtomName} = string_strip_enclosed(AtomName0),
@@ -1806,8 +2165,10 @@ check_atom_names(Regex,
                 ForbiddenRegexNormal
         end,
     AccOut =
-        case re:run(
-                 unicode:characters_to_list(AtomName, unicode), RE)
+        case
+            re:run(
+                unicode:characters_to_list(AtomName, unicode), RE
+            )
         of
             _ when IsExceptionClass andalso not IsEnclosed ->
                 AccIn;
@@ -1839,12 +2200,14 @@ check_atom_names(Regex,
                         end
                 end
         end,
-    check_atom_names(Regex,
-                     ForbiddenRegexNormal,
-                     RegexEnclosed,
-                     ForbiddenRegexEnclosed,
-                     RemainingAtomNodes,
-                     AccOut).
+    check_atom_names(
+        Regex,
+        ForbiddenRegexNormal,
+        RegexEnclosed,
+        ForbiddenRegexEnclosed,
+        RemainingAtomNodes,
+        AccOut
+    ).
 
 %% @private
 string_strip_enclosed([$' | Rest]) ->
@@ -1867,9 +2230,10 @@ re_compile_for_atom_type(true = _IsEnclosed, _Regex, RegexEnclosed) ->
 %% @private
 is_atom_node(MaybeAtom) ->
     ktn_code:type(
-        zipper:node(MaybeAtom))
-    =:= atom
-    andalso not check_parent_remote(MaybeAtom).
+        zipper:node(MaybeAtom)
+    ) =:=
+        atom andalso
+        not check_parent_remote(MaybeAtom).
 
 %% Variables name
 %% @private
@@ -1908,17 +2272,17 @@ check_variables_name(Regex, ForbiddenRegex, [Variable | RemainingVars]) ->
 %% @private
 result_node_line_fun(Msg) ->
     fun(Node) ->
-       {Line, _} = ktn_code:attr(location, Node),
-       Info = [Line],
-       elvis_result:new(item, Msg, Info, Line)
+        {Line, _} = ktn_code:attr(location, Node),
+        Info = [Line],
+        elvis_result:new(item, Msg, Info, Line)
     end.
 
 %% @private
 result_node_line_col_fun(Msg) ->
     fun(Node) ->
-       {Line, Col} = ktn_code:attr(location, Node),
-       Info = [Line, Col],
-       elvis_result:new(item, Msg, Info, Line)
+        {Line, Col} = ktn_code:attr(location, Node),
+        Info = [Line, Col],
+        elvis_result:new(item, Msg, Info, Line)
     end.
 
 %%% Rule checking
@@ -1991,23 +2355,28 @@ macro_as_atom({var, _Text, MacroAsAtom}, _Types, _MacroNodeValue) ->
     MacroAsAtom;
 macro_as_atom({atom, _Text, MacroAsAtom}, _Types, _MacroNodeValue) ->
     MacroAsAtom;
-macro_as_atom({call, _CallText, {Type, _AtomText, MacroAsAtom}, _VarArg},
-              _Types,
-              _MacroNodeValue)
-    when Type =:= var orelse Type =:= atom ->
+macro_as_atom(
+    {call, _CallText, {Type, _AtomText, MacroAsAtom}, _VarArg},
+    _Types,
+    _MacroNodeValue
+) when
+    Type =:= var orelse Type =:= atom
+->
     MacroAsAtom;
 macro_as_atom(false, [Type | OtherTypes], MacroNodeValue) ->
     macro_as_atom(lists:keyfind(Type, _N = 1, MacroNodeValue), OtherTypes, MacroNodeValue).
 
 %% Operator (and Text) Spaces
 %% @private
--spec check_spaces(Lines :: [binary()],
-                   Nodes :: [ktn_code:tree_node()],
-                   Rule :: {right | left, string()},
-                   Encoding :: latin1 | utf8,
-                   How :: {should_have, []} | {should_not_have, [{string(), {ok, _}}]}) ->
-                      [elvis_result:item()].
-         % _ is re:mp()
+-spec check_spaces(
+    Lines :: [binary()],
+    Nodes :: [ktn_code:tree_node()],
+    Rule :: {right | left, string()},
+    Encoding :: latin1 | utf8,
+    How :: {should_have, []} | {should_not_have, [{string(), {ok, _}}]}
+) ->
+    [elvis_result:item()].
+% _ is re:mp()
 
 check_spaces(Lines, UnfilteredNodes, {Position, Text}, Encoding, {How0, _} = How) ->
     FilterFun = fun(Node) -> ktn_code:attr(text, Node) =:= Text end,
@@ -2015,25 +2384,25 @@ check_spaces(Lines, UnfilteredNodes, {Position, Text}, Encoding, {How0, _} = How
     SpaceChar = $\s,
     FlatFun =
         fun(Node) ->
-           Location = ktn_code:attr(location, Node),
-           case character_at_location(Position, Lines, Text, Location, Encoding, How) of
-               Char when Char =:= SpaceChar andalso How0 =:= should_have ->
-                   [];
-               Char when Char =/= SpaceChar andalso How0 =:= should_not_have ->
-                   [];
-               _ when How0 =:= should_have ->
-                   Msg = ?MISSING_SPACE_MSG,
-                   {Line, _Col} = Location,
-                   Info = [Position, Text, Line],
-                   Result = elvis_result:new(item, Msg, Info, Line),
-                   [Result];
-               _ when How0 =:= should_not_have ->
-                   Msg = ?UNEXPECTED_SPACE_MSG,
-                   {Line, _Col} = Location,
-                   Info = [Position, Text, Line],
-                   Result = elvis_result:new(item, Msg, Info, Line),
-                   [Result]
-           end
+            Location = ktn_code:attr(location, Node),
+            case character_at_location(Position, Lines, Text, Location, Encoding, How) of
+                Char when Char =:= SpaceChar andalso How0 =:= should_have ->
+                    [];
+                Char when Char =/= SpaceChar andalso How0 =:= should_not_have ->
+                    [];
+                _ when How0 =:= should_have ->
+                    Msg = ?MISSING_SPACE_MSG,
+                    {Line, _Col} = Location,
+                    Info = [Position, Text, Line],
+                    Result = elvis_result:new(item, Msg, Info, Line),
+                    [Result];
+                _ when How0 =:= should_not_have ->
+                    Msg = ?UNEXPECTED_SPACE_MSG,
+                    {Line, _Col} = Location,
+                    Info = [Position, Text, Line],
+                    Result = elvis_result:new(item, Msg, Info, Line),
+                    [Result]
+            end
         end,
     lists:flatmap(FlatFun, Nodes).
 
@@ -2044,20 +2413,24 @@ maybe_run_regex({ok, Regex}, Line) ->
     re:run(Line, Regex).
 
 %% @private
--spec character_at_location(Position :: atom(),
-                            Lines :: [binary()],
-                            Text :: string(),
-                            Location :: {integer(), integer()},
-                            Encoding :: latin1 | utf8,
-                            How :: {should_have, []} | {should_not_have, [{string(), {ok, _}}]}) ->
-                               char().
+-spec character_at_location(
+    Position :: atom(),
+    Lines :: [binary()],
+    Text :: string(),
+    Location :: {integer(), integer()},
+    Encoding :: latin1 | utf8,
+    How :: {should_have, []} | {should_not_have, [{string(), {ok, _}}]}
+) ->
+    char().
 % _ is re:mp()
-character_at_location(Position,
-                      Lines,
-                      Text,
-                      {LineNo, Col},
-                      Encoding,
-                      {How, TextRegexes}) ->
+character_at_location(
+    Position,
+    Lines,
+    Text,
+    {LineNo, Col},
+    Encoding,
+    {How, TextRegexes}
+) ->
     Line = lists:nth(LineNo, Lines),
     TextRegex =
         case TextRegexes of
@@ -2111,10 +2484,10 @@ check_nesting_level(ParentNode, [MaxLevel]) ->
             Msg = ?NESTING_LEVEL_MSG,
 
             Fun = fun(Node) ->
-                     {Line, Col} = ktn_code:attr(location, Node),
-                     Info = [Line, Col, MaxLevel],
-                     elvis_result:new(item, Msg, Info, Line)
-                  end,
+                {Line, Col} = ktn_code:attr(location, Node),
+                Info = [Line, Col, MaxLevel],
+                elvis_result:new(item, Msg, Info, Line)
+            end,
 
             lists:map(Fun, NestedNodes)
     end.
@@ -2153,8 +2526,10 @@ is_dynamic_call(Node) ->
 %% @private
 -spec is_var(zipper:zipper(_)) -> boolean().
 is_var(Zipper) ->
-    case ktn_code:type(
-             zipper:node(Zipper))
+    case
+        ktn_code:type(
+            zipper:node(Zipper)
+        )
     of
         var ->
             PrevLocation =
@@ -2164,8 +2539,10 @@ is_var(Zipper) ->
                     {L, C} ->
                         {L, C - 1}
                 end,
-            case elvis_code:find_token(
-                     zipper:root(Zipper), PrevLocation)
+            case
+                elvis_code:find_token(
+                    zipper:root(Zipper), PrevLocation
+                )
             of
                 not_found ->
                     true;
@@ -2235,16 +2612,17 @@ is_otp_module(Root) ->
             ValueFun = fun(Node) -> ktn_code:attr(value, Node) end,
             Names = lists:map(ValueFun, Behaviors),
             BehaviorsSet = sets:from_list(Names),
-            not
-                sets:is_empty(
-                    sets:intersection(OtpSet, BehaviorsSet))
+            not sets:is_empty(
+                sets:intersection(OtpSet, BehaviorsSet)
+            )
     end.
 
 %% @private
 -spec has_state_record(ktn_code:tree_node()) -> boolean().
 has_state_record(Root) ->
     IsStateRecord =
-        fun(Node) -> (record_attr == ktn_code:type(Node)) and (state == ktn_code:attr(name, Node))
+        fun(Node) ->
+            (record_attr == ktn_code:type(Node)) and (state == ktn_code:attr(name, Node))
         end,
     [] /= elvis_code:find(IsStateRecord, Root).
 
@@ -2253,19 +2631,19 @@ has_state_record(Root) ->
 has_state_type(Root) ->
     IsStateType =
         fun(Node) ->
-           case ktn_code:type(Node) of
-               type_attr ->
-                   state == ktn_code:attr(name, Node);
-               opaque ->
-                   case ktn_code:attr(value, Node) of
-                       {state, _, _} ->
-                           true;
-                       _ ->
-                           false
-                   end;
-               _ ->
-                   false
-           end
+            case ktn_code:type(Node) of
+                type_attr ->
+                    state == ktn_code:attr(name, Node);
+                opaque ->
+                    case ktn_code:attr(value, Node) of
+                        {state, _, _} ->
+                            true;
+                        _ ->
+                            false
+                    end;
+                _ ->
+                    false
+            end
         end,
     elvis_code:find(IsStateType, Root) /= [].
 
@@ -2275,8 +2653,7 @@ has_state_type(Root) ->
 -spec spec_includes_record(ktn_code:tree_node()) -> boolean().
 spec_includes_record(Node) ->
     IsTypeRecord =
-        fun(Child) -> (ktn_code:type(Child) == type) and (ktn_code:attr(name, Child) == record)
-        end,
+        fun(Child) -> (ktn_code:type(Child) == type) and (ktn_code:attr(name, Child) == record) end,
     Opts = #{traverse => all},
     (ktn_code:type(Node) == spec) and (elvis_code:find(IsTypeRecord, Node, Opts) /= []).
 
@@ -2284,24 +2661,24 @@ spec_includes_record(Node) ->
 
 %% @private
 -spec find_repeated_nodes(ktn_code:tree_node(), non_neg_integer()) ->
-                             [ktn_code:tree_node()].
+    [ktn_code:tree_node()].
 find_repeated_nodes(Root, MinComplexity) ->
     TypeAttrs = #{var => [location, name, text], clause => [location, text]},
 
     FoldFun =
         fun(Node, Map) ->
-           Zipper = elvis_code:code_zipper(Node),
-           case zipper:size(Zipper) of
-               Count when Count >= MinComplexity ->
-                   Loc = ktn_code:attr(location, Node),
-                   StrippedNode = remove_attrs_zipper(Zipper, TypeAttrs),
+            Zipper = elvis_code:code_zipper(Node),
+            case zipper:size(Zipper) of
+                Count when Count >= MinComplexity ->
+                    Loc = ktn_code:attr(location, Node),
+                    StrippedNode = remove_attrs_zipper(Zipper, TypeAttrs),
 
-                   ValsSet = maps:get(StrippedNode, Map, sets:new()),
-                   NewValsSet = sets:add_element(Loc, ValsSet),
-                   maps:put(StrippedNode, NewValsSet, Map);
-               _ ->
-                   Map
-           end
+                    ValsSet = maps:get(StrippedNode, Map, sets:new()),
+                    NewValsSet = sets:add_element(Loc, ValsSet),
+                    maps:put(StrippedNode, NewValsSet, Map);
+                _ ->
+                    Map
+            end
         end,
     ZipperRoot = elvis_code:code_zipper(Root),
     Grouped = zipper:fold(FoldFun, #{}, ZipperRoot),
@@ -2319,19 +2696,25 @@ remove_attrs_zipper(Zipper, TypeAttrs) ->
 
 %% @private
 -spec remove_attrs(ktn_code:tree_node() | [ktn_code:tree_node()], map()) ->
-                      ktn_code:tree_node().
+    ktn_code:tree_node().
 remove_attrs(Nodes, TypeAttrs) when is_list(Nodes) ->
     [remove_attrs(Node, TypeAttrs) || Node <- Nodes];
-remove_attrs(#{attrs := Attrs,
-               type := Type,
-               node_attrs := NodeAttrs} =
-                 Node,
-             TypeAttrs) ->
+remove_attrs(
+    #{
+        attrs := Attrs,
+        type := Type,
+        node_attrs := NodeAttrs
+    } =
+        Node,
+    TypeAttrs
+) ->
     AttrsName = maps:get(Type, TypeAttrs, [location]),
     AttrsNoLoc = maps:without(AttrsName, Attrs),
     NodeAttrsNoLoc =
-        [{Key, remove_attrs_zipper(elvis_code:code_zipper(Value), TypeAttrs)}
-         || {Key, Value} <- maps:to_list(NodeAttrs)],
+        [
+            {Key, remove_attrs_zipper(elvis_code:code_zipper(Value), TypeAttrs)}
+         || {Key, Value} <- maps:to_list(NodeAttrs)
+        ],
 
     Node#{attrs => AttrsNoLoc, node_attrs => maps:from_list(NodeAttrsNoLoc)};
 remove_attrs(#{attrs := Attrs, type := Type} = Node, TypeAttrs) ->
@@ -2351,11 +2734,13 @@ filter_repeated(NodesLocs) ->
 
     RepeatedNodes = maps:keys(RepeatedMap),
     Nested =
-        [Node
+        [
+            Node
          || Node <- RepeatedNodes,
             Parent <- RepeatedNodes,
             Node =/= Parent,
-            is_children(Parent, Node)],
+            is_children(Parent, Node)
+        ],
 
     maps:without(Nested, RepeatedMap).
 
@@ -2366,12 +2751,14 @@ is_children(Parent, Node) ->
 
 %% No call
 %% @private
--spec no_call_common(elvis_config:config(),
-                     elvis_file:file(),
-                     [function_spec()],
-                     string(),
-                     RuleConfig :: elvis_core:rule_config()) ->
-                        [elvis_result:item()].
+-spec no_call_common(
+    elvis_config:config(),
+    elvis_file:file(),
+    [function_spec()],
+    string(),
+    RuleConfig :: elvis_core:rule_config()
+) ->
+    [elvis_result:item()].
 no_call_common(Config, Target, NoCallFuns, Msg, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
 
@@ -2380,14 +2767,14 @@ no_call_common(Config, Target, NoCallFuns, Msg, RuleConfig) ->
 
 %% @private
 -spec check_no_call([ktn_code:tree_node()], string(), [function_spec()]) ->
-                       [elvis_result:item()].
+    [elvis_result:item()].
 check_no_call(Calls, Msg, NoCallFuns) ->
     BadCalls = [Call || Call <- Calls, is_in_call_list(Call, NoCallFuns)],
     ResultFun =
         fun(Call) ->
-           {M, F, A} = call_mfa(Call),
-           {Line, _} = ktn_code:attr(location, Call),
-           elvis_result:new(item, Msg, [M, F, A, Line], Line)
+            {M, F, A} = call_mfa(Call),
+            {Line, _} = ktn_code:attr(location, Call),
+            elvis_result:new(item, Msg, [M, F, A, Line], Line)
         end,
     lists:map(ResultFun, BadCalls).
 
@@ -2407,9 +2794,9 @@ call_mfa(Call) ->
 
 %% @private
 is_call(Node, {F, A}) ->
-    ktn_code:type(Node) =:= call
-    andalso list_to_atom(ktn_code:attr(text, Node)) =:= F
-    andalso length(ktn_code:content(Node)) =:= A;
+    ktn_code:type(Node) =:= call andalso
+        list_to_atom(ktn_code:attr(text, Node)) =:= F andalso
+        length(ktn_code:content(Node)) =:= A;
 is_call(Node, {M, F, A}) ->
     call_mfa(Node) =:= {M, F, A}.
 
@@ -2432,15 +2819,17 @@ wildcard_match(X, Y) ->
 %% @private
 %% @doc No nested try...catch blocks
 check_nested_try_catchs(ResultFun, TryExp) ->
-    lists:filtermap(fun(Node) ->
-                       case ktn_code:type(Node) == 'try' of
-                           true ->
-                               {true, ResultFun(Node)};
-                           false ->
-                               false
-                       end
-                    end,
-                    ktn_code:content(TryExp)).
+    lists:filtermap(
+        fun(Node) ->
+            case ktn_code:type(Node) == 'try' of
+                true ->
+                    {true, ResultFun(Node)};
+                false ->
+                    false
+            end
+        end,
+        ktn_code:content(TryExp)
+    ).
 
 %% @private
 %% @doc No #{...}#{...}
@@ -2461,49 +2850,49 @@ check_successive_maps(ResultFun, MapExp) ->
 %% @private
 consistent_generic_type_predicate(TypePreference) ->
     fun(Node) ->
-       NodeType = ktn_code:type(Node),
-       NodeName = ktn_code:attr(name, Node),
-       lists:member(NodeType, [type, callback])
-       andalso lists:member(NodeName, [term, any])
-       andalso NodeName /= TypePreference
+        NodeType = ktn_code:type(Node),
+        NodeName = ktn_code:attr(name, Node),
+        lists:member(NodeType, [type, callback]) andalso
+            lists:member(NodeName, [term, any]) andalso
+            NodeName /= TypePreference
     end.
 
 %% @private
 consistent_generic_type_result(TypePreference) ->
     fun(Node) ->
-       {Line, _} = ktn_code:attr(location, Node),
-       NodeName = ktn_code:attr(name, Node),
-       Info = [NodeName, Line, TypePreference],
-       elvis_result:new(item, ?CONSISTENT_GENERIC_TYPE, Info, Line)
+        {Line, _} = ktn_code:attr(location, Node),
+        NodeName = ktn_code:attr(name, Node),
+        Info = [NodeName, Line, TypePreference],
+        elvis_result:new(item, ?CONSISTENT_GENERIC_TYPE, Info, Line)
     end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Internal Function Definitions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec option(OptionName, RuleConfig, Rule) -> OptionValue
-    when OptionName :: atom(),
-         RuleConfig :: elvis_core:rule_config(),
-         Rule :: atom(),
-         OptionValue :: term().
+-spec option(OptionName, RuleConfig, Rule) -> OptionValue when
+    OptionName :: atom(),
+    RuleConfig :: elvis_core:rule_config(),
+    Rule :: atom(),
+    OptionValue :: term().
 option(OptionName, RuleConfig, Rule) ->
     maybe_default_option(maps:get(OptionName, RuleConfig, undefined), OptionName, Rule).
 
--spec maybe_default_option(UserDefinedOptionValue, OptionName, Rule) -> OptionValue
-    when UserDefinedOptionValue :: undefined | term(),
-         OptionName :: atom(),
-         Rule :: atom(),
-         OptionValue :: term().
+-spec maybe_default_option(UserDefinedOptionValue, OptionName, Rule) -> OptionValue when
+    UserDefinedOptionValue :: undefined | term(),
+    OptionName :: atom(),
+    Rule :: atom(),
+    OptionValue :: term().
 maybe_default_option(undefined = _UserDefinedOptionValue, OptionName, Rule) ->
     maps:get(OptionName, default(Rule));
 maybe_default_option(UserDefinedOptionValue, _OptionName, _Rule) ->
     UserDefinedOptionValue.
 
--spec get_root(Config, Target, RuleConfig) -> Res
-    when Config :: elvis_config:config(),
-         Target :: elvis_file:file(),
-         RuleConfig :: (Options :: #{atom() => term()}),
-         Res :: ktn_code:tree_node().
+-spec get_root(Config, Target, RuleConfig) -> Res when
+    Config :: elvis_config:config(),
+    Target :: elvis_file:file(),
+    RuleConfig :: (Options :: #{atom() => term()}),
+    Res :: ktn_code:tree_node().
 get_root(Config, Target, RuleConfig) ->
     {Root0, File0} = elvis_file:parse_tree(Config, Target, RuleConfig),
     case maps:get(ruleset, Config, undefined) of
@@ -2513,9 +2902,9 @@ get_root(Config, Target, RuleConfig) ->
             Root0
     end.
 
--spec doc_bin_parts(Src) -> [Part]
-    when Src :: binary(),
-         Part :: binary_part().
+-spec doc_bin_parts(Src) -> [Part] when
+    Src :: binary(),
+    Part :: binary_part().
 doc_bin_parts(Src) when is_binary(Src) ->
     RE = "(?ms)^-(?:(moduledoc|doc))\\b\\s*(\"*)?.*?\\2\\.(\\r\\n|\\n)",
     case re:run(Src, RE, [global, {capture, first, index}]) of
@@ -2525,10 +2914,10 @@ doc_bin_parts(Src) when is_binary(Src) ->
             []
     end.
 
--spec ignore_bin_parts(Src, [DocPart]) -> [TextPart]
-    when Src :: binary(),
-         DocPart :: binary_part(),
-         TextPart :: binary_part().
+-spec ignore_bin_parts(Src, [DocPart]) -> [TextPart] when
+    Src :: binary(),
+    DocPart :: binary_part(),
+    TextPart :: binary_part().
 ignore_bin_parts(Src, DocParts) when is_binary(Src), is_list(DocParts) ->
     ignore_bin_parts_1(DocParts, 0, Src).
 
@@ -2537,8 +2926,8 @@ ignore_bin_parts_1([], Prev, Src) ->
 ignore_bin_parts_1([{Start, Len} | T], Prev, Src) ->
     [{Prev, Start - Prev} | ignore_bin_parts_1(T, Start + Len, Src)].
 
--spec bin_parts_to_iolist(Src, Parts) -> iolist()
-    when Src :: binary(),
-         Parts :: [binary_part()].
+-spec bin_parts_to_iolist(Src, Parts) -> iolist() when
+    Src :: binary(),
+    Parts :: [binary_part()].
 bin_parts_to_iolist(Src, Parts) when is_binary(Src), is_list(Parts) ->
     [binary_part(Src, Start, Len) || {Start, Len} <- Parts].

--- a/src/elvis_task.erl
+++ b/src/elvis_task.erl
@@ -7,26 +7,35 @@
 %% equal to Concurrency. On successful evaluation FunAcc function is called
 %% with the result of successful execution as a first parameter and accumulator
 %% as a second parameter.
--spec chunk_fold(FunWork :: {Module :: module(), Function :: atom()},
-                 FunAcc :: fun((NewElem :: term(), Acc :: term()) -> Acc :: term()),
-                 InitialAcc :: term(),
-                 ExtraArgs :: list(),
-                 JoinItemList :: list(),
-                 Concurrency :: non_neg_integer()) ->
-                    {ok, FinalAcc :: term()} | {error, term()}.
-chunk_fold({M, F} = FunWork, FunAcc, InitialAcc, ExtraArgs, List, ChunkSize)
-    when is_atom(M), is_atom(F), is_function(FunAcc, 2), is_list(ExtraArgs), is_list(List),
-         is_integer(ChunkSize) andalso ChunkSize > 0 ->
+-spec chunk_fold(
+    FunWork :: {Module :: module(), Function :: atom()},
+    FunAcc :: fun((NewElem :: term(), Acc :: term()) -> Acc :: term()),
+    InitialAcc :: term(),
+    ExtraArgs :: list(),
+    JoinItemList :: list(),
+    Concurrency :: non_neg_integer()
+) ->
+    {ok, FinalAcc :: term()} | {error, term()}.
+chunk_fold({M, F} = FunWork, FunAcc, InitialAcc, ExtraArgs, List, ChunkSize) when
+    is_atom(M),
+    is_atom(F),
+    is_function(FunAcc, 2),
+    is_list(ExtraArgs),
+    is_list(List),
+    is_integer(ChunkSize) andalso ChunkSize > 0
+->
     try
         Term =
-            do_in_parallel(FunWork,
-                           FunAcc,
-                           ExtraArgs,
-                           List,
-                           _MaxW = ChunkSize,
-                           _RemainW = ChunkSize,
-                           InitialAcc,
-                           []),
+            do_in_parallel(
+                FunWork,
+                FunAcc,
+                ExtraArgs,
+                List,
+                _MaxW = ChunkSize,
+                _RemainW = ChunkSize,
+                InitialAcc,
+                []
+            ),
         {ok, Term}
     catch
         {T, E} ->

--- a/src/elvis_text_style.erl
+++ b/src/elvis_text_style.erl
@@ -1,7 +1,13 @@
 -module(elvis_text_style).
 
--export([default/1, line_length/3, no_tabs/3, no_trailing_whitespace/3,
-         prefer_unquoted_atoms/3, no_redundant_blank_lines/3]).
+-export([
+    default/1,
+    line_length/3,
+    no_tabs/3,
+    no_trailing_whitespace/3,
+    prefer_unquoted_atoms/3,
+    no_redundant_blank_lines/3
+]).
 
 -export_type([line_length_config/0, no_trailing_whitespace_config/0]).
 
@@ -9,22 +15,27 @@
 -define(NO_TABS_MSG, "Line ~p has a tab at column ~p.").
 -define(NO_TRAILING_WHITESPACE_MSG, "Line ~b has ~b trailing whitespace characters.").
 -define(ATOM_PREFERRED_QUOTES_MSG,
-        "Atom ~p on line ~p is quoted "
-        "but quotes are not needed.").
+    "Atom ~p on line ~p is quoted "
+    "but quotes are not needed."
+).
 -define(NO_REDUNDANT_BLANK_LINES_MSG,
-        "Too many blank lines at line ~p. ~p sequential blank lines found,"
-        "when the maximum is set to ~p.").
+    "Too many blank lines at line ~p. ~p sequential blank lines found,"
+    "when the maximum is set to ~p."
+).
 
 % These are part of a non-declared "behaviour"
 % The reason why we don't try to handle them with different arity is
 %  that arguments are ignored in different positions (1 and 3) so that'd
 %  probably be messier than to ignore the warning
--hank([{unnecessary_function_arguments,
-        [{no_trailing_whitespace, 3},
-         {no_tabs, 3},
-         {line_length, 3},
-         {prefer_unquoted_atoms, 3},
-         {no_redundant_blank_lines, 3}]}]).
+-hank([
+    {unnecessary_function_arguments, [
+        {no_trailing_whitespace, 3},
+        {no_tabs, 3},
+        {line_length, 3},
+        {prefer_unquoted_atoms, 3},
+        {no_redundant_blank_lines, 3}
+    ]}
+]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Default values
@@ -32,9 +43,11 @@
 
 -spec default(Rule :: atom()) -> DefaultRuleConfig :: term().
 default(line_length) ->
-    #{limit => 100,
-      skip_comments => false,
-      no_whitespace_after_limit => true};
+    #{
+        limit => 100,
+        skip_comments => false,
+        no_whitespace_after_limit => true
+    };
 default(no_tabs) ->
     #{};
 default(no_trailing_whitespace) ->
@@ -47,14 +60,16 @@ default(no_redundant_blank_lines) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 -type line_length_config() ::
-    #{ignore => [elvis_style:ignorable()],
-      limit => integer(),
-      skip_comments => false | any | whole_line}.
+    #{
+        ignore => [elvis_style:ignorable()],
+        limit => integer(),
+        skip_comments => false | any | whole_line
+    }.
 
 %% @doc Target can be either a filename or the
 %% name of a module.
 -spec line_length(elvis_config:config(), elvis_file:file(), line_length_config()) ->
-                     [elvis_result:item()].
+    [elvis_result:item()].
 line_length(_Config, Target, RuleConfig) ->
     Limit = option(limit, RuleConfig, line_length),
     SkipComments = option(skip_comments, RuleConfig, line_length),
@@ -63,10 +78,12 @@ line_length(_Config, Target, RuleConfig) ->
     Args = [Limit, SkipComments, Encoding, NoWhitespace],
     elvis_utils:check_lines(Src, fun check_line_length/3, Args).
 
--spec no_tabs(elvis_config:config(),
-              elvis_file:file(),
-              elvis_style:empty_rule_config()) ->
-                 [elvis_result:item()].
+-spec no_tabs(
+    elvis_config:config(),
+    elvis_file:file(),
+    elvis_style:empty_rule_config()
+) ->
+    [elvis_result:item()].
 no_tabs(_Config, Target, _RuleConfig) ->
     {Src, _} = elvis_file:src(Target),
     elvis_utils:check_lines(Src, fun check_no_tabs/2, []).
@@ -74,23 +91,29 @@ no_tabs(_Config, Target, _RuleConfig) ->
 -type no_trailing_whitespace_config() ::
     #{ignore => [module()], ignore_empty_lines => boolean()}.
 
--spec no_trailing_whitespace(Config :: elvis_config:config(),
-                             Target :: elvis_file:file(),
-                             no_trailing_whitespace_config()) ->
-                                [elvis_result:item()].
+-spec no_trailing_whitespace(
+    Config :: elvis_config:config(),
+    Target :: elvis_file:file(),
+    no_trailing_whitespace_config()
+) ->
+    [elvis_result:item()].
 no_trailing_whitespace(_Config, Target, RuleConfig) ->
     {Src, _} = elvis_file:src(Target),
     IgnoreEmptyLines = option(ignore_empty_lines, RuleConfig, no_trailing_whitespace),
-    elvis_utils:check_lines(Src,
-                            fun(Src1, Fun, _Args) ->
-                               check_no_trailing_whitespace(Src1, Fun, IgnoreEmptyLines)
-                            end,
-                            RuleConfig).
+    elvis_utils:check_lines(
+        Src,
+        fun(Src1, Fun, _Args) ->
+            check_no_trailing_whitespace(Src1, Fun, IgnoreEmptyLines)
+        end,
+        RuleConfig
+    ).
 
--spec prefer_unquoted_atoms(elvis_config:config(),
-                            elvis_file:file(),
-                            elvis_style:empty_rule_config()) ->
-                               [elvis_result:item()].
+-spec prefer_unquoted_atoms(
+    elvis_config:config(),
+    elvis_file:file(),
+    elvis_style:empty_rule_config()
+) ->
+    [elvis_result:item()].
 prefer_unquoted_atoms(_Config, Target, _RuleConfig) ->
     {Content, #{encoding := _Encoding}} = elvis_file:src(Target),
     Tree = ktn_code:parse_tree(Content),
@@ -126,7 +149,8 @@ no_redundant_blank_lines(_Config, Target, RuleConfig) ->
     Result = redundant_blank_lines(Lines, {1, []}),
 
     ResultFun =
-        fun ({Line, BlankLinesLength}) when BlankLinesLength >= MaxLines ->
+        fun
+            ({Line, BlankLinesLength}) when BlankLinesLength >= MaxLines ->
                 Info = [Line, BlankLinesLength, MaxLines],
                 {true, elvis_result:new(item, ?NO_REDUNDANT_BLANK_LINES_MSG, Info, Line)};
             (_) ->
@@ -151,8 +175,10 @@ redundant_blank_lines(Lines, {CurrentLineNum, ResultList}) ->
         0 ->
             redundant_blank_lines(lists:nthtail(Index, Lines), {NextLineNum, ResultList});
         _ ->
-            redundant_blank_lines(lists:nthtail(Index, Lines),
-                                  {NextLineNum, [{CurrentLineNum, BlankElements} | ResultList]})
+            redundant_blank_lines(
+                lists:nthtail(Index, Lines),
+                {NextLineNum, [{CurrentLineNum, BlankElements} | ResultList]}
+            )
     end.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -183,7 +209,7 @@ remove_comment(Line) ->
 
 %% @private
 -spec check_line_length(binary(), integer(), [term()]) ->
-                           no_result | {ok, elvis_result:item()}.
+    no_result | {ok, elvis_result:item()}.
 check_line_length(Line, Num, [Limit, whole_line, Encoding, NoWhitespace]) ->
     case line_is_comment(Line) of
         false ->
@@ -237,7 +263,7 @@ check_no_tabs(Line, Num) ->
 
 %% @private
 -spec check_no_trailing_whitespace(binary(), integer(), boolean()) ->
-                                      no_result | {ok, elvis_result:item()}.
+    no_result | {ok, elvis_result:item()}.
 check_no_trailing_whitespace(Line, Num, IgnoreEmptyLines) ->
     Regex =
         case IgnoreEmptyLines of
@@ -265,29 +291,55 @@ is_atom_node(MaybeAtom) ->
 %% @private
 is_exception_prefer_quoted(Elem) ->
     KeyWords =
-        ["'after'", "'and'", "'andalso'", "'band'", "'begin'", "'bnot'", "'bor'", "'bsl'",
-         "'bsr'", "'bxor'", "'case'", "'catch'", "'cond'", "'div'", "'end'", "'fun'", "'if'",
-         "'let'", "'not'", "'of'", "'or'", "'orelse'", "'receive'", "'rem'", "'try'", "'when'",
-         "'xor'", "'maybe'"],
+        [
+            "'after'",
+            "'and'",
+            "'andalso'",
+            "'band'",
+            "'begin'",
+            "'bnot'",
+            "'bor'",
+            "'bsl'",
+            "'bsr'",
+            "'bxor'",
+            "'case'",
+            "'catch'",
+            "'cond'",
+            "'div'",
+            "'end'",
+            "'fun'",
+            "'if'",
+            "'let'",
+            "'not'",
+            "'of'",
+            "'or'",
+            "'orelse'",
+            "'receive'",
+            "'rem'",
+            "'try'",
+            "'when'",
+            "'xor'",
+            "'maybe'"
+        ],
     lists:member(Elem, KeyWords).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Internal Function Definitions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--spec option(OptionName, RuleConfig, Rule) -> OptionValue
-    when OptionName :: atom(),
-         RuleConfig :: elvis_core:rule_config(),
-         Rule :: atom(),
-         OptionValue :: term().
+-spec option(OptionName, RuleConfig, Rule) -> OptionValue when
+    OptionName :: atom(),
+    RuleConfig :: elvis_core:rule_config(),
+    Rule :: atom(),
+    OptionValue :: term().
 option(OptionName, RuleConfig, Rule) ->
     maybe_default_option(maps:get(OptionName, RuleConfig, undefined), OptionName, Rule).
 
--spec maybe_default_option(UserDefinedOptionValue, OptionName, Rule) -> OptionValue
-    when UserDefinedOptionValue :: undefined | term(),
-         OptionName :: atom(),
-         Rule :: atom(),
-         OptionValue :: term().
+-spec maybe_default_option(UserDefinedOptionValue, OptionName, Rule) -> OptionValue when
+    UserDefinedOptionValue :: undefined | term(),
+    OptionName :: atom(),
+    Rule :: atom(),
+    OptionValue :: term().
 maybe_default_option(undefined = _UserDefinedOptionValue, OptionName, Rule) ->
     maps:get(OptionName, default(Rule));
 maybe_default_option(UserDefinedOptionValue, _OptionName, _Rule) ->

--- a/src/elvis_utils.erl
+++ b/src/elvis_utils.erl
@@ -7,8 +7,14 @@
 %% General
 -export([erlang_halt/1, to_str/1, split_all_lines/1, split_all_lines/2]).
 %% Output
--export([info/1, info/2, notice/1, notice/2, error/1, error/2, error_prn/1, error_prn/2,
-         warn_prn/2, parse_colors/1]).
+-export([
+    info/1, info/2,
+    notice/1, notice/2,
+    error/1, error/2,
+    error_prn/1, error_prn/2,
+    warn_prn/2,
+    parse_colors/1
+]).
 
 -export_type([file/0, line_content/0]).
 
@@ -31,7 +37,7 @@ check_lines(Src, Fun, Args) ->
 %% @doc Checks each line calling fun and providing the previous and next
 %%      lines based on the context tuple {Before, After}.
 -spec check_lines_with_context(binary(), fun(), term(), line_content()) ->
-                                  [elvis_result:item()].
+    [elvis_result:item()].
 check_lines_with_context(Src, Fun, Args, Ctx) ->
     Lines = split_all_lines(Src),
     LinesContext = context(Lines, Ctx),
@@ -40,7 +46,8 @@ check_lines_with_context(Src, Fun, Args, Ctx) ->
 %% @private
 check_lines([], _Fun, _Args, Results, _Num) ->
     lists:flatten(
-        lists:reverse(Results));
+        lists:reverse(Results)
+    );
 check_lines([Line | Lines], Fun, Args, Results, Num) ->
     FunRes =
         case is_function(Fun, 3) of
@@ -190,24 +197,26 @@ print(Message, Args) ->
 -spec parse_colors(string()) -> string().
 parse_colors(Message) ->
     Colors =
-        #{"red" => "\e[0;31m",
-          "red-bold" => "\e[1;31m",
-          "green" => "\e[0;32m",
-          "green-bold" => "\e[1;32m",
-          "white" => "\e[0;37m",
-          "white-bold" => "\e[1;37m",
-          "magenta" => "\e[1;35m",
-          "reset" => "\e[0m"},
+        #{
+            "red" => "\e[0;31m",
+            "red-bold" => "\e[1;31m",
+            "green" => "\e[0;32m",
+            "green-bold" => "\e[1;32m",
+            "white" => "\e[0;37m",
+            "white-bold" => "\e[1;37m",
+            "magenta" => "\e[1;35m",
+            "reset" => "\e[0m"
+        },
     Opts = [global, {return, list}],
     case elvis_config:from_application_or_config(output_format, colors) of
         P when P =:= plain orelse P =:= parsable ->
             re:replace(Message, "{{.*?}}", "", Opts);
         colors ->
             Fun = fun(Key, Acc) ->
-                     Regex = ["{{", Key, "}}"],
-                     Color = maps:get(Key, Colors),
-                     re:replace(Acc, Regex, Color, Opts)
-                  end,
+                Regex = ["{{", Key, "}}"],
+                Color = maps:get(Key, Colors),
+                re:replace(Acc, Regex, Color, Opts)
+            end,
             lists:foldl(Fun, Message, maps:keys(Colors))
     end.
 

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -3,19 +3,38 @@
 -behaviour(ct_suite).
 
 -export([all/0, init_per_suite/1, end_per_suite/1, chunk_fold_task/2]).
--export([rock_with_empty_map_config/1, rock_with_empty_list_config/1,
-         rock_with_incomplete_config/1, rock_with_list_config/1, rock_with_file_config/1,
-         rock_with_old_config/1, rock_with_rebar_default_config/1, rock_this/1,
-         rock_without_colors/1, rock_with_parsable/1, rock_with_no_output_has_no_output/1,
-         rock_with_non_parsable_file/1, rock_with_errors_has_output/1,
-         rock_without_errors_has_no_output/1, rock_without_errors_and_with_verbose_has_output/1,
-         rock_with_rule_groups/1, rock_this_skipping_files/1, rock_this_not_skipping_files/1,
-         rock_with_umbrella_apps/1, custom_ruleset/1, hrl_ruleset/1, throw_configuration/1,
-         find_file_and_check_src/1, find_file_with_ignore/1, invalid_file/1, to_string/1,
-         chunk_fold/1, erl_files_strict_ruleset/1]).
+-export([
+    rock_with_empty_map_config/1,
+    rock_with_empty_list_config/1,
+    rock_with_incomplete_config/1,
+    rock_with_list_config/1,
+    rock_with_file_config/1,
+    rock_with_old_config/1,
+    rock_with_rebar_default_config/1,
+    rock_this/1,
+    rock_without_colors/1,
+    rock_with_parsable/1,
+    rock_with_no_output_has_no_output/1,
+    rock_with_non_parsable_file/1,
+    rock_with_errors_has_output/1,
+    rock_without_errors_has_no_output/1,
+    rock_without_errors_and_with_verbose_has_output/1,
+    rock_with_rule_groups/1,
+    rock_this_skipping_files/1,
+    rock_this_not_skipping_files/1,
+    rock_with_umbrella_apps/1,
+    custom_ruleset/1,
+    hrl_ruleset/1,
+    throw_configuration/1,
+    find_file_and_check_src/1,
+    find_file_with_ignore/1,
+    invalid_file/1,
+    to_string/1,
+    chunk_fold/1,
+    erl_files_strict_ruleset/1
+]).
 
--define(EXCLUDED_FUNS,
-        [module_info, all, test, init_per_suite, end_per_suite, chunk_fold_task]).
+-define(EXCLUDED_FUNS, [module_info, all, test, init_per_suite, end_per_suite, chunk_fold_task]).
 
 -type config() :: [{atom(), term()}].
 
@@ -244,8 +263,10 @@ rock_without_errors_has_no_output(_Config) ->
     RemoveSearchPattern = "fail_non_parsable_file.erl",
     ct:pal("Output=~p~n", [Output]),
     [] =
-        lists:filter(fun(String) -> string:find(String, RemoveSearchPattern) == nomatch end,
-                     Output),
+        lists:filter(
+            fun(String) -> string:find(String, RemoveSearchPattern) == nomatch end,
+            Output
+        ),
     ok.
 
 -spec rock_without_errors_and_with_verbose_has_output(config()) -> ok.
@@ -263,21 +284,33 @@ rock_with_rule_groups(_Config) ->
     % elvis_config will load default elvis_core rules for every
     % rule_group in the config.
     RulesGroupConfig =
-        [#{dirs => ["src"],
-           filter => "*.erl",
-           ruleset => erl_files},
-         #{dirs => ["include"],
-           filter => "*.erl",
-           ruleset => hrl_files},
-         #{dirs => ["_build/test/lib/elvis_core/ebin"],
-           filter => "*.beam",
-           ruleset => beam_files},
-         #{dirs => ["."],
-           filter => "rebar.config",
-           ruleset => rebar_config},
-         #{dirs => ["."],
-           filter => "elvis.config",
-           ruleset => elvis_config}],
+        [
+            #{
+                dirs => ["src"],
+                filter => "*.erl",
+                ruleset => erl_files
+            },
+            #{
+                dirs => ["include"],
+                filter => "*.erl",
+                ruleset => hrl_files
+            },
+            #{
+                dirs => ["_build/test/lib/elvis_core/ebin"],
+                filter => "*.beam",
+                ruleset => beam_files
+            },
+            #{
+                dirs => ["."],
+                filter => "rebar.config",
+                ruleset => rebar_config
+            },
+            #{
+                dirs => ["."],
+                filter => "elvis.config",
+                ruleset => elvis_config
+            }
+        ],
     ok =
         try
             ok = elvis_core:rock(RulesGroupConfig)
@@ -287,10 +320,16 @@ rock_with_rule_groups(_Config) ->
         end,
     % Override default elvis_core rules without ruleset should fail.
     OverrideFailConfig =
-        [#{dirs => ["src"],
-           rules =>
-               [{elvis_text_style, line_length, #{limit => 90}},
-                {elvis_style, state_record_and_type, disable}]}],
+        [
+            #{
+                dirs => ["src"],
+                rules =>
+                    [
+                        {elvis_text_style, line_length, #{limit => 90}},
+                        {elvis_style, state_record_and_type, disable}
+                    ]
+            }
+        ],
     ok =
         try
             _ = elvis_core:rock(OverrideFailConfig),
@@ -301,18 +340,30 @@ rock_with_rule_groups(_Config) ->
         end,
     % Override default elvis_core rules.
     OverrideConfig =
-        [#{dirs => ["src"],
-           filter => "*.erl",
-           ruleset => erl_files,
-           rules =>
-               [{elvis_text_style, line_length, #{limit => 90}}, % I like 90 chars per line.
-                {elvis_text_style, no_tabs, disable}]}, % I like tabs so disable this rule.
-         #{dirs => ["."],
-           filter => "rebar.config",
-           ruleset => rebar_config},
-         #{dirs => ["."],
-           filter => "elvis.config",
-           ruleset => elvis_config}],
+        [
+            #{
+                dirs => ["src"],
+                filter => "*.erl",
+                ruleset => erl_files,
+                rules =>
+                    % I like 90 chars per line.
+                    [
+                        {elvis_text_style, line_length, #{limit => 90}},
+                        % I like tabs so disable this rule.
+                        {elvis_text_style, no_tabs, disable}
+                    ]
+            },
+            #{
+                dirs => ["."],
+                filter => "rebar.config",
+                ruleset => rebar_config
+            },
+            #{
+                dirs => ["."],
+                filter => "elvis.config",
+                ruleset => elvis_config
+            }
+        ],
     ok =
         try
             ok = elvis_core:rock(OverrideConfig)
@@ -350,17 +401,26 @@ rock_this_not_skipping_files(_Config) ->
 rock_with_umbrella_apps(_Config) ->
     ElvisUmbrellaConfigFile = "../../config/elvis-umbrella.config",
     ElvisConfig = elvis_config:from_file(ElvisUmbrellaConfigFile),
-    {fail,
-     [#{file := "../../_build/test/lib/elvis_core/test/dirs/test/dir_test.erl"},
-      #{file := "../../_build/test/lib/elvis_core/test/dirs/src/dirs_src.erl"},
-      #{file :=
-            "../../_build/test/lib/elvis_core/test/dirs/apps/app2/test/dirs_apps_app2_test.erl"},
-      #{file :=
-            "../../_build/test/lib/elvis_core/test/dirs/apps/app2/src/dirs_apps_app2_src.erl"},
-      #{file :=
-            "../../_build/test/lib/elvis_core/test/dirs/apps/app1/test/dirs_apps_app1_test.erl"},
-      #{file :=
-            "../../_build/test/lib/elvis_core/test/dirs/apps/app1/src/dirs_apps_app1_src.erl"}]} =
+    {fail, [
+        #{file := "../../_build/test/lib/elvis_core/test/dirs/test/dir_test.erl"},
+        #{file := "../../_build/test/lib/elvis_core/test/dirs/src/dirs_src.erl"},
+        #{
+            file :=
+                "../../_build/test/lib/elvis_core/test/dirs/apps/app2/test/dirs_apps_app2_test.erl"
+        },
+        #{
+            file :=
+                "../../_build/test/lib/elvis_core/test/dirs/apps/app2/src/dirs_apps_app2_src.erl"
+        },
+        #{
+            file :=
+                "../../_build/test/lib/elvis_core/test/dirs/apps/app1/test/dirs_apps_app1_test.erl"
+        },
+        #{
+            file :=
+                "../../_build/test/lib/elvis_core/test/dirs/apps/app1/src/dirs_apps_app1_src.erl"
+        }
+    ]} =
         elvis_core:rock(ElvisConfig),
     ok.
 
@@ -384,10 +444,13 @@ custom_ruleset(_Config) ->
 hrl_ruleset(_Config) ->
     ConfigPath = "../../config/elvis-test-hrl-files.config",
     ElvisConfig = elvis_config:from_file(ConfigPath),
-    {fail,
-     [#{file := "../../_build/test/lib/elvis_core/test/examples/test-good.hrl", rules := []},
-      #{file := "../../_build/test/lib/elvis_core/test/examples/test-bad.hrl",
-        rules := [#{name := line_length}]}]} =
+    {fail, [
+        #{file := "../../_build/test/lib/elvis_core/test/examples/test-good.hrl", rules := []},
+        #{
+            file := "../../_build/test/lib/elvis_core/test/examples/test-bad.hrl",
+            rules := [#{name := line_length}]
+        }
+    ]} =
         elvis_core:rock(ElvisConfig),
     ok.
 
@@ -399,10 +462,12 @@ erl_files_strict_ruleset(_Config) ->
 
     FunctionsNotErlRuleNames = [no_specs, no_types, option],
     AllRuleNames =
-        [Function
+        [
+            Function
          || {Function, Arity} <- elvis_style:module_info(exports),
             Arity =:= 3,
-            not lists:member(Function, FunctionsNotErlRuleNames)],
+            not lists:member(Function, FunctionsNotErlRuleNames)
+        ],
     AllRuleNamesSorted = lists:sort(AllRuleNames),
 
     true = AllRuleNamesSorted =:= DefinedRuleNamesSorted.
@@ -471,23 +536,28 @@ chunk_fold(_Config) ->
     Multiplier = 10,
     List = lists:seq(1, 10),
     {ok, Value} =
-        elvis_task:chunk_fold({?MODULE, chunk_fold_task},
-                              fun(Elem, Acc) -> {ok, Acc + Elem} end,
-                              0,
-                              [Multiplier],
-                              lists:seq(1, 10),
-                              10),
+        elvis_task:chunk_fold(
+            {?MODULE, chunk_fold_task},
+            fun(Elem, Acc) -> {ok, Acc + Elem} end,
+            0,
+            [Multiplier],
+            lists:seq(1, 10),
+            10
+        ),
     Value =
         lists:sum(
-            lists:map(fun(E) -> E * Multiplier end, List)),
+            lists:map(fun(E) -> E * Multiplier end, List)
+        ),
 
     {error, {error, undef}} =
-        elvis_task:chunk_fold({?MODULE, chunk_fold_task_do_not_exist},
-                              fun(Elem, Acc) -> {ok, Acc + Elem} end,
-                              0,
-                              [Multiplier],
-                              lists:seq(1, 10),
-                              10).
+        elvis_task:chunk_fold(
+            {?MODULE, chunk_fold_task_do_not_exist},
+            fun(Elem, Acc) -> {ok, Acc + Elem} end,
+            0,
+            [Multiplier],
+            lists:seq(1, 10),
+            10
+        ).
 
 -spec chunk_fold_task(integer(), integer()) -> {ok, integer()}.
 chunk_fold_task(Elem, Multiplier) ->

--- a/test/project_SUITE.erl
+++ b/test/project_SUITE.erl
@@ -3,8 +3,12 @@
 -behaviour(ct_suite).
 
 -export([all/0, init_per_suite/1, end_per_suite/1]).
--export([verify_no_branch_deps/1, verify_hex_dep/1, verify_protocol_for_deps/1,
-         verify_old_config_format/1]).
+-export([
+    verify_no_branch_deps/1,
+    verify_hex_dep/1,
+    verify_protocol_for_deps/1,
+    verify_old_config_format/1
+]).
 
 -define(EXCLUDED_FUNS, [module_info, all, test, init_per_suite, end_per_suite]).
 
@@ -60,14 +64,16 @@ verify_protocol_for_deps(_Config) ->
     Filename = "rebar.config.fail",
     {ok, File} = elvis_test_utils:find_file(SrcDirs, Filename),
 
-    [#{info := [lager, _]},
-     #{info := [getopt, _]},
-     #{info := [jiffy, _]},
-     #{info := [jsx, _]},
-     #{info := [lager, _]},
-     #{info := [getopt, _]},
-     #{info := [jiffy, _]},
-     #{info := [opentelemetry_api, _]}] =
+    [
+        #{info := [lager, _]},
+        #{info := [getopt, _]},
+        #{info := [jiffy, _]},
+        #{info := [jsx, _]},
+        #{info := [lager, _]},
+        #{info := [getopt, _]},
+        #{info := [jiffy, _]},
+        #{info := [opentelemetry_api, _]}
+    ] =
         elvis_project:protocol_for_deps(ElvisConfig, File, #{}),
 
     RuleConfig = #{ignore => [getopt, jsx]},

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -2,62 +2,123 @@
 
 -behaviour(ct_suite).
 
--export([all/0, groups/0, init_per_suite/1, end_per_suite/1, init_per_group/2,
-         end_per_group/2]).
--export([verify_function_naming_convention/1, verify_variable_naming_convention/1,
-         verify_line_length_rule/1, verify_line_length_rule_latin1/1,
-         verify_unicode_line_length_rule/1, verify_no_tabs_rule/1,
-         verify_no_trailing_whitespace_rule/1, verify_no_trailing_whitespace_rule_lf_crlf/1,
-         verify_macro_names_rule/1, verify_macro_module_names/1, verify_no_macros/1,
-         verify_no_block_expressions/1, verify_operator_spaces/1, verify_no_space/1,
-         verify_no_space_after_pound/1, verify_operator_spaces_latin1/1, verify_nesting_level/1,
-         verify_god_modules/1, verify_no_if_expression/1, verify_invalid_dynamic_call/1,
-         verify_used_ignored_variable/1, verify_no_behavior_info/1,
-         verify_module_naming_convention/1, verify_state_record_and_type/1,
-         verify_state_record_and_type_plus_export_used_types/1, verify_no_spec_with_records/1,
-         verify_dont_repeat_yourself/1, verify_max_module_length/1,
-         verify_max_anonymous_function_arity/1, verify_max_function_arity/1,
-         verify_max_function_length/1, verify_max_function_clause_length/1, verify_no_debug_call/1,
-         verify_no_common_caveats_call/1, verify_no_call/1, verify_no_nested_try_catch/1,
-         verify_no_successive_maps/1, verify_atom_naming_convention/1, verify_no_throw/1,
-         verify_no_dollar_space/1, verify_no_author/1, verify_no_import/1,
-         verify_no_catch_expressions/1, verify_no_single_clause_case/1, verify_numeric_format/1,
-         verify_behaviour_spelling/1, verify_always_shortcircuit/1,
-         verify_consistent_generic_type/1, verify_no_types/1, verify_no_specs/1,
-         verify_export_used_types/1, verify_consistent_variable_casing/1,
-         verify_no_match_in_condition/1, verify_param_pattern_matching/1,
-         verify_private_data_types/1, verify_unquoted_atoms/1, verify_no_init_lists/1,
-         verify_ms_transform_included/1, verify_redundant_blank_lines/1,
-         verify_no_boolean_in_comparison/1]).
+-export([
+    all/0,
+    groups/0,
+    init_per_suite/1,
+    end_per_suite/1,
+    init_per_group/2,
+    end_per_group/2
+]).
+-export([
+    verify_function_naming_convention/1,
+    verify_variable_naming_convention/1,
+    verify_line_length_rule/1,
+    verify_line_length_rule_latin1/1,
+    verify_unicode_line_length_rule/1,
+    verify_no_tabs_rule/1,
+    verify_no_trailing_whitespace_rule/1,
+    verify_no_trailing_whitespace_rule_lf_crlf/1,
+    verify_macro_names_rule/1,
+    verify_macro_module_names/1,
+    verify_no_macros/1,
+    verify_no_block_expressions/1,
+    verify_operator_spaces/1,
+    verify_no_space/1,
+    verify_no_space_after_pound/1,
+    verify_operator_spaces_latin1/1,
+    verify_nesting_level/1,
+    verify_god_modules/1,
+    verify_no_if_expression/1,
+    verify_invalid_dynamic_call/1,
+    verify_used_ignored_variable/1,
+    verify_no_behavior_info/1,
+    verify_module_naming_convention/1,
+    verify_state_record_and_type/1,
+    verify_state_record_and_type_plus_export_used_types/1,
+    verify_no_spec_with_records/1,
+    verify_dont_repeat_yourself/1,
+    verify_max_module_length/1,
+    verify_max_anonymous_function_arity/1,
+    verify_max_function_arity/1,
+    verify_max_function_length/1,
+    verify_max_function_clause_length/1,
+    verify_no_debug_call/1,
+    verify_no_common_caveats_call/1,
+    verify_no_call/1,
+    verify_no_nested_try_catch/1,
+    verify_no_successive_maps/1,
+    verify_atom_naming_convention/1,
+    verify_no_throw/1,
+    verify_no_dollar_space/1,
+    verify_no_author/1,
+    verify_no_import/1,
+    verify_no_catch_expressions/1,
+    verify_no_single_clause_case/1,
+    verify_numeric_format/1,
+    verify_behaviour_spelling/1,
+    verify_always_shortcircuit/1,
+    verify_consistent_generic_type/1,
+    verify_no_types/1,
+    verify_no_specs/1,
+    verify_export_used_types/1,
+    verify_consistent_variable_casing/1,
+    verify_no_match_in_condition/1,
+    verify_param_pattern_matching/1,
+    verify_private_data_types/1,
+    verify_unquoted_atoms/1,
+    verify_no_init_lists/1,
+    verify_ms_transform_included/1,
+    verify_redundant_blank_lines/1,
+    verify_no_boolean_in_comparison/1
+]).
 %% -elvis attribute
--export([verify_elvis_attr_atom_naming_convention/1, verify_elvis_attr_numeric_format/1,
-         verify_elvis_attr_dont_repeat_yourself/1, verify_elvis_attr_function_naming_convention/1,
-         verify_elvis_attr_god_modules/1, verify_elvis_attr_invalid_dynamic_call/1,
-         verify_elvis_attr_line_length/1, verify_elvis_attr_macro_module_names/1,
-         verify_elvis_attr_macro_names/1, verify_elvis_attr_max_anonymous_function_arity/1,
-         verify_elvis_attr_max_function_arity/1, verify_elvis_attr_max_function_length/1,
-         verify_elvis_attr_max_module_length/1, verify_elvis_attr_module_naming_convention/1,
-         verify_elvis_attr_nesting_level/1, verify_elvis_attr_no_behavior_info/1,
-         verify_elvis_attr_no_call/1, verify_elvis_attr_no_debug_call/1,
-         verify_elvis_attr_no_if_expression/1, verify_elvis_attr_no_nested_try_catch/1,
-         verify_elvis_attr_no_successive_maps/1, verify_elvis_attr_no_spec_with_records/1,
-         verify_elvis_attr_no_tabs/1, verify_elvis_attr_no_trailing_whitespace/1,
-         verify_elvis_attr_operator_spaces/1, verify_elvis_attr_state_record_and_type/1,
-         verify_elvis_attr_used_ignored_variable/1, verify_elvis_attr_variable_naming_convention/1,
-         verify_elvis_attr_behaviour_spelling/1, verify_elvis_attr_param_pattern_matching/1,
-         verify_elvis_attr_private_data_types/1]).
+-export([
+    verify_elvis_attr_atom_naming_convention/1,
+    verify_elvis_attr_numeric_format/1,
+    verify_elvis_attr_dont_repeat_yourself/1,
+    verify_elvis_attr_function_naming_convention/1,
+    verify_elvis_attr_god_modules/1,
+    verify_elvis_attr_invalid_dynamic_call/1,
+    verify_elvis_attr_line_length/1,
+    verify_elvis_attr_macro_module_names/1,
+    verify_elvis_attr_macro_names/1,
+    verify_elvis_attr_max_anonymous_function_arity/1,
+    verify_elvis_attr_max_function_arity/1,
+    verify_elvis_attr_max_function_length/1,
+    verify_elvis_attr_max_module_length/1,
+    verify_elvis_attr_module_naming_convention/1,
+    verify_elvis_attr_nesting_level/1,
+    verify_elvis_attr_no_behavior_info/1,
+    verify_elvis_attr_no_call/1,
+    verify_elvis_attr_no_debug_call/1,
+    verify_elvis_attr_no_if_expression/1,
+    verify_elvis_attr_no_nested_try_catch/1,
+    verify_elvis_attr_no_successive_maps/1,
+    verify_elvis_attr_no_spec_with_records/1,
+    verify_elvis_attr_no_tabs/1,
+    verify_elvis_attr_no_trailing_whitespace/1,
+    verify_elvis_attr_operator_spaces/1,
+    verify_elvis_attr_state_record_and_type/1,
+    verify_elvis_attr_used_ignored_variable/1,
+    verify_elvis_attr_variable_naming_convention/1,
+    verify_elvis_attr_behaviour_spelling/1,
+    verify_elvis_attr_param_pattern_matching/1,
+    verify_elvis_attr_private_data_types/1
+]).
 %% Non-rule
 -export([results_are_ordered_by_line/1, oddities/1]).
 
--define(EXCLUDED_FUNS,
-        [module_info,
-         all,
-         groups,
-         test,
-         init_per_suite,
-         end_per_suite,
-         init_per_group,
-         end_per_group]).
+-define(EXCLUDED_FUNS, [
+    module_info,
+    all,
+    groups,
+    test,
+    init_per_suite,
+    end_per_suite,
+    init_per_group,
+    end_per_group
+]).
 
 -type config() :: [{atom(), term()}].
 
@@ -80,20 +141,45 @@ all() ->
 
 -spec groups() -> [{beam_files, [sequence], [atom()]}].
 groups() ->
-    [{beam_files,
-      [sequence],
-      [verify_function_naming_convention, verify_variable_naming_convention,
-       verify_consistent_variable_casing, verify_nesting_level, verify_god_modules,
-       verify_no_if_expression, verify_invalid_dynamic_call, verify_used_ignored_variable,
-       verify_no_behavior_info, verify_module_naming_convention, verify_state_record_and_type,
-       verify_state_record_and_type_plus_export_used_types, verify_no_spec_with_records,
-       verify_dont_repeat_yourself, verify_no_debug_call, verify_no_common_caveats_call,
-       verify_no_call, verify_no_nested_try_catch, verify_no_successive_maps,
-       verify_atom_naming_convention, verify_no_throw, verify_no_author, verify_no_import,
-       verify_always_shortcircuit, verify_no_catch_expressions, verify_no_single_clause_case,
-       verify_no_macros, verify_export_used_types, verify_max_anonymous_function_arity,
-       verify_max_function_arity, verify_no_match_in_condition, verify_behaviour_spelling,
-       verify_param_pattern_matching, verify_private_data_types, verify_unquoted_atoms]}].
+    [
+        {beam_files, [sequence], [
+            verify_function_naming_convention,
+            verify_variable_naming_convention,
+            verify_consistent_variable_casing,
+            verify_nesting_level,
+            verify_god_modules,
+            verify_no_if_expression,
+            verify_invalid_dynamic_call,
+            verify_used_ignored_variable,
+            verify_no_behavior_info,
+            verify_module_naming_convention,
+            verify_state_record_and_type,
+            verify_state_record_and_type_plus_export_used_types,
+            verify_no_spec_with_records,
+            verify_dont_repeat_yourself,
+            verify_no_debug_call,
+            verify_no_common_caveats_call,
+            verify_no_call,
+            verify_no_nested_try_catch,
+            verify_no_successive_maps,
+            verify_atom_naming_convention,
+            verify_no_throw,
+            verify_no_author,
+            verify_no_import,
+            verify_always_shortcircuit,
+            verify_no_catch_expressions,
+            verify_no_single_clause_case,
+            verify_no_macros,
+            verify_export_used_types,
+            verify_max_anonymous_function_arity,
+            verify_max_function_arity,
+            verify_no_match_in_condition,
+            verify_behaviour_spelling,
+            verify_param_pattern_matching,
+            verify_private_data_types,
+            verify_unquoted_atoms
+        ]}
+    ].
 
 -spec init_per_suite(config()) -> config().
 init_per_suite(Config) ->
@@ -132,77 +218,99 @@ verify_function_naming_convention(Config) ->
 
     RuleConfig = #{regex => DefaultRegex},
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              function_naming_convention,
-                              RuleConfig,
-                              PathPass),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            function_naming_convention,
+            RuleConfig,
+            PathPass
+        ),
 
     RuleConfig2 = #{regex => DefaultRegex, ignore => [fail_function_naming_convention]},
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              function_naming_convention,
-                              RuleConfig2,
-                              PathPass),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            function_naming_convention,
+            RuleConfig2,
+            PathPass
+        ),
 
     % fail
     PathFail = "fail_function_naming_convention." ++ Ext,
-    [_CamelCaseError,
-     _ALL_CAPSError,
-     _InitialCapError,
-     _HyphenError,
-     _PredError,
-     _EmailError,
-     _BeforeAfter] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              function_naming_convention,
-                              RuleConfig,
-                              PathFail),
+    [
+        _CamelCaseError,
+        _ALL_CAPSError,
+        _InitialCapError,
+        _HyphenError,
+        _PredError,
+        _EmailError,
+        _BeforeAfter
+    ] =
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            function_naming_convention,
+            RuleConfig,
+            PathFail
+        ),
 
     RuleConfig3 =
-        #{regex => DefaultRegex,
-          ignore =>
-              [{fail_function_naming_convention, camelCase},
-               {fail_function_naming_convention, 'ALL_CAPS'},
-               {fail_function_naming_convention, 'Initial_cap'},
-               {fail_function_naming_convention, 'ok-for-lisp'},
-               {fail_function_naming_convention, 'no_predicates?'}]},
+        #{
+            regex => DefaultRegex,
+            ignore =>
+                [
+                    {fail_function_naming_convention, camelCase},
+                    {fail_function_naming_convention, 'ALL_CAPS'},
+                    {fail_function_naming_convention, 'Initial_cap'},
+                    {fail_function_naming_convention, 'ok-for-lisp'},
+                    {fail_function_naming_convention, 'no_predicates?'}
+                ]
+        },
     [_EmailError2, _BeforeAfter2] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              function_naming_convention,
-                              RuleConfig3,
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            function_naming_convention,
+            RuleConfig3,
+            PathFail
+        ),
 
     % ignored
     PathIgnored = "fail_function_naming_convention_ignored_function." ++ Ext,
 
     RuleConfig4 =
-        #{regex => DefaultRegex,
-          ignore =>
-              [{fail_function_naming_convention, camelCase},
-               {fail_function_naming_convention, 'ALL_CAPS'},
-               {fail_function_naming_convention, 'Initial_cap'},
-               {fail_function_naming_convention, 'ok-for-lisp'},
-               {fail_function_naming_convention, 'no_predicates?'},
-               {fail_function_naming_convention, user@location}]},
+        #{
+            regex => DefaultRegex,
+            ignore =>
+                [
+                    {fail_function_naming_convention, camelCase},
+                    {fail_function_naming_convention, 'ALL_CAPS'},
+                    {fail_function_naming_convention, 'Initial_cap'},
+                    {fail_function_naming_convention, 'ok-for-lisp'},
+                    {fail_function_naming_convention, 'no_predicates?'},
+                    {fail_function_naming_convention, user@location}
+                ]
+        },
     [_AnError] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              function_naming_convention,
-                              RuleConfig4,
-                              PathIgnored),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            function_naming_convention,
+            RuleConfig4,
+            PathIgnored
+        ),
 
     % forbidden
     PathForbidden = "forbidden_function_naming_convention." ++ Ext,
     [_, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              function_naming_convention,
-                              #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
-                              PathForbidden).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            function_naming_convention,
+            #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
+            PathForbidden
+        ).
 
 -spec verify_variable_naming_convention(config()) -> any().
 verify_variable_naming_convention(Config) ->
@@ -213,32 +321,40 @@ verify_variable_naming_convention(Config) ->
 
     PathPass = "pass_variable_naming_convention." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              variable_naming_convention,
-                              RuleConfig,
-                              PathPass),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            variable_naming_convention,
+            RuleConfig,
+            PathPass
+        ),
 
     PathFail = "fail_variable_naming_convention." ++ Ext,
-    [_AtSign,
-     _Underline_Word_Separator,
-     _Bad_Ignored_Variable,
-     _AtSignAgain,
-     _Underline_Word_SeparatorAgain] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              variable_naming_convention,
-                              RuleConfig,
-                              PathFail),
+    [
+        _AtSign,
+        _Underline_Word_Separator,
+        _Bad_Ignored_Variable,
+        _AtSignAgain,
+        _Underline_Word_SeparatorAgain
+    ] =
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            variable_naming_convention,
+            RuleConfig,
+            PathFail
+        ),
 
     % forbidden
     PathForbidden = "forbidden_variable_naming_convention." ++ Ext,
     [_, _, _, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              variable_naming_convention,
-                              #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
-                              PathForbidden).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            variable_naming_convention,
+            #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
+            PathForbidden
+        ).
 
 -spec verify_consistent_variable_casing(config()) -> any().
 verify_consistent_variable_casing(Config) ->
@@ -248,18 +364,26 @@ verify_consistent_variable_casing(Config) ->
         elvis_core_apply_rule(Config, elvis_style, consistent_variable_casing, #{}, PathPass),
 
     PathFail = "fail_consistent_variable_casing." ++ Ext,
-    [#{info := ["TypeVar", _, ["Typevar"]]},
-     #{info :=
-           ["GeneralInconsistency",
-            _,
-            ["GENERALInconsistencY",
-             "GENERALInconsistency",
-             "GeNeRaLiNcOnSiStEnCy",
-             "GeneralINCONSISTENCY"]]},
-     #{info := ["SpecVar", _, ["SPECVar"]]},
-     #{info := ["FuncVar", _, ["FUNCVar"]]},
-     #{info := ["FunVar", _, ["FunVAR"]]},
-     #{info := ["IgnVar", _, ["IGNVar"]]}] =
+    [
+        #{info := ["TypeVar", _, ["Typevar"]]},
+        #{
+            info :=
+                [
+                    "GeneralInconsistency",
+                    _,
+                    [
+                        "GENERALInconsistencY",
+                        "GENERALInconsistency",
+                        "GeNeRaLiNcOnSiStEnCy",
+                        "GeneralINCONSISTENCY"
+                    ]
+                ]
+        },
+        #{info := ["SpecVar", _, ["SPECVar"]]},
+        #{info := ["FuncVar", _, ["FUNCVar"]]},
+        #{info := ["FunVar", _, ["FunVAR"]]},
+        #{info := ["IgnVar", _, ["IGNVar"]]}
+    ] =
         elvis_core_apply_rule(Config, elvis_style, consistent_variable_casing, #{}, PathFail).
 
 -spec verify_line_length_rule(config()) -> any().
@@ -275,29 +399,37 @@ verify_line_length_rule(Config) ->
     <<"Line 32 is too long. It has ", _/binary>> = list_to_binary(io_lib:format(Msg, Info)),
 
     WholeLineResult =
-        elvis_core_apply_rule(Config,
-                              elvis_text_style,
-                              line_length,
-                              #{limit => 100, skip_comments => whole_line},
-                              Path),
+        elvis_core_apply_rule(
+            Config,
+            elvis_text_style,
+            line_length,
+            #{limit => 100, skip_comments => whole_line},
+            Path
+        ),
     6 = length(WholeLineResult),
 
     AnyResult =
-        elvis_core_apply_rule(Config,
-                              elvis_text_style,
-                              line_length,
-                              #{limit => 100, skip_comments => any},
-                              Path),
+        elvis_core_apply_rule(
+            Config,
+            elvis_text_style,
+            line_length,
+            #{limit => 100, skip_comments => any},
+            Path
+        ),
     6 = length(AnyResult),
 
     WhistespaceResult =
-        elvis_core_apply_rule(Config,
-                              elvis_text_style,
-                              line_length,
-                              #{limit => 100,
-                                skip_comments => false,
-                                no_whitespace_after_limit => false},
-                              Path),
+        elvis_core_apply_rule(
+            Config,
+            elvis_text_style,
+            line_length,
+            #{
+                limit => 100,
+                skip_comments => false,
+                no_whitespace_after_limit => false
+            },
+            Path
+        ),
     3 = length(WhistespaceResult).
 
 -spec verify_line_length_rule_latin1(config()) -> any().
@@ -353,8 +485,8 @@ verify_no_trailing_whitespace_rule_lf_crlf(Config) ->
 do_verify_no_trailing_whitespace(Path, Config, RuleConfig, ExpectedNumItems) ->
     Items =
         elvis_core_apply_rule(Config, elvis_text_style, no_trailing_whitespace, RuleConfig, Path),
-    length(Items) == ExpectedNumItems
-    orelse ct:fail("Expected ~b error items. Got: ~p", [ExpectedNumItems, Items]).
+    length(Items) == ExpectedNumItems orelse
+        ct:fail("Expected ~b error items. Got: ~p", [ExpectedNumItems, Items]).
 
 -spec verify_macro_names_rule(config()) -> any().
 verify_macro_names_rule(Config) ->
@@ -365,54 +497,66 @@ verify_macro_names_rule(Config) ->
     [_, _, _, _, _, _] = elvis_core_apply_rule(Config, elvis_style, macro_names, #{}, Path),
 
     [_, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              macro_names,
-                              #{regex => "^[A-Za-z_ ]+$"},
-                              Path),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            macro_names,
+            #{regex => "^[A-Za-z_ ]+$"},
+            Path
+        ),
 
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              macro_names,
-                              #{regex => "^[A-Za-z_ \-]+$"},
-                              Path),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            macro_names,
+            #{regex => "^[A-Za-z_ \-]+$"},
+            Path
+        ),
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              macro_names,
-                              #{regex => "^[A-Za-z_, \-]+$"},
-                              Path),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            macro_names,
+            #{regex => "^[A-Za-z_, \-]+$"},
+            Path
+        ),
 
     [_, _, _, _, _, _, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              macro_names,
-                              #{regex => "^POTENTIAL_BAD-NAME$"},
-                              Path),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            macro_names,
+            #{regex => "^POTENTIAL_BAD-NAME$"},
+            Path
+        ),
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              macro_names,
-                              #{ignore => [fail_macro_names]},
-                              Path).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            macro_names,
+            #{ignore => [fail_macro_names]},
+            Path
+        ).
 
 -spec verify_macro_module_names(config()) -> any().
 verify_macro_module_names(Config) ->
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
 
     Path = "fail_macro_module_names." ++ Ext,
-    [#{line_num := 20},
-     #{line_num := 20},
-     #{line_num := 21},
-     #{line_num := 22},
-     #{line_num := 23},
-     #{line_num := 23},
-     #{line_num := 27},
-     #{line_num := 28},
-     #{line_num := 29}] =
+    [
+        #{line_num := 20},
+        #{line_num := 20},
+        #{line_num := 21},
+        #{line_num := 22},
+        #{line_num := 23},
+        #{line_num := 23},
+        #{line_num := 27},
+        #{line_num := 28},
+        #{line_num := 29}
+    ] =
         elvis_core_apply_rule(Config, elvis_style, macro_module_names, #{}, Path).
 
 -spec verify_no_macros(config()) -> any().
@@ -423,18 +567,21 @@ verify_no_macros(Config) ->
     FailRes = elvis_core_apply_rule(Config, elvis_style, no_macros, #{}, PathFail),
     case Ext of
         "beam" ->
-            [] = FailRes; % no macros on BEAM files
+            % no macros on BEAM files
+            [] = FailRes;
         _ ->
             [_] = FailRes
     end,
 
     PathPass = "pass_no_macros." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              no_macros,
-                              #{allow => ['ALLOWED_MACRO']},
-                              PathPass).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            no_macros,
+            #{allow => ['ALLOWED_MACRO']},
+            PathPass
+        ).
 
 -spec verify_no_types(config()) -> any().
 verify_no_types(Config) ->
@@ -495,23 +642,57 @@ verify_operator_spaces(Config) ->
         elvis_core_apply_rule(Config, elvis_style, operator_spaces, ComprehensionOperation, Path),
 
     DefaultOptions = #{},
-    [#{info := [right, "," | _]}, #{info := [right, "," | _]}, #{info := [left, "++" | _]},
-     #{info := [right, "," | _]}, #{info := [left, "+" | _]}, #{info := [right, "+" | _]},
-     #{info := [right, "|" | _]}, #{info := [left, "|" | _]}, #{info := [right, "||" | _]},
-     #{info := [left, "||" | _]}, #{info := [right, "::" | _]}, #{info := [left, "::" | _]},
-     #{info := [right, "->" | _]}, #{info := [left, "->" | _]}, #{info := [left, "->" | _]},
-     #{info := [right, "+" | _]}, #{info := [left, "+" | _]}, #{info := [right, "-" | _]},
-     #{info := [left, "-" | _]}, #{info := [right, "*" | _]}, #{info := [left, "*" | _]},
-     #{info := [right, "/" | _]}, #{info := [left, "/" | _]}, #{info := [right, "=<" | _]},
-     #{info := [left, "=<" | _]}, #{info := [right, "<" | _]}, #{info := [left, "<" | _]},
-     #{info := [right, ">" | _]}, #{info := [left, ">" | _]}, #{info := [right, ">=" | _]},
-     #{info := [left, ">=" | _]}, #{info := [right, "==" | _]}, #{info := [left, "==" | _]},
-     #{info := [right, "=:=" | _]}, #{info := [left, "=:=" | _]}, #{info := [right, "/=" | _]},
-     #{info := [left, "/=" | _]}, #{info := [right, "=/=" | _]}, #{info := [left, "=/=" | _]},
-     #{info := [right, "--" | _]}, #{info := [left, "--" | _]}, #{info := [right, "||" | _]},
-     #{info := [left, "||" | _]}, #{info := [right, "||" | _]}, #{info := [left, "||" | _]},
-     #{info := [right, "|" | _]}, #{info := [left, "|" | _]}, #{info := [left, "!" | _]},
-     #{info := [right, "!" | _]}] =
+    [
+        #{info := [right, "," | _]},
+        #{info := [right, "," | _]},
+        #{info := [left, "++" | _]},
+        #{info := [right, "," | _]},
+        #{info := [left, "+" | _]},
+        #{info := [right, "+" | _]},
+        #{info := [right, "|" | _]},
+        #{info := [left, "|" | _]},
+        #{info := [right, "||" | _]},
+        #{info := [left, "||" | _]},
+        #{info := [right, "::" | _]},
+        #{info := [left, "::" | _]},
+        #{info := [right, "->" | _]},
+        #{info := [left, "->" | _]},
+        #{info := [left, "->" | _]},
+        #{info := [right, "+" | _]},
+        #{info := [left, "+" | _]},
+        #{info := [right, "-" | _]},
+        #{info := [left, "-" | _]},
+        #{info := [right, "*" | _]},
+        #{info := [left, "*" | _]},
+        #{info := [right, "/" | _]},
+        #{info := [left, "/" | _]},
+        #{info := [right, "=<" | _]},
+        #{info := [left, "=<" | _]},
+        #{info := [right, "<" | _]},
+        #{info := [left, "<" | _]},
+        #{info := [right, ">" | _]},
+        #{info := [left, ">" | _]},
+        #{info := [right, ">=" | _]},
+        #{info := [left, ">=" | _]},
+        #{info := [right, "==" | _]},
+        #{info := [left, "==" | _]},
+        #{info := [right, "=:=" | _]},
+        #{info := [left, "=:=" | _]},
+        #{info := [right, "/=" | _]},
+        #{info := [left, "/=" | _]},
+        #{info := [right, "=/=" | _]},
+        #{info := [left, "=/=" | _]},
+        #{info := [right, "--" | _]},
+        #{info := [left, "--" | _]},
+        #{info := [right, "||" | _]},
+        #{info := [left, "||" | _]},
+        #{info := [right, "||" | _]},
+        #{info := [left, "||" | _]},
+        #{info := [right, "|" | _]},
+        #{info := [left, "|" | _]},
+        #{info := [left, "!" | _]},
+        #{info := [right, "!" | _]}
+    ] =
         elvis_core_apply_rule(Config, elvis_style, operator_spaces, DefaultOptions, Path).
 
 -spec verify_no_space(config()) -> any().
@@ -519,39 +700,45 @@ verify_no_space(Config) ->
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
 
     Path1 = "fail_no_space." ++ Ext,
-    [#{info := [right, "(", 3]},
-     #{info := [right, "(", 36]},
-     #{info := [right, "(", 52]},
-     #{info := [left, ")", 52]},
-     #{info := [left, ",", 76]},
-     #{info := [left, ")", 79]},
-     #{info := [right, "(", 109]},
-     #{info := [left, ")", 109]},
-     #{info := [right, "#", 121]},
-     #{info := [right, "?", 121]}] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              no_space,
-                              elvis_style:default(no_space),
-                              Path1).
+    [
+        #{info := [right, "(", 3]},
+        #{info := [right, "(", 36]},
+        #{info := [right, "(", 52]},
+        #{info := [left, ")", 52]},
+        #{info := [left, ",", 76]},
+        #{info := [left, ")", 79]},
+        #{info := [right, "(", 109]},
+        #{info := [left, ")", 109]},
+        #{info := [right, "#", 121]},
+        #{info := [right, "?", 121]}
+    ] =
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            no_space,
+            elvis_style:default(no_space),
+            Path1
+        ).
 
 -spec verify_no_space_after_pound(config()) -> any().
 verify_no_space_after_pound(Config) ->
     PathFail = "fail_no_space_after_pound.erl",
-    [#{line_num := 5},
-     #{line_num := 7},
-     #{line_num := 8},
-     #{line_num := 12},
-     #{line_num := 14},
-     #{line_num := 14},
-     #{line_num := 15},
-     #{line_num := 16},
-     #{line_num := 16},
-     #{line_num := 18},
-     #{line_num := 20},
-     #{line_num := 20},
-     #{line_num := 21},
-     #{line_num := 22}] =
+    [
+        #{line_num := 5},
+        #{line_num := 7},
+        #{line_num := 8},
+        #{line_num := 12},
+        #{line_num := 14},
+        #{line_num := 14},
+        #{line_num := 15},
+        #{line_num := 16},
+        #{line_num := 16},
+        #{line_num := 18},
+        #{line_num := 20},
+        #{line_num := 20},
+        #{line_num := 21},
+        #{line_num := 22}
+    ] =
         elvis_core_apply_rule(Config, elvis_style, no_space_after_pound, #{}, PathFail),
 
     PathPass = "pass_no_space_after_pound.erl",
@@ -576,34 +763,41 @@ verify_nesting_level(Config) ->
 
     Path = "fail_nesting_level." ++ Ext,
 
-    _ = case Group of
+    _ =
+        case Group of
             beam_files ->
-                [#{line_num := 9},
-                 #{line_num := 12},
-                 #{line_num := 23},
-                 #{line_num := 39},
-                 #{line_num := 69},
-                 #{line_num := 108},
-                 #{line_num := 153},
-                 #{line_num := 170}] =
+                [
+                    #{line_num := 9},
+                    #{line_num := 12},
+                    #{line_num := 23},
+                    #{line_num := 39},
+                    #{line_num := 69},
+                    #{line_num := 108},
+                    #{line_num := 153},
+                    #{line_num := 170}
+                ] =
                     elvis_core_apply_rule(Config, elvis_style, nesting_level, #{level => 3}, Path);
             erl_files ->
-                [#{line_num := 11},
-                 #{line_num := 18},
-                 #{line_num := 30},
-                 #{line_num := 45},
-                 #{line_num := 78},
-                 #{line_num := 120},
-                 #{line_num := 166},
-                 #{line_num := 182}] =
+                [
+                    #{line_num := 11},
+                    #{line_num := 18},
+                    #{line_num := 30},
+                    #{line_num := 45},
+                    #{line_num := 78},
+                    #{line_num := 120},
+                    #{line_num := 166},
+                    #{line_num := 182}
+                ] =
                     elvis_core_apply_rule(Config, elvis_style, nesting_level, #{level => 3}, Path)
         end,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              nesting_level,
-                              #{ignore => [fail_nesting_level]},
-                              Path).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            nesting_level,
+            #{ignore => [fail_nesting_level]},
+            Path
+        ).
 
 -spec verify_god_modules(config()) -> any().
 verify_god_modules(Config) ->
@@ -621,7 +815,8 @@ verify_no_if_expression(Config) ->
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
 
     Path = "fail_no_if_expression." ++ Ext,
-    _ = case Group of
+    _ =
+        case Group of
             beam_files ->
                 [#{line_num := 8}, #{line_num := 18}, #{line_num := 26}] =
                     elvis_core_apply_rule(Config, elvis_style, no_if_expression, #{}, Path);
@@ -639,24 +834,29 @@ verify_invalid_dynamic_call(Config) ->
     [] = elvis_core_apply_rule(Config, elvis_style, invalid_dynamic_call, #{}, PathPass),
 
     PathFail = "fail_invalid_dynamic_call." ++ Ext,
-    _ = case Group of
+    _ =
+        case Group of
             beam_files ->
-                [#{line_num := _},
-                 #{line_num := _},
-                 #{line_num := _},
-                 #{line_num := _},
-                 #{line_num := _},
-                 #{line_num := _},
-                 #{line_num := _}] =
+                [
+                    #{line_num := _},
+                    #{line_num := _},
+                    #{line_num := _},
+                    #{line_num := _},
+                    #{line_num := _},
+                    #{line_num := _},
+                    #{line_num := _}
+                ] =
                     elvis_core_apply_rule(Config, elvis_style, invalid_dynamic_call, #{}, PathFail);
             erl_files ->
-                [#{line_num := 19},
-                 #{line_num := 31},
-                 #{line_num := 32},
-                 #{line_num := 40},
-                 #{line_num := 48},
-                 #{line_num := 59},
-                 #{line_num := 66}] =
+                [
+                    #{line_num := 19},
+                    #{line_num := 31},
+                    #{line_num := 32},
+                    #{line_num := 40},
+                    #{line_num := 48},
+                    #{line_num := 59},
+                    #{line_num := 66}
+                ] =
                     elvis_core_apply_rule(Config, elvis_style, invalid_dynamic_call, #{}, PathFail)
         end,
 
@@ -671,7 +871,8 @@ verify_used_ignored_variable(Config) ->
 
     Path = "fail_used_ignored_variable." ++ Ext,
     Path2 = "used_ignored_variable_in_macro." ++ Ext,
-    _ = case Group of
+    _ =
+        case Group of
             beam_files ->
                 [#{line_num := _}, #{line_num := _}, #{line_num := _}, #{line_num := _}] =
                     elvis_core_apply_rule(Config, elvis_style, used_ignored_variable, #{}, Path);
@@ -682,11 +883,13 @@ verify_used_ignored_variable(Config) ->
         end,
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              used_ignored_variable,
-                              #{ignore => [fail_used_ignored_variable]},
-                              Path).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            used_ignored_variable,
+            #{ignore => [fail_used_ignored_variable]},
+            Path
+        ).
 
 -spec verify_no_behavior_info(config()) -> any().
 verify_no_behavior_info(Config) ->
@@ -694,7 +897,8 @@ verify_no_behavior_info(Config) ->
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
 
     Path = "fail_no_behavior_info." ++ Ext,
-    _ = case Group of
+    _ =
+        case Group of
             beam_files ->
                 [#{line_num := 7}, #{line_num := 10}] =
                     elvis_core_apply_rule(Config, elvis_style, no_behavior_info, #{}, Path);
@@ -712,36 +916,44 @@ verify_module_naming_convention(Config) ->
 
     PathPass = "pass_module_naming_convention." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              module_naming_convention,
-                              RuleConfig,
-                              PathPass),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            module_naming_convention,
+            RuleConfig,
+            PathPass
+        ),
 
     PathFail = "fail_module_naming_1_convention_1_." ++ Ext,
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              module_naming_convention,
-                              RuleConfig,
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            module_naming_convention,
+            RuleConfig,
+            PathFail
+        ),
 
     RuleConfigIgnore = RuleConfig#{ignore => [fail_module_naming_1_convention_1_]},
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              module_naming_convention,
-                              RuleConfigIgnore,
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            module_naming_convention,
+            RuleConfigIgnore,
+            PathFail
+        ),
 
     % forbidden
     PathForbidden = "forbidden_module_naming_convention_12." ++ Ext,
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              module_naming_convention,
-                              #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
-                              PathForbidden).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            module_naming_convention,
+            #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
+            PathForbidden
+        ).
 
 -spec verify_state_record_and_type(config()) -> any().
 verify_state_record_and_type(Config) ->
@@ -752,11 +964,13 @@ verify_state_record_and_type(Config) ->
 
     PathPassWithOpaque = "pass_state_record_and_type_opaque." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              state_record_and_type,
-                              #{},
-                              PathPassWithOpaque),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            state_record_and_type,
+            #{},
+            PathPassWithOpaque
+        ),
 
     PathPassGenStateM = "pass_state_record_and_type_gen_statem." ++ Ext,
     [] =
@@ -774,19 +988,23 @@ verify_state_record_and_type(Config) ->
 
     PathFailGenStateMType = "fail_state_record_and_type_gen_statem_type." ++ Ext,
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              state_record_and_type,
-                              #{},
-                              PathFailGenStateMType),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            state_record_and_type,
+            #{},
+            PathFailGenStateMType
+        ),
 
     PathPassGenStateMState = "fail_state_record_and_type_gen_statem_state." ++ Ext,
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              state_record_and_type,
-                              #{},
-                              PathPassGenStateMState).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            state_record_and_type,
+            #{},
+            PathPassGenStateMState
+        ).
 
 -spec verify_state_record_and_type_plus_export_used_types(config()) -> any().
 verify_state_record_and_type_plus_export_used_types(Config) ->
@@ -813,33 +1031,41 @@ verify_behaviour_spelling(Config) ->
 
     PathFail = "british_behaviour_spelling." ++ Ext,
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              behaviour_spelling,
-                              #{spelling => behavior},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            behaviour_spelling,
+            #{spelling => behavior},
+            PathFail
+        ),
     PathFail1 = "american_behavior_spelling." ++ Ext,
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              behaviour_spelling,
-                              #{spelling => behaviour},
-                              PathFail1),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            behaviour_spelling,
+            #{spelling => behaviour},
+            PathFail1
+        ),
 
     PathPass = "british_behaviour_spelling." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              behaviour_spelling,
-                              #{spelling => behaviour},
-                              PathPass),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            behaviour_spelling,
+            #{spelling => behaviour},
+            PathPass
+        ),
     PathPass1 = "american_behavior_spelling." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              behaviour_spelling,
-                              #{spelling => behavior},
-                              PathPass1).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            behaviour_spelling,
+            #{spelling => behavior},
+            PathPass1
+        ).
 
 -spec verify_param_pattern_matching(config()) -> any().
 verify_param_pattern_matching(Config) ->
@@ -847,44 +1073,56 @@ verify_param_pattern_matching(Config) ->
 
     PathRight = "right_param_pattern_matching." ++ Ext,
     PathLeft = "left_param_pattern_matching." ++ Ext,
-    [#{info := ['Simple' | _]},
-     #{info := ['SimpleToo' | _]},
-     #{info := ['The' | _]},
-     #{info := ['TheToo' | _]},
-     #{info := ['AsYoda' | _]},
-     #{info := ['AsYodaToo' | _]}] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              param_pattern_matching,
-                              #{side => left},
-                              PathRight),
-    [#{info := ['Simple' | _]},
-     #{info := ['SimpleToo' | _]},
-     #{info := ['Multiple' | _]},
-     #{info := ['MultipleToo' | _]},
-     #{info := ['TheSecond' | _]},
-     #{info := ['TheSecondToo' | _]},
-     #{info := ['But' | _]},
-     #{info := ['ButToo' | _]}] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              param_pattern_matching,
-                              #{side => right},
-                              PathLeft),
+    [
+        #{info := ['Simple' | _]},
+        #{info := ['SimpleToo' | _]},
+        #{info := ['The' | _]},
+        #{info := ['TheToo' | _]},
+        #{info := ['AsYoda' | _]},
+        #{info := ['AsYodaToo' | _]}
+    ] =
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            param_pattern_matching,
+            #{side => left},
+            PathRight
+        ),
+    [
+        #{info := ['Simple' | _]},
+        #{info := ['SimpleToo' | _]},
+        #{info := ['Multiple' | _]},
+        #{info := ['MultipleToo' | _]},
+        #{info := ['TheSecond' | _]},
+        #{info := ['TheSecondToo' | _]},
+        #{info := ['But' | _]},
+        #{info := ['ButToo' | _]}
+    ] =
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            param_pattern_matching,
+            #{side => right},
+            PathLeft
+        ),
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              param_pattern_matching,
-                              #{side => right},
-                              PathRight),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            param_pattern_matching,
+            #{side => right},
+            PathRight
+        ),
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              param_pattern_matching,
-                              #{side => left},
-                              PathLeft).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            param_pattern_matching,
+            #{side => left},
+            PathLeft
+        ).
 
 -spec verify_consistent_generic_type(config()) -> any().
 verify_consistent_generic_type(Config) ->
@@ -892,61 +1130,77 @@ verify_consistent_generic_type(Config) ->
 
     PathFail = "consistent_generic_type_term." ++ Ext,
     [_, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              consistent_generic_type,
-                              #{preferred_type => any},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            consistent_generic_type,
+            #{preferred_type => any},
+            PathFail
+        ),
     PathFail1 = "consistent_generic_type_any." ++ Ext,
     [_, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              consistent_generic_type,
-                              #{preferred_type => term},
-                              PathFail1),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            consistent_generic_type,
+            #{preferred_type => term},
+            PathFail1
+        ),
     PathFail2 = "consistent_generic_type_term_and_any." ++ Ext,
     [_, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              consistent_generic_type,
-                              #{preferred_type => any},
-                              PathFail2),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            consistent_generic_type,
+            #{preferred_type => any},
+            PathFail2
+        ),
     PathFail3 = "consistent_generic_type_term_and_any." ++ Ext,
     [_, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              consistent_generic_type,
-                              #{preferred_type => term},
-                              PathFail3),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            consistent_generic_type,
+            #{preferred_type => term},
+            PathFail3
+        ),
 
     PathPass = "consistent_generic_type_term." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              consistent_generic_type,
-                              #{preferred_type => term},
-                              PathPass),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            consistent_generic_type,
+            #{preferred_type => term},
+            PathPass
+        ),
     PathPass1 = "consistent_generic_type_any." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              consistent_generic_type,
-                              #{preferred_type => any},
-                              PathPass1),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            consistent_generic_type,
+            #{preferred_type => any},
+            PathPass1
+        ),
     PathPass2 = "consistent_generic_type_no_checks." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              consistent_generic_type,
-                              #{preferred_type => term},
-                              PathPass2),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            consistent_generic_type,
+            #{preferred_type => term},
+            PathPass2
+        ),
     PathPass2 = "consistent_generic_type_no_checks." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              consistent_generic_type,
-                              #{preferred_type => any},
-                              PathPass2).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            consistent_generic_type,
+            #{preferred_type => any},
+            PathPass2
+        ).
 
 -spec verify_always_shortcircuit(config()) -> any().
 verify_always_shortcircuit(Config) ->
@@ -1000,9 +1254,11 @@ verify_max_module_length(Config) ->
     PathFail = "fail_max_module_length." ++ Ext,
 
     CountAllRuleConfig =
-        #{count_comments => true,
-          count_whitespace => true,
-          count_docs => true},
+        #{
+            count_comments => true,
+            count_whitespace => true,
+            count_docs => true
+        },
 
     ct:comment("Count whitespace, comment, and documentation lines"),
     RuleConfig = CountAllRuleConfig#{max_length => 18},
@@ -1091,52 +1347,66 @@ verify_max_function_arity(Config) ->
     PathFail = "fail_max_function_arity." ++ Ext,
     [] = elvis_core_apply_rule(Config, elvis_style, max_function_arity, #{}, PathFail),
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_arity,
-                              #{max_arity => 2},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_arity,
+            #{max_arity => 2},
+            PathFail
+        ),
     [_, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_arity,
-                              #{max_arity => 1},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_arity,
+            #{max_arity => 1},
+            PathFail
+        ),
     [_, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_arity,
-                              #{max_arity => 0},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_arity,
+            #{max_arity => 0},
+            PathFail
+        ),
     [_, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_arity,
-                              #{max_arity => -1},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_arity,
+            #{max_arity => -1},
+            PathFail
+        ),
 
     PathNonExportedPass = "pass_max_non_exported_function_arity." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_arity,
-                              #{max_arity => 3, non_exported_max_arity => 9},
-                              PathNonExportedPass),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_arity,
+            #{max_arity => 3, non_exported_max_arity => 9},
+            PathNonExportedPass
+        ),
 
     PathNonExportedFail = "fail_max_non_exported_function_arity." ++ Ext,
     [_, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_arity,
-                              #{max_arity => 1, non_exported_max_arity => 2},
-                              PathNonExportedFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_arity,
+            #{max_arity => 1, non_exported_max_arity => 2},
+            PathNonExportedFail
+        ),
 
     [_, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_arity,
-                              #{max_arity => 3, non_exported_max_arity => same},
-                              PathNonExportedPass),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_arity,
+            #{max_arity => 3, non_exported_max_arity => same},
+            PathNonExportedPass
+        ),
     ok.
 
 -spec verify_max_anonymous_function_arity(config()) -> any().
@@ -1147,40 +1417,50 @@ verify_max_anonymous_function_arity(Config) ->
     RuleConfig = #{max_arity => 3},
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_anonymous_function_arity,
-                              RuleConfig,
-                              PathPass),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_anonymous_function_arity,
+            RuleConfig,
+            PathPass
+        ),
 
     %% This module has funs with 0, 1, 2, and 3 arguments
     PathFail = "fail_max_anonymous_function_arity." ++ Ext,
     [] =
         elvis_core_apply_rule(Config, elvis_style, max_anonymous_function_arity, #{}, PathFail),
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_anonymous_function_arity,
-                              #{max_arity => 2},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_anonymous_function_arity,
+            #{max_arity => 2},
+            PathFail
+        ),
     [_, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_anonymous_function_arity,
-                              #{max_arity => 1},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_anonymous_function_arity,
+            #{max_arity => 1},
+            PathFail
+        ),
     [_, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_anonymous_function_arity,
-                              #{max_arity => 0},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_anonymous_function_arity,
+            #{max_arity => 0},
+            PathFail
+        ),
     [_, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_anonymous_function_arity,
-                              #{max_arity => -1},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_anonymous_function_arity,
+            #{max_arity => -1},
+            PathFail
+        ),
 
     ok.
 
@@ -1262,65 +1542,77 @@ verify_max_function_clause_length(Config) ->
 
     ct:comment("Count whitespace and comment lines"),
     [_, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_clause_length,
-                              RuleConfig,
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_clause_length,
+            RuleConfig,
+            PathFail
+        ),
 
     PathSuccess = "pass_max_function_clause_length." ++ Ext,
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_clause_length,
-                              RuleConfig,
-                              PathSuccess),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_clause_length,
+            RuleConfig,
+            PathSuccess
+        ),
 
     RuleConfig2 = CountAllRuleConfig#{max_length => 15},
     PathExtraSuccess = "fail_max_function_length." ++ Ext,
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_clause_length,
-                              RuleConfig2,
-                              PathExtraSuccess),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_clause_length,
+            RuleConfig2,
+            PathExtraSuccess
+        ),
 
     RuleConfig3 = CountAllRuleConfig#{max_length => 1},
 
     [_, _, _, _, _, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_clause_length,
-                              RuleConfig3,
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_clause_length,
+            RuleConfig3,
+            PathFail
+        ),
 
     RuleConfig4 = CountAllRuleConfig#{max_length => 1},
     PathClauseNumbers = "function_clause_numbers." ++ Ext,
 
     Result =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              max_function_clause_length,
-                              RuleConfig4,
-                              PathClauseNumbers),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            max_function_clause_length,
+            RuleConfig4,
+            PathClauseNumbers
+        ),
 
     Numbers = [Number || #{info := [Number, _, _, _, _]} <- Result],
 
-    ["1st",
-     "5th",
-     "6th",
-     "7th",
-     "11th",
-     "13th",
-     "19th",
-     "20th",
-     "21st",
-     "29th",
-     "30th",
-     "31st",
-     "33rd"] =
+    [
+        "1st",
+        "5th",
+        "6th",
+        "7th",
+        "11th",
+        "13th",
+        "19th",
+        "20th",
+        "21st",
+        "29th",
+        "30th",
+        "31st",
+        "33rd"
+    ] =
         Numbers.
 
 -spec verify_no_debug_call(config()) -> any().
@@ -1330,8 +1622,10 @@ verify_no_debug_call(Config) ->
 
     PathFail = "fail_no_debug_call." ++ Ext,
 
-    _ = case Group of
-            beam_files -> % io:format is preprocessed
+    _ =
+        case Group of
+            % io:format is preprocessed
+            beam_files ->
                 [_, _, _, _, _, _] =
                     elvis_core_apply_rule(Config, elvis_style, no_debug_call, #{}, PathFail);
             erl_files ->
@@ -1343,28 +1637,36 @@ verify_no_debug_call(Config) ->
     [] = elvis_core_apply_rule(Config, elvis_style, no_debug_call, RuleConfig, PathFail),
 
     RuleConfig2 = #{debug_functions => [{ct, pal, 2}]},
-    _ = case Group of
-            beam_files -> % ct:pal is preprocessed
+    _ =
+        case Group of
+            % ct:pal is preprocessed
+            beam_files ->
                 [] =
-                    elvis_core_apply_rule(Config,
-                                          elvis_style,
-                                          no_debug_call,
-                                          RuleConfig2,
-                                          PathFail);
+                    elvis_core_apply_rule(
+                        Config,
+                        elvis_style,
+                        no_debug_call,
+                        RuleConfig2,
+                        PathFail
+                    );
             erl_files ->
                 [_] =
                     elvis_core_apply_rule(Config, elvis_style, no_debug_call, RuleConfig2, PathFail)
         end,
 
     RuleConfig3 = #{debug_functions => [{ct, pal}]},
-    _ = case Group of
-            beam_files -> % ct:pal is preprocessed
+    _ =
+        case Group of
+            % ct:pal is preprocessed
+            beam_files ->
                 [] =
-                    elvis_core_apply_rule(Config,
-                                          elvis_style,
-                                          no_debug_call,
-                                          RuleConfig3,
-                                          PathFail);
+                    elvis_core_apply_rule(
+                        Config,
+                        elvis_style,
+                        no_debug_call,
+                        RuleConfig3,
+                        PathFail
+                    );
             erl_files ->
                 [_, _] =
                     elvis_core_apply_rule(Config, elvis_style, no_debug_call, RuleConfig3, PathFail)
@@ -1388,47 +1690,59 @@ verify_no_call(Config) ->
     verify_no_call_flavours(Config, no_call, no_call_functions, 0).
 
 -spec verify_no_call_flavours(any(), atom(), atom(), non_neg_integer()) -> any().
-verify_no_call_flavours(Config,
-                        RuleName,
-                        RuleConfigMapKey,
-                        ExpectedDefaultRuleMatchCount) ->
+verify_no_call_flavours(
+    Config,
+    RuleName,
+    RuleConfigMapKey,
+    ExpectedDefaultRuleMatchCount
+) ->
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
 
     PathFail = "fail_no_call_classes." ++ Ext,
 
-    assert_length(ExpectedDefaultRuleMatchCount,
-                  elvis_core_apply_rule(Config, elvis_style, RuleName, #{}, PathFail),
-                  RuleName),
+    assert_length(
+        ExpectedDefaultRuleMatchCount,
+        elvis_core_apply_rule(Config, elvis_style, RuleName, #{}, PathFail),
+        RuleName
+    ),
 
     RuleConfig = #{ignore => [fail_no_call_classes]},
-    assert_length(0,
-                  elvis_core_apply_rule(Config, elvis_style, RuleName, RuleConfig, PathFail),
-                  RuleName),
+    assert_length(
+        0,
+        elvis_core_apply_rule(Config, elvis_style, RuleName, RuleConfig, PathFail),
+        RuleName
+    ),
 
     RuleMatchTuples =
-        [{{timer, send_after, 2}, 1},
-         {{timer, send_after, 3}, 1},
-         {{timer, send_interval, 2}, 1},
-         {{timer, send_interval, 3}, 1},
-         {{erlang, size, 1}, 2},
-         {{timer, send_after}, 2},
-         {{timer, '_', '_'}, 4},
-         {{'_', tuple_size, 1}, 1},
-         {{gen_statem, call, 2}, 1},
-         {{gen_server, call, 2}, 1},
-         {{gen_event, call, 3}, 1}],
+        [
+            {{timer, send_after, 2}, 1},
+            {{timer, send_after, 3}, 1},
+            {{timer, send_interval, 2}, 1},
+            {{timer, send_interval, 3}, 1},
+            {{erlang, size, 1}, 2},
+            {{timer, send_after}, 2},
+            {{timer, '_', '_'}, 4},
+            {{'_', tuple_size, 1}, 1},
+            {{gen_statem, call, 2}, 1},
+            {{gen_server, call, 2}, 1},
+            {{gen_event, call, 3}, 1}
+        ],
 
-    lists:foreach(fun({FunSpec, ExpectedCount}) ->
-                     ThisRuleConfig = maps:from_list([{RuleConfigMapKey, [FunSpec]}]),
-                     Result =
-                         elvis_core_apply_rule(Config,
-                                               elvis_style,
-                                               RuleName,
-                                               ThisRuleConfig,
-                                               PathFail),
-                     assert_length(ExpectedCount, Result, RuleName)
-                  end,
-                  RuleMatchTuples).
+    lists:foreach(
+        fun({FunSpec, ExpectedCount}) ->
+            ThisRuleConfig = maps:from_list([{RuleConfigMapKey, [FunSpec]}]),
+            Result =
+                elvis_core_apply_rule(
+                    Config,
+                    elvis_style,
+                    RuleName,
+                    ThisRuleConfig,
+                    PathFail
+                ),
+            assert_length(ExpectedCount, Result, RuleName)
+        end,
+        RuleMatchTuples
+    ).
 
 -spec verify_no_nested_try_catch(config()) -> any().
 verify_no_nested_try_catch(Config) ->
@@ -1437,7 +1751,8 @@ verify_no_nested_try_catch(Config) ->
 
     Module = fail_no_nested_try_catch,
     Path = atom_to_list(Module) ++ "." ++ Ext,
-    _ = case Group of
+    _ =
+        case Group of
             beam_files ->
                 [#{line_num := 9}, #{line_num := 18}, #{line_num := 21}] =
                     elvis_core_apply_rule(Config, elvis_style, no_nested_try_catch, #{}, Path);
@@ -1447,11 +1762,13 @@ verify_no_nested_try_catch(Config) ->
         end,
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              no_nested_try_catch,
-                              #{ignore => [Module]},
-                              Path),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            no_nested_try_catch,
+            #{ignore => [Module]},
+            Path
+        ),
 
     Module2 = pass_no_nested_try_catch,
     Path2 = atom_to_list(Module2) ++ "." ++ Ext,
@@ -1468,7 +1785,8 @@ verify_no_successive_maps(Config) ->
     Path = atom_to_list(Module) ++ "." ++ Ext,
 
     Path2 = "fail_no_successive_maps2." ++ Ext,
-    _ = case Group of
+    _ =
+        case Group of
             beam_files ->
                 [_, _, _] =
                     elvis_core_apply_rule(Config, elvis_style, no_successive_maps, #{}, Path),
@@ -1482,11 +1800,13 @@ verify_no_successive_maps(Config) ->
         end,
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              no_successive_maps,
-                              #{ignore => [Module]},
-                              Path).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            no_successive_maps,
+            #{ignore => [Module]},
+            Path
+        ).
 
 -else.
 
@@ -1514,19 +1834,23 @@ verify_ms_transform_included(Config) ->
 
     CustomFunctionPath = "custom_ms_transform_included." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              ms_transform_included,
-                              #{},
-                              CustomFunctionPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            ms_transform_included,
+            #{},
+            CustomFunctionPath
+        ),
 
     IncludedButNotUsed = "included_but_not_used_ms_transform." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              ms_transform_included,
-                              #{},
-                              IncludedButNotUsed),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            ms_transform_included,
+            #{},
+            IncludedButNotUsed
+        ),
 
     DoubleInclude = "double_include_ms_transform." ++ Ext,
     [] =
@@ -1544,15 +1868,17 @@ verify_no_boolean_in_comparison(Config) ->
     [] = elvis_core_apply_rule(Config, elvis_style, no_boolean_in_comparison, #{}, PassPath),
 
     FailPath = "fail_no_boolean_in_comparison." ++ Ext,
-    [#{line_num := 6},
-     #{line_num := 6},
-     #{line_num := 13},
-     #{line_num := 16},
-     #{line_num := 19},
-     #{line_num := 22},
-     #{line_num := 22},
-     #{line_num := 26},
-     #{line_num := 26}] =
+    [
+        #{line_num := 6},
+        #{line_num := 6},
+        #{line_num := 13},
+        #{line_num := 16},
+        #{line_num := 19},
+        #{line_num := 22},
+        #{line_num := 22},
+        #{line_num := 26},
+        #{line_num := 26}
+    ] =
         elvis_core_apply_rule(Config, elvis_style, no_boolean_in_comparison, #{}, FailPath).
 
 -spec verify_atom_naming_convention(config()) -> any().
@@ -1573,23 +1899,29 @@ verify_atom_naming_convention(Config) ->
     PassPath3 = atom_to_list(PassModule3) ++ "." ++ Ext,
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => BaseRegex},
-                              PassPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => BaseRegex},
+            PassPath
+        ),
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => "^[^xwyhr]*$"},
-                              PassPath2),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => "^[^xwyhr]*$"},
+            PassPath2
+        ),
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => "^^[a-z]([a-zA-Z0-9@]*_?)*(_SUITE)?$"},
-                              PassPath3),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => "^^[a-z]([a-zA-Z0-9@]*_?)*(_SUITE)?$"},
+            PassPath3
+        ),
 
     % fail
     FailModule = fail_atom_naming_convention,
@@ -1598,126 +1930,174 @@ verify_atom_naming_convention(Config) ->
     FailPath2 = atom_to_list(FailModule2) ++ "." ++ Ext,
 
     [_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => BaseRegex, enclosed_atoms => same},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => BaseRegex, enclosed_atoms => same},
+            FailPath
+        ),
     [_, _, _, _, _, _, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => "^([a-zA-Z_]+)$", enclosed_atoms => same},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => "^([a-zA-Z_]+)$", enclosed_atoms => same},
+            FailPath
+        ),
     [_, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => "^([a-zA-Z_' \\\\]+)$", enclosed_atoms => same},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => "^([a-zA-Z_' \\\\]+)$", enclosed_atoms => same},
+            FailPath
+        ),
     [_, _, _, _, _, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => "^([a-zA-Z\-_]+)$", enclosed_atoms => same},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => "^([a-zA-Z\-_]+)$", enclosed_atoms => same},
+            FailPath
+        ),
     [_, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => "^([a-zA-Z\-_' \\\\]+)$", enclosed_atoms => same},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => "^([a-zA-Z\-_' \\\\]+)$", enclosed_atoms => same},
+            FailPath
+        ),
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => "^([0-9]?[a-zA-Z\-_]+)$"},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => "^([0-9]?[a-zA-Z\-_]+)$"},
+            FailPath
+        ),
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => BaseRegex, ignore => [FailModule]},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => BaseRegex, ignore => [FailModule]},
+            FailPath
+        ),
     KeepRegex = "^([a-zA-Z0-9_]+)$",
     [_, _, _, _, _, _, _, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => KeepRegex, enclosed_atoms => "^([a-z][a-z0-9A-Z_]*)$"},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => KeepRegex, enclosed_atoms => "^([a-z][a-z0-9A-Z_]*)$"},
+            FailPath
+        ),
     [_, _, _, _, _, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => KeepRegex,
-                                enclosed_atoms => "^([a-z][a-z0-9A-Z_' \\\\]*)$"},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{
+                regex => KeepRegex,
+                enclosed_atoms => "^([a-z][a-z0-9A-Z_' \\\\]*)$"
+            },
+            FailPath
+        ),
     [_, _, _, _, _, _, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => KeepRegex, enclosed_atoms => "^([a-z][\-a-z0-9A-Z_]*)$"},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => KeepRegex, enclosed_atoms => "^([a-z][\-a-z0-9A-Z_]*)$"},
+            FailPath
+        ),
     [_, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => KeepRegex,
-                                enclosed_atoms => "^([0-9a-z][\-a-z0-9A-Z_' \\\\]*)$"},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{
+                regex => KeepRegex,
+                enclosed_atoms => "^([0-9a-z][\-a-z0-9A-Z_' \\\\]*)$"
+            },
+            FailPath
+        ),
     [_] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => "^[^xwyhr]*$"},
-                              FailPath2),
-    _ = case Group of
-            beam_files -> % 'or_THIS' getting stripped of enclosing '
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{regex => "^[^xwyhr]*$"},
+            FailPath2
+        ),
+    _ =
+        case Group of
+            % 'or_THIS' getting stripped of enclosing '
+            beam_files ->
                 [_, _, _, _, _, _, _, _] =
-                    elvis_core_apply_rule(Config,
-                                          elvis_style,
-                                          atom_naming_convention,
-                                          #{regex => KeepRegex,
-                                            enclosed_atoms => "^([\\\\][\-a-z0-9A-Z_' \\\\]*)$"},
-                                          FailPath);
+                    elvis_core_apply_rule(
+                        Config,
+                        elvis_style,
+                        atom_naming_convention,
+                        #{
+                            regex => KeepRegex,
+                            enclosed_atoms => "^([\\\\][\-a-z0-9A-Z_' \\\\]*)$"
+                        },
+                        FailPath
+                    );
             erl_files ->
                 [_, _, _, _, _, _, _, _, _] =
-                    elvis_core_apply_rule(Config,
-                                          elvis_style,
-                                          atom_naming_convention,
-                                          #{regex => KeepRegex,
-                                            enclosed_atoms => "^([\\\\][\-a-z0-9A-Z_' \\\\]*)$"},
-                                          FailPath)
+                    elvis_core_apply_rule(
+                        Config,
+                        elvis_style,
+                        atom_naming_convention,
+                        #{
+                            regex => KeepRegex,
+                            enclosed_atoms => "^([\\\\][\-a-z0-9A-Z_' \\\\]*)$"
+                        },
+                        FailPath
+                    )
         end,
 
     % forbidden
     PathForbidden = "forbidden_atom_naming_convention." ++ Ext,
-    _ = case Group of
-            beam_files -> % 'or_THIS' getting stripped of enclosing '
+    _ =
+        case Group of
+            % 'or_THIS' getting stripped of enclosing '
+            beam_files ->
                 [_, _, _, _] =
-                    elvis_core_apply_rule(Config,
-                                          elvis_style,
-                                          atom_naming_convention,
-                                          #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
-                                          PathForbidden);
+                    elvis_core_apply_rule(
+                        Config,
+                        elvis_style,
+                        atom_naming_convention,
+                        #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
+                        PathForbidden
+                    );
             erl_files ->
                 [_, _, _] =
-                    elvis_core_apply_rule(Config,
-                                          elvis_style,
-                                          atom_naming_convention,
-                                          #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
-                                          PathForbidden)
+                    elvis_core_apply_rule(
+                        Config,
+                        elvis_style,
+                        atom_naming_convention,
+                        #{regex => DefaultRegex, forbidden_regex => "[0-9]"},
+                        PathForbidden
+                    )
         end,
 
     [_, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              atom_naming_convention,
-                              #{regex => DefaultRegex,
-                                forbidden_regex => "[0-9]",
-                                forbidden_enclosed_regex => same},
-                              PathForbidden).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            atom_naming_convention,
+            #{
+                regex => DefaultRegex,
+                forbidden_regex => "[0-9]",
+                forbidden_enclosed_regex => same
+            },
+            PathForbidden
+        ).
 
 -spec verify_no_init_lists(config()) -> any().
 verify_no_init_lists(Config) ->
@@ -1804,7 +2184,8 @@ verify_no_catch_expressions(Config) ->
     FailPath = "fail_no_catch_expressions." ++ Ext,
 
     R = elvis_core_apply_rule(Config, elvis_style, no_catch_expressions, #{}, FailPath),
-    _ = case Group of
+    _ =
+        case Group of
             beam_files ->
                 [#{info := [10]}, #{info := [21]}, #{info := [21]}] = lists:sort(R);
             erl_files ->
@@ -1822,7 +2203,8 @@ verify_no_single_clause_case(Config) ->
     FailPath = "fail_no_single_clause_case." ++ Ext,
 
     R = elvis_core_apply_rule(Config, elvis_style, no_single_clause_case, #{}, FailPath),
-    _ = case Group of
+    _ =
+        case Group of
             beam_files ->
                 [_, _, _] = R;
             erl_files ->
@@ -1860,89 +2242,122 @@ verify_numeric_format(Config) ->
     PassPath = atom_to_list(PassModule) ++ "." ++ Ext,
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              numeric_format,
-                              #{regex => BaseRegex},
-                              PassPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            numeric_format,
+            #{regex => BaseRegex},
+            PassPath
+        ),
 
     % fail
     FailModule = fail_numeric_format,
     FailPath = atom_to_list(FailModule) ++ "." ++ Ext,
 
-    [_, _, _, _, _, _, _, _, _, _, _, _, _, _, _] = % no underscores
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              numeric_format,
-                              #{regex => BaseRegex,
-                                int_regex => same,
-                                float_regex => same},
-                              FailPath),
-    [_, _, _, _, _, _, _, _, _, _, _] = % with at least 2 digits
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              numeric_format,
-                              #{regex => "^(.*\\d\\d)$",
-                                int_regex => same,
-                                float_regex => same},
-                              FailPath),
-    [_, _, _, _] = % only base 10
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              numeric_format,
-                              #{regex => "^([^#]+)$",
-                                int_regex => same,
-                                float_regex => same},
-                              FailPath),
+    % no underscores
+    [_, _, _, _, _, _, _, _, _, _, _, _, _, _, _] =
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            numeric_format,
+            #{
+                regex => BaseRegex,
+                int_regex => same,
+                float_regex => same
+            },
+            FailPath
+        ),
+    % with at least 2 digits
+    [_, _, _, _, _, _, _, _, _, _, _] =
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            numeric_format,
+            #{
+                regex => "^(.*\\d\\d)$",
+                int_regex => same,
+                float_regex => same
+            },
+            FailPath
+        ),
+    % only base 10
+    [_, _, _, _] =
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            numeric_format,
+            #{
+                regex => "^([^#]+)$",
+                int_regex => same,
+                float_regex => same
+            },
+            FailPath
+        ),
 
     % any float, nothing else - impossible to match base regex
     [_, _, _, _, _, _, _, _, _, _, _, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              numeric_format,
-                              #{regex => "impossible-to-match",
-                                int_regex => same,
-                                float_regex => ".*"},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            numeric_format,
+            #{
+                regex => "impossible-to-match",
+                int_regex => same,
+                float_regex => ".*"
+            },
+            FailPath
+        ),
 
     % any integer, nothing else - impossible to match base regex
     [_, _, _, _] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              numeric_format,
-                              #{regex => "impossible-to-match",
-                                int_regex => ".*",
-                                float_regex => same},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            numeric_format,
+            #{
+                regex => "impossible-to-match",
+                int_regex => ".*",
+                float_regex => same
+            },
+            FailPath
+        ),
 
     % base regex is ignored
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              numeric_format,
-                              #{regex => "impossible-to-match",
-                                int_regex => ".*",
-                                float_regex => ".*"},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            numeric_format,
+            #{
+                regex => "impossible-to-match",
+                int_regex => ".*",
+                float_regex => ".*"
+            },
+            FailPath
+        ),
 
     % ignored module
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              numeric_format,
-                              #{regex => BaseRegex, ignore => [FailModule]},
-                              FailPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            numeric_format,
+            #{regex => BaseRegex, ignore => [FailModule]},
+            FailPath
+        ),
 
     % ugly
     UglyModule = ugly_numeric_format,
     UglyPath = atom_to_list(UglyModule) ++ "." ++ Ext,
 
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              numeric_format,
-                              #{regex => BaseRegex},
-                              UglyPath),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            numeric_format,
+            #{regex => BaseRegex},
+            UglyPath
+        ),
 
     true.
 
@@ -1961,40 +2376,50 @@ verify_private_data_types(Config) ->
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
     PathPass = "pass_private_data_types2." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              private_data_types,
-                              #{apply_to => [record, map, tuple]},
-                              PathPass),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            private_data_types,
+            #{apply_to => [record, map, tuple]},
+            PathPass
+        ),
     PathPass2 = "pass_private_data_types2." ++ Ext,
     [] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              private_data_types,
-                              #{apply_to => [record, map, tuple]},
-                              PathPass2),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            private_data_types,
+            #{apply_to => [record, map, tuple]},
+            PathPass2
+        ),
     % Default applies only to records
     PathFail = "fail_private_data_types." ++ Ext,
     [#{line_num := _}] =
         elvis_core_apply_rule(Config, elvis_style, private_data_types, #{}, PathFail),
     [#{line_num := _}] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              private_data_types,
-                              #{apply_to => [tuple]},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            private_data_types,
+            #{apply_to => [tuple]},
+            PathFail
+        ),
     [#{line_num := _}] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              private_data_types,
-                              #{apply_to => [map]},
-                              PathFail),
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            private_data_types,
+            #{apply_to => [map]},
+            PathFail
+        ),
     [#{line_num := _}, #{line_num := _}, #{line_num := _}] =
-        elvis_core_apply_rule(Config,
-                              elvis_style,
-                              private_data_types,
-                              #{apply_to => [record, tuple, map]},
-                              PathFail).
+        elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            private_data_types,
+            #{apply_to => [record, tuple, map]},
+            PathFail
+        ).
 
 -spec results_are_ordered_by_line(config()) -> true.
 results_are_ordered_by_line(_Config) ->
@@ -2005,10 +2430,14 @@ results_are_ordered_by_line(_Config) ->
 -spec oddities(config()) -> true.
 oddities(_Config) ->
     ElvisConfig =
-        [#{dirs => ["../../_build/test/lib/elvis_core/test/examples"],
-           filter => "odditiesß.erl",
-           ruleset => erl_files,
-           rules => [{elvis_style, god_modules, #{limit => 0}}]}],
+        [
+            #{
+                dirs => ["../../_build/test/lib/elvis_core/test/examples"],
+                filter => "odditiesß.erl",
+                ruleset => erl_files,
+                rules => [{elvis_style, god_modules, #{limit => 0}}]
+            }
+        ],
     {fail, [#{rules := [_, _, _, _]}]} = elvis_core:rock(ElvisConfig),
     true.
 
@@ -2161,7 +2590,8 @@ verify_elvis_attr_private_data_types(Config) ->
 elvis_core_apply_rule(Config, Module, Function, RuleConfig, Filename) ->
     ElvisConfig =
         elvis_test_utils:config(
-            proplists:get_value(group, Config, erl_files)),
+            proplists:get_value(group, Config, erl_files)
+        ),
     SrcDirs = elvis_config:dirs(ElvisConfig),
     {ok, File} = elvis_test_utils:find_file(SrcDirs, Filename),
     {[RulesResults], _, _} =
@@ -2176,7 +2606,8 @@ elvis_core_apply_rule(Config, Module, Function, RuleConfig, Filename) ->
 verify_elvis_attr(Config, FilenameNoExt) ->
     ElvisConfig =
         elvis_test_utils:config(
-            proplists:get_value(group, Config, erl_files)),
+            proplists:get_value(group, Config, erl_files)
+        ),
     SrcDirs = elvis_config:dirs(ElvisConfig),
     Ext = proplists:get_value(test_file_ext, Config, "erl"),
 


### PR DESCRIPTION
# Description

Change formatting tool from `rebar3_formatter` to `erlfmt`.

We have some options for formatting lists, maps, etc., so please comment on your opinions about the first default versions.
Available change options: https://github.com/WhatsApp/erlfmt?tab=readme-ov-file#manual-interventions

Or should I only commit to `rebar.config` with the possibility of fmt but not formatting all the files first?

Closes #387.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
