### PR TITLE
Add `{gen_statem, call, 2}`, `{gen_server, call, 2}`, and `{gen_event, call, 3}` to option `caveat_functions` in rule `no_common_caveats_call`

### DIFF
--- a/doc_rules/elvis_style/no_common_caveats_call.md
+++ b/doc_rules/elvis_style/no_common_caveats_call.md
@@ -28,6 +28,9 @@ results in clearer, faster, and more maintainable code.
              , {gen_event, call, 3}
               ]`
 
+`{gen_statem, call, 2}`, `{gen_server, call, 2}`, and `{gen_event, call, 3}` were added in
+[4.1.0](https://github.com/inaka/elvis_core/releases/tag/4.1.0)
+
 ## Example configuration
 
 ```erlang

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -421,7 +421,10 @@ default(no_common_caveats_call) ->
                 {timer, send_after, 3},
                 {timer, send_interval, 2},
                 {timer, send_interval, 3},
-                {erlang, size, 1}
+                {erlang, size, 1},
+                {gen_statem, call, 2},
+                {gen_server, call, 2},
+                {gen_event, call, 3}
             ]
     };
 default(atom_naming_convention) ->

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1720,7 +1720,7 @@ verify_no_debug_call(Config) ->
 %% other than defaults, they behave the same
 -spec verify_no_common_caveats_call(config()) -> any().
 verify_no_common_caveats_call(Config) ->
-    verify_no_call_flavours(Config, no_common_caveats_call, caveat_functions, 6).
+    verify_no_call_flavours(Config, no_common_caveats_call, caveat_functions, 9).
 
 -spec verify_no_call(config()) -> any().
 verify_no_call(Config) ->


### PR DESCRIPTION
# Description

Add the missing implementation details. As is, it seems to me the test code is rather brittle:

1. I don't know how easy it is to find that reference (that I changed from `6` to `9`)
2. the fact that we were able to accept an update that didn't actually add to the rules is kinda proof of brittleness

Closes #408.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
