### PR TITLE
Fix badge link and support range

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `elvis_core` [![GitHub Actions CI](https://github.com/inaka/elvis_core/workflows/build/badge.svg)](https://github.com/inaka/elvis_core) [![Erlang Support](https://img.shields.io/badge/Erlang/OTP-25+-blue)](https://www.erlang.org)
+# `elvis_core` [![GitHub Actions CI](https://github.com/inaka/elvis_core/workflows/build/badge.svg)](https://github.com/inaka/elvis_core/actions) [![Erlang Support](https://img.shields.io/badge/Erlang/OTP-26+-blue)](https://www.erlang.org)
 
 `elvis_core` is the core library for the [`elvis`](https://github.com/inaka/elvis) Erlang style
 reviewer. It is also used by [`rebar3_lint`](https://github.com/project-fifo/rebar3_lint) for easier


### PR DESCRIPTION
# Description

Two minor fixes:

1. CI says we're 25+, when now we're 26+
2. CI points to the repo itself, not to Actions, where it should

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
