### PR TITLE
Simplify `elvis_code`

### DIFF
--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -5,7 +5,6 @@
     find/2,
     find/3,
     find_by_location/2,
-    find_by_names/2,
     find_by_types/2,
     find_by_types/3,
     find_by_types_in_tokens/2,
@@ -144,14 +143,6 @@ find_by_location(Root, Location) ->
         [Node | _] ->
             {ok, Node}
     end.
-
-find_by_names(Names, Root) ->
-    find(
-        fun(Node) ->
-            lists:member(ktn_code:attr(name, Node), Names)
-        end,
-        Root
-    ).
 
 find_by_types(Types, Root) ->
     find_by_types(Types, Root, #{mode => node, traverse => content}).

--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -32,7 +32,7 @@
 -spec find(fun((zipper:zipper(_)) -> boolean()), ktn_code:tree_node()) ->
     [ktn_code:tree_node()].
 find(Pred, Root) ->
-    find(Pred, Root, #{mode => node, traverse => content}).
+    find(Pred, Root, #{}).
 
 %% @doc Find all nodes in the tree for which the predicate function returns
 %%      `true'. The options map has two keys:
@@ -141,7 +141,7 @@ find_by_location(Root, Location) ->
     end.
 
 find_by_types(Types, Root) ->
-    find_by_types(Types, Root, #{mode => node, traverse => content}).
+    find_by_types(Types, Root, #{}).
 
 find_by_types(Types, Root, Opts) ->
     find(

--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -50,7 +50,6 @@ find(Pred, Root) ->
 %%        </li>
 %%      </ul>
 %% @end
-
 -spec find(fun((zipper:zipper(_)) -> boolean()), ktn_code:tree_node(), find_options()) ->
     [ktn_code:tree_node()].
 find(Pred, Root, Opts) ->
@@ -184,6 +183,7 @@ find_token(Root, Location) ->
 print_node(Node) ->
     print_node(Node, 0).
 
+%% @doc Debugging utility function.
 -spec print_node(ktn_code:tree_node(), integer()) -> ok.
 print_node(#{type := Type} = Node, CurrentLevel) ->
     Type = ktn_code:type(Node),

--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -17,7 +17,6 @@
     past_nesting_limit/2,
     exported_functions/1,
     exported_types/1,
-    function_names/1,
     module_name/1,
     print_node/1, print_node/2
 ]).
@@ -241,13 +240,6 @@ exported_types(#{type := root, content := Content}) ->
     Fun = make_extractor_fun(exported_types),
     lists:flatmap(Fun, Content).
 
-%% @doc Takes the root node of a parse_tree and returns the name
-%%      of each function, whether exported or not.
--spec function_names(ktn_code:tree_node()) -> [atom()].
-function_names(#{type := root, content := Content}) ->
-    Fun = make_extractor_fun(function_names),
-    lists:flatmap(Fun, Content).
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Internal
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -281,13 +273,6 @@ make_extractor_fun(exported_types) ->
     fun
         (#{type := export_type} = Node) ->
             ktn_code:attr(value, Node);
-        (_) ->
-            []
-    end;
-make_extractor_fun(function_names) ->
-    fun
-        (#{type := function} = Node) ->
-            [ktn_code:attr(name, Node)];
         (_) ->
             []
     end.

--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -15,7 +15,6 @@
 %% Specific
 -export([
     past_nesting_limit/2,
-    exported_types/1,
     module_name/1,
     print_node/1, print_node/2
 ]).
@@ -227,11 +226,6 @@ module_name(#{type := root, content := Content}) ->
             undefined
     end.
 
--spec exported_types(ktn_code:tree_node()) -> [{atom(), integer()}].
-exported_types(#{type := root, content := Content}) ->
-    Fun = make_extractor_fun(exported_types),
-    lists:flatmap(Fun, Content).
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Internal
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -249,12 +243,4 @@ level_increment(#{type := Type}) ->
             1;
         false ->
             0
-    end.
-
-make_extractor_fun(exported_types) ->
-    fun
-        (#{type := export_type} = Node) ->
-            ktn_code:attr(value, Node);
-        (_) ->
-            []
     end.

--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -15,7 +15,6 @@
 %% Specific
 -export([
     past_nesting_limit/2,
-    exported_functions/1,
     exported_types/1,
     module_name/1,
     print_node/1, print_node/2
@@ -228,13 +227,6 @@ module_name(#{type := root, content := Content}) ->
             undefined
     end.
 
-%% @doc Takes the root node of a parse_tree and returns name and arity
-%%      of each exported function.
--spec exported_functions(ktn_code:tree_node()) -> [{atom(), integer()}].
-exported_functions(#{type := root, content := Content}) ->
-    Fun = make_extractor_fun(exported_functions),
-    lists:flatmap(Fun, Content).
-
 -spec exported_types(ktn_code:tree_node()) -> [{atom(), integer()}].
 exported_types(#{type := root, content := Content}) ->
     Fun = make_extractor_fun(exported_types),
@@ -259,16 +251,6 @@ level_increment(#{type := Type}) ->
             0
     end.
 
-%% @private
-%% @doc Returns an anonymous Fun to be flatmapped over node content, as
-%% appropriate for the exported function whose name is the argument given.
-make_extractor_fun(exported_functions) ->
-    fun
-        (#{type := export} = Node) ->
-            ktn_code:attr(value, Node);
-        (_) ->
-            []
-    end;
 make_extractor_fun(exported_types) ->
     fun
         (#{type := export_type} = Node) ->

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -146,7 +146,6 @@ is_invalid_rule({Module, RuleName}) ->
 normalize(Config) when is_list(Config) ->
     lists:map(fun do_normalize/1, Config).
 
-%% @private
 do_normalize(#{src_dirs := Dirs} = Config) ->
     %% NOTE: Provided for backwards compatibility.
     %% Rename 'src_dirs' key to 'dirs'.

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -82,7 +82,6 @@ rock_this(Path, Config) ->
             elvis_result_status(Results)
     end.
 
-%% @private
 -spec do_parallel_rock(elvis_config:config()) ->
     ok
     | {fail, [{throw, term()} | elvis_result:file() | elvis_result:rule()]}.
@@ -119,7 +118,6 @@ do_rock(File, Config) ->
     Results = apply_rules(Config, LoadedFile),
     {ok, Results}.
 
-%% @private
 -spec load_file_data(elvis_config:configs() | elvis_config:config(), elvis_file:file()) ->
     elvis_file:file().
 load_file_data(Config, File) ->
@@ -134,7 +132,6 @@ load_file_data(Config, File) ->
             File
     end.
 
-%% @private
 -spec main([]) -> true | no_return().
 main([]) ->
     ok = application:load(elvis_core),
@@ -148,7 +145,6 @@ main([]) ->
 %%% Private
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%% @private
 -spec combine_results(
     ok | {fail, [elvis_result:file()]},
     ok | {fail, [elvis_result:file()]}
@@ -166,7 +162,6 @@ apply_rules_and_print(Config, File) ->
     elvis_result:print_results(Results),
     Results.
 
-%% @private
 -spec apply_rules(
     elvis_config:configs() | elvis_config:config(),
     File :: elvis_file:file()
@@ -180,24 +175,20 @@ apply_rules(Config, File) ->
         lists:foldl(fun apply_rule/2, Acc, merge_rules({file, ParseTree}, lists:flatten(Rules))),
     elvis_result:new(file, File, RulesResults).
 
-%% @private
 merge_rules({file, ParseTree}, ElvisConfigRules) ->
     ElvisAttrs =
         elvis_code:find(fun is_elvis_attr/1, ParseTree, #{traverse => content, mode => node}),
     ElvisAttrRules = elvis_attr_rules(ElvisAttrs),
     elvis_config:merge_rules(ElvisAttrRules, ElvisConfigRules).
 
-%% @private
 is_elvis_attr(Node) ->
     ktn_code:type(Node) =:= elvis.
 
-%% @private
 elvis_attr_rules([] = _ElvisAttrs) ->
     [];
 elvis_attr_rules(ElvisAttrs) ->
     [Rule || ElvisAttr <- ElvisAttrs, Rule <- ktn_code:attr(value, ElvisAttr)].
 
-%% @private
 -spec apply_rule({Mod, Fun} | {Mod, Fun, RuleCfg}, {Results, ElvisCfg, File}) -> Result when
     Mod :: module(),
     Fun :: atom(),
@@ -241,7 +232,6 @@ apply_rule({Module, Function, ConfigArgs}, {Result, Config, File}) ->
         end,
     {[RuleResult | Result], Config, File}.
 
-%% @private
 %% @doc Process a tules configuration argument and converts it to a map.
 ensure_config_map(_, _, Map) when is_map(Map) ->
     Map;
@@ -262,7 +252,6 @@ ensure_config_map(elvis_style, module_naming_convention, [Regex, IgnoreModules])
 ensure_config_map(_, _, []) ->
     #{}.
 
-%% @private
 elvis_result_status(Results) ->
     case elvis_result:status(Results) of
         fail ->

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -36,8 +36,6 @@ start() ->
     {ok, _} = application:ensure_all_started(elvis_core),
     ok.
 
-%%% Rock Command
-
 -spec rock(elvis_config:configs()) ->
     ok | {fail, [{throw, term()} | elvis_result:file() | elvis_result:rule()]}.
 rock(Config) ->

--- a/src/elvis_file.erl
+++ b/src/elvis_file.erl
@@ -140,7 +140,6 @@ module(#{path := Path}) ->
 %% Private
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%% @private
 -spec resolve_parse_tree(string(), string() | binary(), module(), list()) ->
     undefined | ktn_code:tree_node().
 resolve_parse_tree(".erl", Content, Mod, Ignore) ->
@@ -152,7 +151,6 @@ resolve_parse_tree(".hrl", Content, Mod, Ignore) ->
 resolve_parse_tree(_, _, _, _) ->
     undefined.
 
-%% @private
 filter_tree_for(Tree, Mod, Ignore) when is_map(Tree) ->
     TreeContent = maps:get(content, Tree, []),
     Tree#{
@@ -176,7 +174,6 @@ filter_tree_for(Tree, Mod, Ignore) when is_map(Tree) ->
 filter_tree_for(Tree, _Mod, _Ignore) ->
     Tree.
 
-%% @private
 -spec find_encoding(Content :: binary()) -> atom().
 find_encoding(Content) ->
     case epp:read_encoding_from_binary(Content) of
@@ -186,7 +183,6 @@ find_encoding(Content) ->
             Enc
     end.
 
-%% @private
 -spec maybe_add_abstract_parse_tree(Config, File, Mod, Ignore) -> Res when
     Config :: elvis_config:configs() | elvis_config:config(),
     File :: file(),
@@ -204,7 +200,6 @@ maybe_add_abstract_parse_tree(
 maybe_add_abstract_parse_tree(_Config, File, _Mod, _Ignore) ->
     File.
 
-%% @private
 -spec get_abstract_parse_tree(BeamPath, Mod, Ignore) -> Res when
     BeamPath :: file:filename(),
     Mod :: module(),
@@ -214,7 +209,6 @@ get_abstract_parse_tree(BeamPath, Mod, Ignore) ->
     AbstractSrc = get_abstract_source(BeamPath),
     resolve_parse_tree(".erl", AbstractSrc, Mod, Ignore).
 
-%% @private
 -spec get_abstract_source(BeamPath) -> Res when
     BeamPath :: file:filename() | binary(),
     Res :: string().

--- a/src/elvis_gitignore.erl
+++ b/src/elvis_gitignore.erl
@@ -69,7 +69,6 @@ forbidden_patterns(_Config, #{path := Path}, RuleConfig) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %% .gitignore
-%% @private
 check_patterns_in_lines(_Lines, [], Results, _Mode) ->
     {ok, Results};
 check_patterns_in_lines(Lines, [Pattern | Rest], Results0, Mode) ->

--- a/src/elvis_project.erl
+++ b/src/elvis_project.erl
@@ -102,7 +102,6 @@ old_configuration_format(_Config, Target, _RuleConfig) ->
 
 %%% Rebar
 
-%% @private
 get_deps(File) ->
     {Src, _} = elvis_file:src(File),
     Terms = ktn_code:consult(Src),
@@ -121,7 +120,6 @@ get_deps(File) ->
     end.
 
 %% Rebar3
-%% @private
 is_branch_dep({_AppName, {_SCM, _Location, {branch, _}}}) ->
     true;
 is_branch_dep({_AppName, {git_subdir, _Url, {branch, _}, _SubDir}}) ->
@@ -130,13 +128,11 @@ is_branch_dep({_AppName, {git_subdir, _Url, {branch, _}, _SubDir}}) ->
 is_branch_dep({AppName, {raw, DepResourceSpecification}}) ->
     is_branch_dep({AppName, DepResourceSpecification});
 %% Rebar2
-%% @private
 is_branch_dep({_AppName, _Vsn, {_SCM, _Location, {branch, _}}}) ->
     true;
 is_branch_dep(_) ->
     false.
 
-%% @private
 is_hex_dep(_AppName) when is_atom(_AppName) ->
     true;
 is_hex_dep({_AppName, _Vsn, {pkg, _PackageName}}) when
@@ -150,7 +146,6 @@ is_hex_dep({_AppName, _Vsn}) when is_atom(_AppName), is_list(_Vsn) ->
 is_hex_dep(_) ->
     false.
 
-%% @private
 is_not_git_dep({_AppName, {_SCM, Url, _Branch}}, Regex) ->
     nomatch == re:run(Url, Regex, []);
 is_not_git_dep(
@@ -179,7 +174,6 @@ is_not_git_dep({_AppName, _Vsn, {_SCM, Url, {BranchTagOrRefType, _Branch}}, _Opt
 ->
     nomatch == re:run(Url, Regex, []).
 
-%% @private
 dep_to_result({AppName, _}, Message, {IgnoreDeps, Regex}) ->
     case lists:member(AppName, IgnoreDeps) of
         true ->
@@ -203,7 +197,6 @@ dep_to_result({AppName, _Vsn, GitInfo, _Opts}, Message, IgnoreDeps) ->
 
 %% Old config
 
-%% @private
 is_old_config(ElvisConfig) ->
     case proplists:get_value(config, ElvisConfig) of
         undefined ->
@@ -218,7 +211,6 @@ is_old_config(ElvisConfig) ->
             lists:filter(SrcDirsIsKey, Config) /= []
     end.
 
-%% @private
 exists_old_rule(#{rules := Rules}) ->
     Filter =
         fun

--- a/src/elvis_result.erl
+++ b/src/elvis_result.erl
@@ -167,6 +167,7 @@ print_rules(Format, File, [Error | Items]) ->
     print_rules(Format, File, Items).
 
 %% Item
+
 print_item(
     Format,
     File,

--- a/src/elvis_result.erl
+++ b/src/elvis_result.erl
@@ -219,7 +219,6 @@ status(_Rules) ->
 clean(Files) ->
     clean(Files, []).
 
-%% @private
 -spec clean([file() | rule()], [file() | rule()]) -> [file() | rule()].
 clean([], Result) ->
     lists:reverse(Result);

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1671,9 +1671,7 @@ no_boolean_in_comparison(Config, Target, RuleConfig) ->
 
     IsBoolean =
         fun(Node) ->
-            lists:member(
-                ktn_code:attr(value, Node), [true, false]
-            )
+            is_boolean(ktn_code:attr(value, Node))
         end,
 
     IsComparisonWithBoolean =

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1589,15 +1589,12 @@ is_relevant_behaviour(Root, RuleConfig) ->
     ConfigBehaviors = option(behaviours, RuleConfig, no_init_lists),
     Behaviours = elvis_code:find_by_types([behaviour, behavior], Root),
     lists:any(
-        fun(Elem) -> Elem end,
-        lists:map(
-            fun(BehaviourNode) ->
-                lists:member(
-                    ktn_code:attr(value, BehaviourNode), ConfigBehaviors
-                )
-            end,
-            Behaviours
-        )
+        fun(BehaviourNode) ->
+            lists:member(
+                ktn_code:attr(value, BehaviourNode), ConfigBehaviors
+            )
+        end,
+        Behaviours
     ).
 
 filter_list_clause_location(Clause) ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -532,7 +532,8 @@ function_naming_convention(Config, Target, RuleConfig) ->
     Regex = option(regex, RuleConfig, function_naming_convention),
     ForbiddenRegex = option(forbidden_regex, RuleConfig, function_naming_convention),
     Root = get_root(Config, Target, RuleConfig),
-    FunctionNames0 = elvis_code:function_names(Root),
+    Functions = elvis_code:find_by_types([function], Root),
+    FunctionNames0 = lists:map(fun(Node) -> ktn_code:attr(name, Node) end, Functions),
     errors_for_function_names(Regex, ForbiddenRegex, FunctionNames0).
 
 errors_for_function_names(_Regex, _ForbiddenRegex, []) ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2097,9 +2097,8 @@ always_shortcircuit(Config, Target, RuleConfig) ->
     [elvis_result:item()].
 export_used_types(Config, Target, RuleConfig) ->
     TreeRootNode = get_root(Config, Target, RuleConfig),
-    Exports = elvis_code:find_by_types([export], TreeRootNode),
-    ExportedFunctions = lists:flatmap(fun(Node) -> ktn_code:attr(value, Node) end, Exports),
-    ExportedTypes = elvis_code:exported_types(TreeRootNode),
+    FunctionExports = elvis_code:find_by_types([export], TreeRootNode),
+    ExportedFunctions = lists:flatmap(fun(Node) -> ktn_code:attr(value, Node) end, FunctionExports),
     SpecNodes = elvis_code:find_by_types([spec], TreeRootNode),
     ExportedSpecs =
         lists:filter(
@@ -2125,6 +2124,8 @@ export_used_types(Config, Target, RuleConfig) ->
                 ExportedSpecs
             )
         ),
+    TypeExports = elvis_code:find_by_types([export_type], TreeRootNode),
+    ExportedTypes = lists:flatmap(fun(Node) -> ktn_code:attr(value, Node) end, TypeExports),
     UnexportedUsedTypes = lists:subtract(UsedTypes, ExportedTypes),
     LineNumbers = map_type_declarations_to_line_numbers(TreeRootNode),
 
@@ -2157,7 +2158,8 @@ get_type_of_type(_) ->
 private_data_types(Config, Target, RuleConfig) ->
     TypesToCheck = option(apply_to, RuleConfig, private_data_types),
     TreeRootNode = get_root(Config, Target, RuleConfig),
-    ExportedTypes = elvis_code:exported_types(TreeRootNode),
+    TypeExports = elvis_code:find_by_types([export_type], TreeRootNode),
+    ExportedTypes = lists:flatmap(fun(Node) -> ktn_code:attr(value, Node) end, TypeExports),
     LineNumbers = map_type_declarations_to_line_numbers(TreeRootNode),
 
     PublicDataTypes = public_data_types(TypesToCheck, TreeRootNode, ExportedTypes),

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -950,7 +950,8 @@ god_modules(Config, Target, RuleConfig) ->
 
     Root = get_root(Config, Target, RuleConfig),
 
-    Exported = elvis_code:exported_functions(Root),
+    Exports = elvis_code:find_by_types([export], Root),
+    Exported = lists:flatmap(fun(Node) -> ktn_code:attr(value, Node) end, Exports),
     case length(Exported) of
         Count when Count > Limit ->
             Msg = ?GOD_MODULES_MSG,
@@ -1270,8 +1271,10 @@ max_function_arity(Config, Target, RuleConfig) ->
     Functions = elvis_code:find_by_types([function], Root),
     lists:filtermap(
         fun(#{attrs := #{arity := Arity, name := Name}} = Function) ->
+            Exports = elvis_code:find_by_types([export], Root),
+            ExportedFunctions = lists:flatmap(fun(Node) -> ktn_code:attr(value, Node) end, Exports),
             IsExported =
-                lists:member({Name, Arity}, elvis_code:exported_functions(Root)),
+                lists:member({Name, Arity}, ExportedFunctions),
             MaxArity =
                 case IsExported of
                     true ->
@@ -2094,7 +2097,8 @@ always_shortcircuit(Config, Target, RuleConfig) ->
     [elvis_result:item()].
 export_used_types(Config, Target, RuleConfig) ->
     TreeRootNode = get_root(Config, Target, RuleConfig),
-    ExportedFunctions = elvis_code:exported_functions(TreeRootNode),
+    Exports = elvis_code:find_by_types([export], TreeRootNode),
+    ExportedFunctions = lists:flatmap(fun(Node) -> ktn_code:attr(value, Node) end, Exports),
     ExportedTypes = elvis_code:exported_types(TreeRootNode),
     SpecNodes = elvis_code:find_by_types([spec], TreeRootNode),
     ExportedSpecs =

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2184,12 +2184,10 @@ public_data_types(TypesToCheck, TreeRootNode, ExportedTypes) ->
 %% Private
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-%% @private
 -spec name_arity_from_type_line(ktn_code:tree_node()) -> {atom(), integer()}.
 name_arity_from_type_line(#{attrs := #{name := Name}, node_attrs := #{args := Args}}) ->
     {Name, length(Args)}.
 
-%% @private
 -spec map_type_declarations_to_line_numbers(ktn_code:tree_node()) ->
     #{{atom(), number()} => number()}.
 map_type_declarations_to_line_numbers(TreeRootNode) ->
@@ -2211,13 +2209,11 @@ map_type_declarations_to_line_numbers(TreeRootNode) ->
         AllTypes
     ).
 
-%% @private
 specific_or_default(same, Regex) ->
     Regex;
 specific_or_default(RegexEnclosed, _Regex) ->
     RegexEnclosed.
 
-%% @private
 check_numeric_format(_Regex, [], Acc) ->
     lists:reverse(Acc);
 check_numeric_format(Regex, [NumNode | RemainingNumNodes], AccIn) ->
@@ -2243,7 +2239,6 @@ check_numeric_format(Regex, [NumNode | RemainingNumNodes], AccIn) ->
         end,
     check_numeric_format(Regex, RemainingNumNodes, AccOut).
 
-%% @private
 is_exception_or_non_reversible(error) ->
     true;
 is_exception_or_non_reversible(exit) ->
@@ -2255,7 +2250,6 @@ is_exception_or_non_reversible(non_reversible_form) ->
 is_exception_or_non_reversible(_) ->
     false.
 
-%% @private
 check_atom_names(_Regex, _, _RegexEnclosed, _, [] = _AtomNodes, Acc) ->
     Acc;
 check_atom_names(
@@ -2323,7 +2317,6 @@ check_atom_names(
         AccOut
     ).
 
-%% @private
 string_strip_enclosed([$' | Rest]) ->
     [$' | Reversed] = lists:reverse(Rest),
     IsEnclosed = true,
@@ -2333,7 +2326,6 @@ string_strip_enclosed(NonEnclosedAtomName) ->
     IsEnclosed = false,
     {IsEnclosed, NonEnclosedAtomName}.
 
-%% @private
 re_compile_for_atom_type(false = _IsEnclosed, Regex, _RegexEnclosed) ->
     {ok, RE} = re:compile(Regex, [unicode]),
     RE;
@@ -2342,7 +2334,6 @@ re_compile_for_atom_type(true = _IsEnclosed, _Regex, RegexEnclosed) ->
     RE.
 
 %% Variables name
-%% @private
 check_variables_name(_Regex, _, []) ->
     [];
 check_variables_name(Regex, ForbiddenRegex, [Variable | RemainingVars]) ->
@@ -2375,7 +2366,6 @@ check_variables_name(Regex, ForbiddenRegex, [Variable | RemainingVars]) ->
 
 %% Result building
 
-%% @private
 result_node_line_fun(Msg) ->
     fun(Node) ->
         {Line, _} = ktn_code:attr(location, Node),
@@ -2383,7 +2373,6 @@ result_node_line_fun(Msg) ->
         elvis_result:new(item, Msg, Info, Line)
     end.
 
-%% @private
 result_node_line_col_fun(Msg) ->
     fun(Node) ->
         {Line, Col} = ktn_code:attr(location, Node),
@@ -2395,7 +2384,6 @@ result_node_line_col_fun(Msg) ->
 
 %% Line Length
 
-%% @private
 -spec line_is_comment(binary()) -> boolean().
 line_is_comment(Line) ->
     case re:run(Line, "^[ \t]*%") of
@@ -2405,7 +2393,6 @@ line_is_comment(Line) ->
             true
     end.
 
-%% @private
 -spec line_is_whitespace(binary()) -> boolean().
 line_is_whitespace(Line) ->
     case re:run(Line, "^[ \t]*$") of
@@ -2417,7 +2404,6 @@ line_is_whitespace(Line) ->
 
 %% Macro Names
 
-%% @private
 check_macro_names(_Regexp, [] = _MacroNodes, ResultsIn) ->
     ResultsIn;
 check_macro_names(Regexp, [MacroNode | RemainingMacroNodes], ResultsIn) ->
@@ -2437,7 +2423,6 @@ check_macro_names(Regexp, [MacroNode | RemainingMacroNodes], ResultsIn) ->
         end,
     check_macro_names(Regexp, RemainingMacroNodes, ResultsOut).
 
-%% @private
 macro_name_from_node(MacroNode) ->
     MacroNodeValue = ktn_code:attr(value, MacroNode),
     MacroAsAtom = macro_as_atom(false, [call, var, atom], MacroNodeValue),
@@ -2445,7 +2430,6 @@ macro_name_from_node(MacroNode) ->
     MacroNameStripped = string:strip(MacroNameOriginal, both, $'),
     {MacroNameStripped, MacroNameOriginal}.
 
-%% @private
 macro_as_atom({var, _Text, MacroAsAtom}, _Types, _MacroNodeValue) ->
     MacroAsAtom;
 macro_as_atom({atom, _Text, MacroAsAtom}, _Types, _MacroNodeValue) ->
@@ -2462,7 +2446,6 @@ macro_as_atom(false, [Type | OtherTypes], MacroNodeValue) ->
     macro_as_atom(lists:keyfind(Type, _N = 1, MacroNodeValue), OtherTypes, MacroNodeValue).
 
 %% Operator (and Text) Spaces
-%% @private
 -spec check_spaces(
     Lines :: [binary()],
     Nodes :: [ktn_code:tree_node()],
@@ -2501,13 +2484,11 @@ check_spaces(Lines, UnfilteredNodes, {Position, Text}, Encoding, {How0, _} = How
         end,
     lists:flatmap(FlatFun, Nodes).
 
-%% @private
 maybe_run_regex(undefined = _Regex, _Line) ->
     false;
 maybe_run_regex({ok, Regex}, Line) ->
     re:run(Line, Regex).
 
-%% @private
 -spec character_at_location(
     Position :: atom(),
     Lines :: [binary()],
@@ -2567,7 +2548,6 @@ character_at_location(
     end.
 
 %% Nesting Level
-%% @private
 -spec check_nesting_level(ktn_code:tree_node(), [integer()]) -> [elvis_result:item()].
 check_nesting_level(ParentNode, [MaxLevel]) ->
     case past_nesting_limit(ParentNode, MaxLevel) of
@@ -2619,7 +2599,6 @@ level_increment(#{type := Type}) ->
 
 %% Invalid Dynamic Calls
 
-%% @private
 -spec check_invalid_dynamic_calls(ktn_code:tree_node()) -> [elvis_result:item()].
 check_invalid_dynamic_calls(Root) ->
     case elvis_code:find(fun is_dynamic_call/1, Root, #{traverse => all}) of
@@ -2630,7 +2609,6 @@ check_invalid_dynamic_calls(Root) ->
             lists:map(ResultFun, InvalidCalls)
     end.
 
-%% @private
 -spec is_dynamic_call(ktn_code:tree_node()) -> boolean().
 is_dynamic_call(Node) ->
     case ktn_code:type(Node) of
@@ -2648,7 +2626,6 @@ is_dynamic_call(Node) ->
     end.
 
 %% Plain Variable
-%% @private
 -spec is_var(zipper:zipper(_)) -> boolean().
 is_var(Zipper) ->
     case
@@ -2680,7 +2657,6 @@ is_var(Zipper) ->
 
 %% Ignored Variable
 
-%% @private
 -spec is_ignored_var(zipper:zipper(_)) -> boolean().
 is_ignored_var(Zipper) ->
     Node = zipper:node(Zipper),
@@ -2694,7 +2670,6 @@ is_ignored_var(Zipper) ->
             false
     end.
 
-%% @private
 check_parent_match_or_macro(Zipper) ->
     case zipper:up(Zipper) of
         undefined ->
@@ -2710,7 +2685,6 @@ check_parent_match_or_macro(Zipper) ->
             end
     end.
 
-%% @private
 check_parent_remote(Zipper) ->
     case zipper:up(Zipper) of
         undefined ->
@@ -2722,7 +2696,6 @@ check_parent_remote(Zipper) ->
 
 %% State record in OTP module
 
-%% @private
 -spec is_otp_module(ktn_code:tree_node()) -> boolean().
 is_otp_module(Root) ->
     OtpSet = sets:from_list([gen_server, gen_event, gen_fsm, gen_statem, supervisor_bridge]),
@@ -2738,7 +2711,6 @@ is_otp_module(Root) ->
             )
     end.
 
-%% @private
 -spec has_state_record(ktn_code:tree_node()) -> boolean().
 has_state_record(Root) ->
     IsStateRecord =
@@ -2747,7 +2719,6 @@ has_state_record(Root) ->
         end,
     elvis_code:find(IsStateRecord, Root) =/= [].
 
-%% @private
 -spec has_state_type(ktn_code:tree_node()) -> boolean().
 has_state_type(Root) ->
     IsStateType =
@@ -2770,7 +2741,6 @@ has_state_type(Root) ->
 
 %% Spec includes records
 
-%% @private
 -spec spec_includes_record(ktn_code:tree_node()) -> boolean().
 spec_includes_record(Node) ->
     IsTypeRecord =
@@ -2782,7 +2752,6 @@ spec_includes_record(Node) ->
 
 %% Don't repeat yourself
 
-%% @private
 -spec find_repeated_nodes(ktn_code:tree_node(), non_neg_integer()) ->
     [ktn_code:tree_node()].
 find_repeated_nodes(Root, MinComplexity) ->
@@ -2812,12 +2781,10 @@ find_repeated_nodes(Root, MinComplexity) ->
 
     lists:map(fun lists:sort/1, Locations).
 
-%% @private
 -spec remove_attrs_zipper(zipper:zipper(_), map()) -> ktn_code:tree_node().
 remove_attrs_zipper(Zipper, TypeAttrs) ->
     zipper:fmap(fun remove_attrs/2, [TypeAttrs], Zipper).
 
-%% @private
 -spec remove_attrs(ktn_code:tree_node() | [ktn_code:tree_node()], map()) ->
     ktn_code:tree_node().
 remove_attrs(Nodes, TypeAttrs) when is_list(Nodes) ->
@@ -2847,7 +2814,6 @@ remove_attrs(#{attrs := Attrs, type := Type} = Node, TypeAttrs) ->
 remove_attrs(Node, _TypeAttrs) ->
     Node.
 
-%% @private
 -spec filter_repeated(map()) -> map().
 filter_repeated(NodesLocs) ->
     NotRepeated =
@@ -2867,13 +2833,11 @@ filter_repeated(NodesLocs) ->
 
     maps:without(Nested, RepeatedMap).
 
-%% @private
 is_children(Parent, Node) ->
     Zipper = elvis_code:code_zipper(Parent),
     zipper:filter(fun(Child) -> Child =:= Node end, Zipper) =/= [].
 
 %% No call
-%% @private
 -spec no_call_common(
     elvis_config:config(),
     elvis_file:file(),
@@ -2888,7 +2852,6 @@ no_call_common(Config, Target, NoCallFuns, Msg, RuleConfig) ->
     Calls = elvis_code:find_by_types([call], Root),
     check_no_call(Calls, Msg, NoCallFuns).
 
-%% @private
 -spec check_no_call([ktn_code:tree_node()], string(), [function_spec()]) ->
     [elvis_result:item()].
 check_no_call(Calls, Msg, NoCallFuns) ->
@@ -2901,13 +2864,11 @@ check_no_call(Calls, Msg, NoCallFuns) ->
         end,
     lists:map(ResultFun, BadCalls).
 
-%% @private
 is_in_call_list(Call, DisallowedFuns) ->
     MFA = call_mfa(Call),
     MatchFun = fun(Spec) -> fun_spec_match(Spec, MFA) end,
     lists:any(MatchFun, DisallowedFuns).
 
-%% @private
 call_mfa(Call) ->
     FunctionSpec = ktn_code:node_attr(function, Call),
     M = ktn_code:attr(value, ktn_code:node_attr(module, FunctionSpec)),
@@ -2915,7 +2876,6 @@ call_mfa(Call) ->
     A = length(ktn_code:content(Call)),
     {M, F, A}.
 
-%% @private
 is_call(Node, {F, A}) ->
     is_call(Node) andalso
         list_to_atom(ktn_code:attr(text, Node)) =:= F andalso
@@ -2923,23 +2883,19 @@ is_call(Node, {F, A}) ->
 is_call(Node, {M, F, A}) ->
     call_mfa(Node) =:= {M, F, A}.
 
-%% @private
 is_call(Node) ->
     ktn_code:type(Node) =:= call.
 
-%% @private
 fun_spec_match({M, F}, MFA) ->
     fun_spec_match({M, F, '_'}, MFA);
 fun_spec_match({M1, F1, A1}, {M2, F2, A2}) ->
     wildcard_match(M1, M2) andalso wildcard_match(F1, F2) andalso wildcard_match(A1, A2).
 
-%% @private
 wildcard_match('_', _) ->
     true;
 wildcard_match(X, Y) ->
     X =:= Y.
 
-%% @private
 %% @doc No nested try...catch blocks
 check_nested_try_catchs(ResultFun, TryExp) ->
     lists:filtermap(
@@ -2954,7 +2910,6 @@ check_nested_try_catchs(ResultFun, TryExp) ->
         ktn_code:content(TryExp)
     ).
 
-%% @private
 %% @doc No #{...}#{...}
 check_successive_maps(ResultFun, MapExp) ->
     case ktn_code:node_attr(var, MapExp) of
@@ -2970,7 +2925,6 @@ check_successive_maps(ResultFun, MapExp) ->
     end.
 
 %% Consistent Generic Type
-%% @private
 consistent_generic_type_predicate(TypePreference) ->
     fun(Node) ->
         NodeName = ktn_code:attr(name, Node),
@@ -2979,7 +2933,6 @@ consistent_generic_type_predicate(TypePreference) ->
             NodeName =/= TypePreference
     end.
 
-%% @private
 consistent_generic_type_result(TypePreference) ->
     fun(Node) ->
         {Line, _} = ktn_code:attr(location, Node),

--- a/src/elvis_text_style.erl
+++ b/src/elvis_text_style.erl
@@ -120,7 +120,6 @@ prefer_unquoted_atoms(_Config, Target, _RuleConfig) ->
     AtomNodes = elvis_code:find(fun is_atom_node/1, Tree, #{traverse => all, mode => node}),
     check_atom_quotes(AtomNodes, []).
 
-%% @private
 check_atom_quotes([] = _AtomNodes, Acc) ->
     Acc;
 check_atom_quotes([AtomNode | RemainingAtomNodes], AccIn) ->
@@ -187,7 +186,6 @@ redundant_blank_lines(Lines, {CurrentLineNum, ResultList}) ->
 
 %% Line Length
 
-%% @private
 -spec line_is_comment(binary()) -> boolean().
 line_is_comment(Line) ->
     case re:run(Line, "^[ \t]*%") of
@@ -197,7 +195,6 @@ line_is_comment(Line) ->
             true
     end.
 
-%% @private
 -spec remove_comment(binary()) -> binary().
 remove_comment(Line) ->
     case re:run(Line, "([^%]+)", [{capture, first, binary}]) of
@@ -207,7 +204,6 @@ remove_comment(Line) ->
             Without
     end.
 
-%% @private
 -spec check_line_length(binary(), integer(), [term()]) ->
     no_result | {ok, elvis_result:item()}.
 check_line_length(Line, Num, [Limit, whole_line, Encoding, NoWhitespace]) ->
@@ -246,7 +242,6 @@ check_line_length(Line0, Num, [Limit, Encoding, NoWhitespace]) ->
 
 %% No Tabs
 
-%% @private
 -spec check_no_tabs(binary(), integer()) -> no_result | {ok, elvis_result:item()}.
 check_no_tabs(Line, Num) ->
     case binary:match(Line, <<"\t">>) of
@@ -261,7 +256,6 @@ check_no_tabs(Line, Num) ->
 
 %% No Trailing Whitespace
 
-%% @private
 -spec check_no_trailing_whitespace(binary(), integer(), boolean()) ->
     no_result | {ok, elvis_result:item()}.
 check_no_trailing_whitespace(Line, Num, IgnoreEmptyLines) ->
@@ -284,11 +278,9 @@ check_no_trailing_whitespace(Line, Num, IgnoreEmptyLines) ->
             {ok, Result}
     end.
 
-%% @private
 is_atom_node(MaybeAtom) ->
     ktn_code:type(MaybeAtom) =:= atom.
 
-%% @private
 is_exception_prefer_quoted(Elem) ->
     KeyWords =
         [

--- a/src/elvis_text_style.erl
+++ b/src/elvis_text_style.erl
@@ -117,7 +117,7 @@ no_trailing_whitespace(_Config, Target, RuleConfig) ->
 prefer_unquoted_atoms(_Config, Target, _RuleConfig) ->
     {Content, #{encoding := _Encoding}} = elvis_file:src(Target),
     Tree = ktn_code:parse_tree(Content),
-    AtomNodes = elvis_code:find(fun is_atom_node/1, Tree, #{traverse => all, mode => node}),
+    AtomNodes = elvis_code:find_by_types([atom], Tree, #{traverse => all, mode => node}),
     check_atom_quotes(AtomNodes, []).
 
 check_atom_quotes([] = _AtomNodes, Acc) ->
@@ -188,12 +188,7 @@ redundant_blank_lines(Lines, {CurrentLineNum, ResultList}) ->
 
 -spec line_is_comment(binary()) -> boolean().
 line_is_comment(Line) ->
-    case re:run(Line, "^[ \t]*%") of
-        nomatch ->
-            false;
-        {match, _} ->
-            true
-    end.
+    re:run(Line, "^[ \t]*%") =/= nomatch.
 
 -spec remove_comment(binary()) -> binary().
 remove_comment(Line) ->
@@ -277,9 +272,6 @@ check_no_trailing_whitespace(Line, Num, IgnoreEmptyLines) ->
             Result = elvis_result:new(item, Msg, Info, Num),
             {ok, Result}
     end.
-
-is_atom_node(MaybeAtom) ->
-    ktn_code:type(MaybeAtom) =:= atom.
 
 is_exception_prefer_quoted(Elem) ->
     KeyWords =

--- a/src/elvis_utils.erl
+++ b/src/elvis_utils.erl
@@ -43,7 +43,6 @@ check_lines_with_context(Src, Fun, Args, Ctx) ->
     LinesContext = context(Lines, Ctx),
     check_lines(LinesContext, Fun, Args, [], 1).
 
-%% @private
 check_lines([], _Fun, _Args, Results, _Num) ->
     lists:flatten(
         lists:reverse(Results)
@@ -63,7 +62,6 @@ check_lines([Line | Lines], Fun, Args, Results, Num) ->
             check_lines(Lines, Fun, Args, Results, Num + 1)
     end.
 
-%% @private
 context(List, CtxCount) ->
     context(List, [], CtxCount, []).
 
@@ -84,7 +82,6 @@ check_nodes(RootNode, Fun, Args) ->
     ChildNodes = ktn_code:content(RootNode),
     check_nodes(ChildNodes, Fun, Args, []).
 
-%% @private
 check_nodes([], _Fun, _Args, Results) ->
     FlatResults = lists:flatten(Results),
     lists:reverse(FlatResults);


### PR DESCRIPTION
# Description

I try to simplify `elvis_code` a bit:

1. I move to their corresponding modules code that's not that generic
2. in trying to make `get_root` more generic I found the abstraction wasn't worth the result, but found a refactoring opportunity for some default options
3. for commits "Simplify ..." we actually increase the code, because we duplicate it in corresponding rules, but this also seems to make for more independent rule code (lemme know and I can make a generic function in `elvis_style`)

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
