### PR TITLE
Handle named funs in all rules

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1090,7 +1090,7 @@ max_anonymous_function_arity(Rule, ElvisConfig) ->
     MaxArity = elvis_rule:option(max_arity, Rule),
 
     {nodes, FunNodes} = elvis_code:find(#{
-        of_types => ['fun'],
+        of_types => ['fun', named_fun],
         inside => elvis_code:root(Rule, ElvisConfig),
         filtered_by => fun has_clauses/1
     }),

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2113,7 +2113,7 @@ param_pattern_matching(Rule, ElvisConfig) ->
         inside => elvis_code:root(Rule, ElvisConfig),
         filtered_by =>
             fun(ClauseZipper) ->
-                is_function_clause(ClauseZipper, [function, 'fun'])
+                is_function_clause(ClauseZipper, [function, 'fun', named_fun])
             end,
         filtered_from => zipper,
         traverse => all

--- a/test/examples/fail_max_anonymous_function_arity.erl
+++ b/test/examples/fail_max_anonymous_function_arity.erl
@@ -5,10 +5,13 @@
 f() ->
     fun() ->
        fun(_) ->
-          fun(_, _) ->
-             fun(_, _, _) ->
-                three_arguments
-             end
+          fun NamedFun(_, _) ->
+            NamedFun(
+               fun(_, _, _) ->
+                  three_arguments
+               end,
+               two_arguments
+            )
           end
        end
     end.

--- a/test/examples/left_param_pattern_matching.erl
+++ b/test/examples/left_param_pattern_matching.erl
@@ -11,7 +11,7 @@ multiple(Multiple = Assignments = {on, the, left, side}) ->
     end.
 
 different_param(happens_on, TheSecond = #{param := of_the}, function) ->
-    fun(happens_on, TheSecondToo = #{param := of_the}, function) -> TheSecond == TheSecondToo
+    fun NamedFun(happens_on, TheSecondToo = #{param := of_the}, function) -> NamedFun(TheSecond, TheSecondToo, param)
     end.
 
 different_clause("it doesn't happen on the first clause") ->

--- a/test/examples/right_param_pattern_matching.erl
+++ b/test/examples/right_param_pattern_matching.erl
@@ -16,7 +16,7 @@ multiple({on, the, right, side} = Multiple = Assignments) ->
     end.
 
 different_param(happens_on, #{the_second := param_of} = The, function) ->
-    fun(happens_on, #{the_second := param_of} = TheToo, function) -> The == TheToo
+    fun NamedFun(happens_on, #{the_second := param_of} = TheToo, function) -> NamedFun(The, TheToo, other_param)
     end.
 
 different_clause("it doesn't happen on the first clause") ->


### PR DESCRIPTION
# Description

While working on #522, I figured that other rules could be missing the `named_fun`s when analyzing `fun`s. I fixed those in this PR.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
