### PR TITLE
Add forbidden_regex to macro_names

### DIFF
--- a/doc_rules/elvis_style/macro_names.md
+++ b/doc_rules/elvis_style/macro_names.md
@@ -1,6 +1,7 @@
 # Macro Names
 
-Macro names should be written in SCREAMING_SNAKE_CASE.
+All macro names should conform to the pattern defined by the `regex` option pattern, unless they match
+the `forbidden_regex` option pattern, in which case they are disallowed.
 
 ## Avoid
 
@@ -34,11 +35,15 @@ the standard.
 
 - `regex :: string()`. [![](https://img.shields.io/badge/since-1.0.0-blue)](https://github.com/inaka/elvis_core/releases/tag/1.0.0)
   - default: `"^[A-Z](_?[A-Z0-9]+)*$"`
+- `forbidden_regex :: string() | undefined` [![](https://img.shields.io/badge/since-4.2.0-blue)](https://github.com/inaka/elvis_core/releases/tag/4.2.0)
+  - default: `undefined`
 
 `regex` was `"^([A-Z][A-Z_0-9]+)$"` until [4.0.0](https://github.com/inaka/elvis_core/releases/tag/4.0.0).
 
 ## Example configuration
 
 ```erlang
-{elvis_style, macro_names, #{ regex => "^[A-Z](_?[A-Z0-9]+)*$" }}
+{elvis_style, macro_names, #{ regex => "^[A-Z](_?[A-Z0-9]+)*$"
+                            , forbidden_regex => undefined
+                            }}
 ```

--- a/test/examples/forbidden_macro_names.erl
+++ b/test/examples/forbidden_macro_names.erl
@@ -1,0 +1,11 @@
+-module(forbidden_macro_names).
+
+-define(FORBIDDEN,  "THIS IS FORBIDDEN").
+-define(NOT_forbidden, "This is not FORBIDDEN since it's lowercase").
+-define(ITS_FORBIDDEN(Arg), "This one is also forbidden").
+-define (FORBIDDEN_TOO, also:forbidden).
+
+-export([use/0]).
+
+use() ->
+  ?FORBIDDEN_TOO(?ITS_FORBIDDEN({?FORBIDDEN, ?NOT_forbidden})).

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -425,6 +425,17 @@ verify_macro_names_rule(Config) ->
             macro_names,
             #{ignore => [fail_macro_names]},
             Path
+        ),
+
+    % forbidden
+    PathForbidden = "forbidden_macro_names." ++ Ext,
+    [_, _, _] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            macro_names,
+            #{regex => "^[A-Za-z_, \-]+$", forbidden_regex => "FORBIDDEN"},
+            PathForbidden
         ).
 
 verify_no_macros(Config) ->


### PR DESCRIPTION
# Description

Add `forbidden_regex` to `macro_names`.

Closes #477.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)

> [!NOTE]
> It includes fixes to some other similar specs/types.