### PR TITLE
Allow catch expressions if the result is discarded

### DIFF
--- a/doc_rules/elvis_style/no_catch_expressions.md
+++ b/doc_rules/elvis_style/no_catch_expressions.md
@@ -21,7 +21,11 @@ risky_call() ->
     end.
 ```
 
-## Except
+## Exceptions
+
+`catch` expressions where the result is explicitly discarded are allowed.
+When you want to evaluate an expression and discard all possible results of it, even the errors,
+you can signal that intention by preceding the expression with `_ =`, like in the following example:
 
 ```erlang
 ignore_results_and_errors() ->
@@ -36,10 +40,6 @@ The `catch` expression in Erlang catches all kinds of exceptions - including run
 making debugging and reasoning about failure states more difficult. In contrast, `try ... catch`
 allows finer-grained control over different types of exceptions and supports pattern matching on
 the reason and stack trace, enabling safer and more maintainable error handling.
-
-The only exception to this is when you want to evaluate an expression and discard all possible
-results of it, even if they are errors. You can signal that intention by preceding the expression
-with `_ =`, like it's shown in the example above.
 
 ## Options
 

--- a/doc_rules/elvis_style/no_catch_expressions.md
+++ b/doc_rules/elvis_style/no_catch_expressions.md
@@ -21,6 +21,14 @@ risky_call() ->
     end.
 ```
 
+## Except
+
+```erlang
+ignore_results_and_errors() ->
+    _ = catch do_something(),
+    done.
+```
+
 ## Rationale
 
 The `catch` expression in Erlang catches all kinds of exceptions - including runtime errors,
@@ -28,6 +36,10 @@ The `catch` expression in Erlang catches all kinds of exceptions - including run
 making debugging and reasoning about failure states more difficult. In contrast, `try ... catch`
 allows finer-grained control over different types of exceptions and supports pattern matching on
 the reason and stack trace, enabling safer and more maintainable error handling.
+
+The only exception to this is when you want to evaluate an expression and discard all possible
+results of it, even if they are errors. You can signal that intention by preceding the expression
+with `_ =`, like it's shown in the example above.
 
 ## Options
 

--- a/test/examples/fail_no_catch_expressions.erl
+++ b/test/examples/fail_no_catch_expressions.erl
@@ -1,8 +1,8 @@
 -module(fail_no_catch_expressions).
 
--export([catchf/0, try_catch/0, mixem/0]).
+-export([catchf/0, try_catch/0, mixem/0, discarded/0]).
 
--dialyzer({nowarn_function, [catchf/0, try_catch/0, mixem/0]}).
+-dialyzer({nowarn_function, [catchf/0, try_catch/0, mixem/0, discarded/0]}).
 
 catchf() ->
     F = fun (a) -> "catch" end,
@@ -25,3 +25,6 @@ mixem() ->
     catch _ ->
         catch F(a)
     end.
+
+discarded() ->
+    _ = catch this:should(be, fine).

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -2424,7 +2424,7 @@ verify_no_catch_expressions(Config) ->
     _ =
         case Group of
             beam_files ->
-                [#{line_num := 10}, #{line_num := 21}, #{line_num := 21}] = lists:sort(R);
+                [_, _, _] = R;
             erl_files ->
                 [#{line_num := 9}, #{line_num := 24}, #{line_num := 26}] = lists:sort(R)
         end.


### PR DESCRIPTION
# Description

Allow `catch` expressions if the result is discarded (i.e., `_ = catch ...`).

Closes #494.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
