### PR TITLE
Fix `no_boolean_in_comparison`: adds [`=:=`, `/=`, `=/=`]

### DIFF
--- a/doc_rules/elvis_style/no_boolean_in_comparison.md
+++ b/doc_rules/elvis_style/no_boolean_in_comparison.md
@@ -8,6 +8,10 @@ Explicit comparisons of expressions to boolean literals (`true` or `false`) shou
 mycondition(Assumptions) == true
 
 mycondition(Assumptions) == false
+
+mycondition(Assumptions) =/= true
+
+mycondition(Assumptions) =:= false
 ```
 
 ## Prefer
@@ -16,11 +20,15 @@ mycondition(Assumptions) == false
 mycondition(Assumptions)
 
 not(mycondition(Assumptions))
+
+not(mycondition(Assumptions))
+
+not(mycondition(Assumptions))
 ```
 
 ## Rationale
 
-Explicitly comparing expressions to boolean literals (e.g., `Expr == true` or `Expr == false`) is
+Explicitly comparing expressions to boolean literals (e.g., `Expr == true` or `Expr =/= false`) is
 redundant and non-idiomatic in Erlang. Erlang's control flow constructs (such as `if`, `case`,
 guards, and boolean operators like `andalso`/`orelse`) are designed to evaluate the truthiness of
 expressions directly. Using direct comparisons can obscure intent, reduce readability, and increase

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2497,7 +2497,7 @@ check_spaces(Lines, UnfilteredNodes, {Position, Text}, Encoding, {How0, _} = How
 
 %% @private
 maybe_run_regex(undefined = _Regex, _Line) ->
-    false;
+    undefined;
 maybe_run_regex({ok, Regex}, Line) ->
     re:run(Line, Regex).
 
@@ -2524,7 +2524,7 @@ character_at_location(
     TextRegex =
         case TextRegexes of
             [] ->
-                false;
+                undefined;
             _ ->
                 maybe_run_regex(proplists:get_value(Text, TextRegexes), Line)
         end,
@@ -2554,7 +2554,7 @@ character_at_location(
             "";
         _ when How =:= should_have ->
             lists:nth(ColToCheck, TextLineStr);
-        _ when How =:= should_not_have, not TextRegex; TextRegex =:= nomatch ->
+        _ when How =:= should_not_have, TextRegex =:= undefined; TextRegex =:= nomatch ->
             lists:nth(ColToCheck, TextLineStr);
         _ ->
             ""

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2554,7 +2554,7 @@ character_at_location(
             "";
         _ when How =:= should_have ->
             lists:nth(ColToCheck, TextLineStr);
-        _ when How =:= should_not_have, TextRegex =:= false; TextRegex =:= nomatch ->
+        _ when How =:= should_not_have, not TextRegex; TextRegex =:= nomatch ->
             lists:nth(ColToCheck, TextLineStr);
         _ ->
             ""

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1677,7 +1677,7 @@ no_boolean_in_comparison(Config, Target, RuleConfig) ->
         fun(Node) ->
             Content = ktn_code:content(Node),
             ktn_code:type(Node) =:= op andalso
-                ktn_code:attr(operation, Node) =:= '==' andalso
+                lists:member(ktn_code:attr(operation, Node), ['==', '=:=', '/=', '=/=']) andalso
                 lists:any(IsBoolean, Content)
         end,
     ComparisonsWithBoolean =

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2497,7 +2497,7 @@ check_spaces(Lines, UnfilteredNodes, {Position, Text}, Encoding, {How0, _} = How
 
 %% @private
 maybe_run_regex(undefined = _Regex, _Line) ->
-    undefined;
+    nomatch;
 maybe_run_regex({ok, Regex}, Line) ->
     re:run(Line, Regex).
 
@@ -2524,7 +2524,7 @@ character_at_location(
     TextRegex =
         case TextRegexes of
             [] ->
-                undefined;
+                nomatch;
             _ ->
                 maybe_run_regex(proplists:get_value(Text, TextRegexes), Line)
         end,
@@ -2552,9 +2552,7 @@ character_at_location(
             SpaceChar;
         {_, right, LenLine} when How =:= should_not_have, ColToCheck > LenLine ->
             "";
-        _ when How =:= should_have ->
-            lists:nth(ColToCheck, TextLineStr);
-        _ when How =:= should_not_have, TextRegex =:= undefined; TextRegex =:= nomatch ->
+        _ when How =:= should_have; TextRegex =:= nomatch ->
             lists:nth(ColToCheck, TextLineStr);
         _ ->
             ""

--- a/test/examples/fail_no_boolean_in_comparison.erl
+++ b/test/examples/fail_no_boolean_in_comparison.erl
@@ -29,6 +29,6 @@ other_examples(A) ->
     F(X, Y),
 
     case the:result(F, Y) of
-        Bool when Bool == true; Bool == false -> do:something_with(the, Bool);
+        Bool when Bool == true; Bool /= false -> do:something_with(the, Bool);
         NotBool -> do:something_else_with(this, NotBool, thingy)
     end.

--- a/test/examples/fail_no_boolean_in_comparison.erl
+++ b/test/examples/fail_no_boolean_in_comparison.erl
@@ -19,7 +19,7 @@ other_examples(A) ->
     Y = X =:= true,
 
     %% And yet another (stricter) one
-    Y = X =/= true,
+    Y1 = X =/= true,
 
     %% A list comprehension (different places)
     [ E || E <- build:a_list(), false == check:something_on(E)],
@@ -28,7 +28,7 @@ other_examples(A) ->
     F = fun(X2, Y2) when X2 == true, false == Y2 -> {shake, my, head} end,
     F(X, Y),
 
-    case the:result(F, Y) of
+    case the:result(F, Y1) of
         Bool when Bool == true; Bool /= false -> do:something_with(the, Bool);
         NotBool -> do:something_else_with(this, NotBool, thingy)
     end.

--- a/test/examples/fail_no_boolean_in_comparison.erl
+++ b/test/examples/fail_no_boolean_in_comparison.erl
@@ -15,6 +15,12 @@ other_examples(A) ->
     %% A regular match operator
     Y = X == true,
 
+    %% And a stricter one
+    Y = X =:= true,
+
+    %% And yet another (stricter) one
+    Y = X =/= true,
+
     %% A list comprehension (different places)
     [ E || E <- build:a_list(), false == check:something_on(E)],
 

--- a/test/examples/pass_no_boolean_in_comparison.erl
+++ b/test/examples/pass_no_boolean_in_comparison.erl
@@ -1,6 +1,6 @@
 -module(pass_no_boolean_in_comparison).
 
--export [my_fun/2, my_fun/3, my_fun/4, my_fun/5].
+-export([my_fun/2, my_fun/3, my_fun/4, my_fun/5, my_fun2/5]).
 
 my_fun(P1, P2) ->
     case (not do:something(P1)) orelse (not do:something(P2)) of
@@ -36,3 +36,14 @@ my_fun(P1, P2, _, _, _) ->
 
 get_boolean(0) -> true;
 get_boolean(1) -> false.
+
+%% … or even …
+
+my_fun2(P1, P2, _, _, _) ->
+    case do:something(P1) =:= get_boolean2(0) orelse do:something(P2) =/= get_boolean2(1) of
+        true -> "There is a false";
+        false -> "All true"
+    end.
+
+get_boolean2(0) -> true;
+get_boolean2(1) -> false.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1946,11 +1946,11 @@ verify_no_boolean_in_comparison(Config) ->
         #{line_num := 6},
         #{line_num := 13},
         #{line_num := 16},
-        #{line_num := 19},
-        #{line_num := 22},
-        #{line_num := 22},
-        #{line_num := 26},
-        #{line_num := 26}
+        #{line_num := 25},
+        #{line_num := 28},
+        #{line_num := 28},
+        #{line_num := 32},
+        #{line_num := 32}
     ] =
         elvis_core_apply_rule(Config, elvis_style, no_boolean_in_comparison, #{}, FailPath).
 

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1946,6 +1946,10 @@ verify_no_boolean_in_comparison(Config) ->
         #{line_num := 6},
         #{line_num := 13},
         #{line_num := 16},
+        % =:=
+        #{line_num := 19},
+        % =/=
+        #{line_num := 22},
         #{line_num := 25},
         #{line_num := 28},
         #{line_num := 28},


### PR DESCRIPTION
# Description

This is for the `no_boolean_in_comparison` bug. I think we should also be comparing with `/=` and `=/=`, so I add those.

Closes #441.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
