### PR TITLE
Allow for OTP behaviours to bypass `export_used_types`

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1094,7 +1094,7 @@ is_forbidden_module_name(Target, Regex, Message) ->
     [elvis_result:item()].
 state_record_and_type(Config, Target, RuleConfig) ->
     Root = get_root(Config, Target, RuleConfig),
-    case is_otp_module(Root) of
+    case is_otp_behaviour(Root) of
         true ->
             case {has_state_record(Root), has_state_type(Root)} of
                 {true, true} ->
@@ -2693,8 +2693,8 @@ check_parent_remote(Zipper) ->
 
 %% State record in OTP module
 
--spec is_otp_module(ktn_code:tree_node()) -> boolean().
-is_otp_module(Root) ->
+-spec is_otp_behaviour(ktn_code:tree_node()) -> boolean().
+is_otp_behaviour(Root) ->
     OtpSet = sets:from_list([gen_server, gen_event, gen_fsm, gen_statem, supervisor_bridge]),
     case elvis_code:find_by_types([behaviour, behavior], Root) of
         [] ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2094,7 +2094,15 @@ always_shortcircuit(Config, Target, RuleConfig) ->
 -spec export_used_types(elvis_config:config(), elvis_file:file(), empty_rule_config()) ->
     [elvis_result:item()].
 export_used_types(Config, Target, RuleConfig) ->
-    TreeRootNode = get_root(Config, Target, RuleConfig),
+    Root = get_root(Config, Target, RuleConfig),
+    case is_otp_behaviour(Root) of
+        false ->
+            export_used_types_in(Root);
+        true ->
+            []
+    end.
+
+export_used_types_in(TreeRootNode) ->
     FunctionExports = elvis_code:find_by_types([export], TreeRootNode),
     ExportedFunctions = lists:flatmap(fun(Node) -> ktn_code:attr(value, Node) end, FunctionExports),
     SpecNodes = elvis_code:find_by_types([spec], TreeRootNode),

--- a/test/examples/fail_state_record_and_type_plus_export_used_types.erl
+++ b/test/examples/fail_state_record_and_type_plus_export_used_types.erl
@@ -2,8 +2,6 @@
 
 -dialyzer(no_behaviours).
 
--behaviour(gen_server).
-
 -export([
          init/1,
          handle_call/3,

--- a/test/examples/pass_state_record_and_type_plus_export_used_types.erl
+++ b/test/examples/pass_state_record_and_type_plus_export_used_types.erl
@@ -2,8 +2,6 @@
 
 -dialyzer(no_behaviours).
 
--behaviour(gen_server).
-
 -export([
          init/1,
          handle_call/3,

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1238,7 +1238,6 @@ verify_consistent_generic_type(Config) ->
             #{preferred_type => term},
             PathPass2
         ),
-    PathPass2 = "consistent_generic_type_no_checks." ++ Ext,
     [] =
         elvis_core_apply_rule(
             Config,


### PR DESCRIPTION
# Description

Closes #308.

Lemme know if this seems like enough, or if e.g. we want a new option to the rule to bypass for other behaviours (user-defined)? It can always be disabled or ignored per module, so by default ignoring what we do now (with this PR) might be enough.

Also, should we have a follow-up task for when dynamic callbacks land?

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
