### PR TITLE
Fixes #390: Allow test generators in default `function_naming_convention` regex

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ file.
 ## Development
 
 CI for `elvis_core` is pretty simple, but in case you want to replicate it locally before
-pushing most issues will be found via `rebar3 do format --verify, test`.
+pushing most issues will be found via `rebar3 do fmt --check, test`.
 
 ## Questions?
 

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -352,7 +352,7 @@ default(nesting_level) ->
 default(god_modules) ->
     #{limit => 25};
 default(function_naming_convention) ->
-    #{regex => "^[a-z](_?[a-z0-9]+)*$", forbidden_regex => undefined};
+    #{regex => "^[a-z](_?[a-z0-9]+)*(_test_)?$", forbidden_regex => undefined};
 default(variable_naming_convention) ->
     #{regex => "^_?([A-Z][0-9a-zA-Z]*)$", forbidden_regex => undefined};
 default(module_naming_convention) ->

--- a/test/examples/pass_function_naming_convention.erl
+++ b/test/examples/pass_function_naming_convention.erl
@@ -12,3 +12,11 @@ has_digit1(Should, Pass) ->
 
 snake_case(Should, Pass) ->
     [Should, Pass].
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% A function with a name ending in ..._test_() (note the final underscore) is 
+%% recognized by EUnit as a test generator function. 
+%% Test generators return a representation of a set of tests to be executed by EUnit.
+basic_test_() ->
+    fun () -> ?assert(1 + 1 =:= 2) end.


### PR DESCRIPTION
# Description

Allow test generators in default `function_naming_convention` regex

Closes #390 

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
