### PR TITLE
Clarify documentation for rule `no_debug_call`

### DIFF
--- a/doc_rules/elvis_style/no_debug_call.md
+++ b/doc_rules/elvis_style/no_debug_call.md
@@ -1,6 +1,8 @@
 # No debug call
 
-Don't leave debugging function calls such as `io:format` or `ct:pal` in your source code.
+Don't leave debugging function calls, such as `io:format/1` or `ct:pal/1,2,3,4,5`, in your source
+code.
+The functions listed in option `debug_functions` are the ones you want the rule to warn you about.
 
 > Works on `.beam` file? Yes!
 


### PR DESCRIPTION
# Description

I try to clarify `no_debug_call`'s option `debug_functions` via more explicit text.

Closes #398.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
