### PR TITLE
Fix #476: Ensure modules are loadABLE instead loadED

### DIFF
--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -431,7 +431,9 @@ rock_with_invalid_rules(_Config) ->
     ExpectedErrorMessage =
         {invalid_rules, [
             {invalid_rule, {elvis_style, not_existing_rule}},
-            {invalid_rule, {elvis_style, what_is_this_rule}}
+            {invalid_rule, {elvis_style, what_is_this_rule}},
+            {invalid_rule, {not_existing_module, dont_repeat_yourself}},
+            {invalid_rule, {not_existing_module, dont_repeat_yourself}}
         ]},
     try
         ok = elvis_core:rock(ElvisConfig),


### PR DESCRIPTION
fail config validation if:
- the module referenced in a rule does not exist
- a module does not export the function referenced in a rule

# Description

- use `module_info(exports)` (runtime will attempt to load the module) to get the list of exported functions 
- change `elvis_SUITE:rock_with_invalid_rules/1`

Closes #476

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
