### PR TITLE
Fix false positive warning for no-match-in-condition

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1794,8 +1794,19 @@ no_match_in_condition(Config, Target, RuleConfig) ->
     ).
 
 is_match_in_condition(Node) ->
-    (ktn_code:type(Node) == case_expr orelse ktn_code:type(Node) == block) andalso
-        lists:any(fun is_match/1, ktn_code:content(Node)).
+    ktn_code:type(Node) == case_expr andalso
+        %% case_expr followed by a match
+        (has_match_child(Node) orelse
+            %% or case_expr followed by a block which contains a match in the first layer
+            lists:any(
+                fun(Node1) ->
+                    ktn_code:type(Node1) == block andalso has_match_child(Node1)
+                end,
+                ktn_code:content(Node)
+            )).
+
+has_match_child(Node) ->
+    lists:any(fun is_match/1, ktn_code:content(Node)).
 
 is_match(Node) ->
     ktn_code:type(Node) == match orelse ktn_code:type(Node) == maybe_match.

--- a/test/examples/pass_no_match_in_condition3.erl
+++ b/test/examples/pass_no_match_in_condition3.erl
@@ -1,0 +1,20 @@
+-module(pass_no_match_in_condition3).
+
+-export([valid/1]).
+
+valid(List) ->
+    case
+        do_some(
+            begin
+                Something = find:something(for, foo),
+                check:something(bar, Something)
+            end,
+            List
+        )
+    of
+        true -> all_true;
+        false -> found_a_bad_one
+    end.
+
+do_some(_Do, _List) ->
+    true.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -2220,6 +2220,8 @@ verify_no_match_in_condition(Config) ->
     [] = elvis_core_apply_rule(Config, elvis_style, no_match_in_condition, #{}, PassPath),
     PassPath2 = "pass_no_match_in_condition2." ++ Ext,
     [] = elvis_core_apply_rule(Config, elvis_style, no_match_in_condition, #{}, PassPath2),
+    PassPath3 = "pass_no_match_in_condition3." ++ Ext,
+    [] = elvis_core_apply_rule(Config, elvis_style, no_match_in_condition, #{}, PassPath3),
 
     FailPath = "fail_no_match_in_condition." ++ Ext,
     R = elvis_core_apply_rule(Config, elvis_style, no_match_in_condition, #{}, FailPath),


### PR DESCRIPTION
# Description

Only `case_expr` followed by a match or `case_expr` followed by a block which contains a match in the first layer will trigger this rule.

Closes #393.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
