### PR TITLE
Allow recent changes to be used in Erlang/OTP24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        otp_vsn: ['25', '26', '27']
+        otp_vsn: ['24']
         rebar3_vsn: ['3.24']
         os: [ubuntu-24.04, windows-2022]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         otp_vsn: ['24']
-        rebar3_vsn: ['3.24']
-        os: [ubuntu-24.04, windows-2022]
+        rebar3_vsn: ['3.22']
+        os: [ubuntu-24.04]
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
@@ -42,9 +42,6 @@ jobs:
                 -otp-${{steps.setup-beam.outputs.otp-version}}\
                 -rebar3-${{steps.setup-beam.outputs.rebar3-version}}\
                 -hash-${{hashFiles('rebar.lock')}}"
-      - name: Format check
-        if: ${{ matrix.os == 'ubuntu-24.04' && matrix.otp_vsn == '26' }}
-        run: rebar3 fmt --check
       - name: Run test
         run: rebar3 test
       - name: Run elvis on elvis

--- a/rebar.config
+++ b/rebar.config
@@ -2,8 +2,6 @@
 
 {erl_opts, [warn_unused_import, warn_export_vars, warnings_as_errors, verbose, report, debug_info]}.
 
-{minimum_otp_vsn, "25"}.
-
 {profiles, [
     {test, [
         {extra_src_dirs, ["test/examples"]},
@@ -16,7 +14,7 @@
     ]}
 ]}.
 
-{alias, [{test, [compile, fmt, hank, xref, dialyzer, ct, cover, ex_doc]}]}.
+{alias, [{test, [compile, fmt, hank, xref, dialyzer, ct, cover]}]}.
 
 {shell, [{config, "config/test.config"}]}.
 

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1665,7 +1665,7 @@ no_boolean_in_comparison(Config, Target, RuleConfig) ->
                 lists:any(IsBoolean, Content)
         end,
     ComparisonsWithBoolean =
-        lists:uniq(
+        lists:usort(
             elvis_code:find(IsComparisonWithBoolean, Root, #{traverse => all})
         ),
 
@@ -1698,7 +1698,7 @@ no_operation_on_same_value(Config, Target, RuleConfig) ->
         end,
 
     OpNodes =
-        lists:uniq(
+        lists:usort(
             elvis_code:find(IsInterestingOp, Root, #{traverse => all})
         ),
 


### PR DESCRIPTION
# Description

I want to be able to use the latest rules we added and the latest fixes we have with my production code which, sadly, still uses OTP24. So I created the `otp24-releases` branch to generate backporting releases for this.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
