### PR TITLE
Add `{dbg, '_'}, {dyntrace, '_'}, {instrument, '_'}` to `no_debug_call`

### DIFF
--- a/doc_rules/elvis_style/no_debug_call.md
+++ b/doc_rules/elvis_style/no_debug_call.md
@@ -15,11 +15,13 @@ lead to performance degradation, unwanted output, or inconsistent logging behavi
 
 - `debug_functions :: [{module(), function(), arity()} | {module(), function()}]`
   - default: `[{ct, pal}, {ct, print}, {io, format, 1}, {io, format, 2}, {erlang, display, 1},
-    {io, put_chars, 1}, {io, put_chars, 2}]`
+    {io, put_chars, 1}, {io, put_chars, 2}, {dbg, '_'}, {dyntrace, '_'}, {instrument, '_'}]`
 
 `{erlang, display, 1}` was added in [1.5.0](https://github.com/inaka/elvis_core/releases/tag/1.5.0).
 
 `{io, put_chars, 1}, {io, put_chars, 2}` was added in [4.0.0](https://github.com/inaka/elvis_core/releases/tag/4.0.0).
+
+`{dbg, '_'}, {dyntrace, '_'}, {instrument, '_'}` was added in [4.1.0](https://github.com/inaka/elvis_core/releases/tag/4.1.0).
 
 ## Example configuration
 
@@ -30,7 +32,10 @@ lead to performance degradation, unwanted output, or inconsistent logging behavi
                                                   , {io, format, 2}
                                                   , {erlang, display, 1}
                                                   , {io, put_chars, 1}
-                                                  , {io, put_chars, 2}
+                                                  , {io, put_chars, 2},
+                                                  , {dbg, '_'},
+                                                  , {dyntrace, '_'}
+                                                  , {instrument, '_'}
                                                    ]
                               }}
 ```

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -402,7 +402,10 @@ default(no_debug_call) ->
                 {io, format, 1},
                 {io, format, 2},
                 {io, put_chars, 1},
-                {io, put_chars, 2}
+                {io, put_chars, 2},
+                {dbg, '_'},
+                {dyntrace, '_'},
+                {instrument, '_'}
             ]
     };
 default(no_common_caveats_call) ->

--- a/test/examples/fail_no_debug_call.erl
+++ b/test/examples/fail_no_debug_call.erl
@@ -14,4 +14,7 @@ fail() ->
     ct:pal("Debug ~s", ["Debug Info"]),
     ct:print("Debug"),
     ct:print("Debug ~s", ["Debug Info"]),
-    io:put_chars("Debug").
+    io:put_chars("Debug"),
+    dbg:whatever_function(),
+    dyntrace:calls(missing),
+    instrument:this().

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1664,7 +1664,10 @@ verify_no_debug_call(Config) ->
                     #{info := [io, format, 2, 10]},
                     #{info := [ct, print, 1, 16]},
                     #{info := [ct, print, 2, 17]},
-                    #{info := [io, put_chars, 1, 18]}
+                    #{info := [io, put_chars, 1, 18]},
+                    #{info := [dbg, whatever_function, 0, 19]},
+                    #{info := [dyntrace, calls, 1, 20]},
+                    #{info := [instrument, this, 0, 21]}
                 ] =
                     elvis_core_apply_rule(Config, elvis_style, no_debug_call, #{}, PathFail);
             erl_files ->
@@ -1675,7 +1678,10 @@ verify_no_debug_call(Config) ->
                     #{info := [ct, pal, 2, 14]},
                     #{info := [ct, print, 1, 15]},
                     #{info := [ct, print, 2, 16]},
-                    #{info := [io, put_chars, 1, 17]}
+                    #{info := [io, put_chars, 1, 17]},
+                    #{info := [dbg, whatever_function, 0, 18]},
+                    #{info := [dyntrace, calls, 1, 19]},
+                    #{info := [instrument, this, 0, 20]}
                 ] =
                     elvis_core_apply_rule(Config, elvis_style, no_debug_call, #{}, PathFail)
         end,


### PR DESCRIPTION
# Description

Consider more calls as debug.

Closes #411.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
