### PR TITLE
Fix #431: New strict rule: strict_term_equivalence

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -79,6 +79,7 @@ Most, if not all, of the rules will present (opinionated) documentation sections
 - [Private Data Types](doc_rules/elvis_style/private_data_types.md)
 - [Simplify Anonymous Functions](doc_rules/elvis_style/simplify_anonymous_functions.md)
 - [State Record And Type](doc_rules/elvis_style/state_record_and_type.md)
+- [Strict Term Equivalence](doc_rules/elvis_style/strict_term_equivalence.md)
 - [Variable Casing](doc_rules/elvis_style/variable_casing.md)
 - [Variable Naming Convention](doc_rules/elvis_style/variable_naming_convention.md)
 

--- a/doc_rules/elvis_style/strict_term_equivalence.md
+++ b/doc_rules/elvis_style/strict_term_equivalence.md
@@ -1,0 +1,34 @@
+# Strict Term Equivalence [![](https://img.shields.io/badge/since-4.2.0-blue)](https://github.com/inaka/elvis_core/releases/tag/4.2.0) ![](https://img.shields.io/badge/BEAM-yes-orange)
+
+Term [non-]equivalence (`=:=`, `=/=`) should be used instead of term [non-]equality (`==`, `/=`).
+
+## Avoid
+
+```erlang
+Expr1 == Expr2 and Expr3 /= Expr4
+```
+
+## Prefer
+
+```erlang
+Expr1 =:= Expr2 and Expr3 =/= Expr4
+```
+
+## Rationale
+
+`==` and `/=` perform numeric coercion, that may hide type errors or logic bugs.
+
+`=:=` and `=/=` are safer (and more defensive) for logic, guards, and type-sensitive operations.
+
+Using strict term equivalence also eliminates the need to have implicit assumptions about data types
+and their representation, while encouraging explicit handling of mismatched types.
+
+## Options
+
+- None.
+
+## Example configuration
+
+```erlang
+{elvis_style, strict_term_equality, #{}}
+```

--- a/src/elvis_file.erl
+++ b/src/elvis_file.erl
@@ -118,7 +118,7 @@ filter_files(Files, Dirs, Filter, IgnoreList) ->
 
     lists:filter(
         fun(#{path := Path}) ->
-            MatchesPath = fun(Regex) -> match == re:run(Path, Regex, [{capture, none}]) end,
+            MatchesPath = fun(Regex) -> match =:= re:run(Path, Regex, [{capture, none}]) end,
             not lists:any(MatchesPath, IgnoreList)
         end,
         FoundUnique

--- a/src/elvis_project.erl
+++ b/src/elvis_project.erl
@@ -132,7 +132,7 @@ is_hex_dep(_) ->
     false.
 
 is_not_git_dep({_AppName, {_SCM, Url, _Branch}}, Regex) ->
-    nomatch == re:run(Url, Regex, []);
+    nomatch =:= re:run(Url, Regex, []);
 is_not_git_dep(
     {_AppName, {git_subdir, Url, {BranchTagOrRefType, _BranchTagOrRef}, _SubDir}},
     Regex
@@ -141,20 +141,20 @@ is_not_git_dep(
     BranchTagOrRefType =:= tag;
     BranchTagOrRefType =:= ref
 ->
-    nomatch == re:run(Url, Regex, []);
+    nomatch =:= re:run(Url, Regex, []);
 %% Specific to plugin rebar_raw_resource
 is_not_git_dep({AppName, {raw, DepResourceSpecification}}, Regex) ->
     is_not_git_dep({AppName, DepResourceSpecification}, Regex);
 %% Alternative formats, backwards compatible declarations
 is_not_git_dep({_AppName, {_SCM, Url}}, Regex) ->
-    nomatch == re:run(Url, Regex, []);
+    nomatch =:= re:run(Url, Regex, []);
 is_not_git_dep({_AppName, _Vsn, {_SCM, Url}}, Regex) ->
-    nomatch == re:run(Url, Regex, []);
+    nomatch =:= re:run(Url, Regex, []);
 is_not_git_dep({_AppName, _Vsn, {_SCM, Url, _Branch}}, Regex) ->
-    nomatch == re:run(Url, Regex, []);
+    nomatch =:= re:run(Url, Regex, []);
 is_not_git_dep({_AppName, _Vsn, {_SCM, Url, {BranchTagOrRefType, _Branch}}, _Opts}, Regex) when
     BranchTagOrRefType =:= branch;
     BranchTagOrRefType =:= tag;
     BranchTagOrRefType =:= ref
 ->
-    nomatch == re:run(Url, Regex, []).
+    nomatch =:= re:run(Url, Regex, []).

--- a/src/elvis_ruleset.erl
+++ b/src/elvis_ruleset.erl
@@ -173,7 +173,8 @@ elvis_style_stricter_rules() ->
         elvis_rule:new(elvis_style, no_macros),
         elvis_rule:new(elvis_style, prefer_unquoted_atoms),
         elvis_rule:new(elvis_style, state_record_and_type),
-        elvis_rule:new(elvis_style, prefer_include)
+        elvis_rule:new(elvis_style, prefer_include),
+        elvis_rule:new(elvis_style, strict_term_equivalence)
     ].
 
 elvis_text_style_stricter_rules() ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1655,7 +1655,7 @@ strict_term_equivalence(Rule, ElvisConfig) ->
 
     [
         elvis_result:new_item(
-            "unexpected non-shortcircuiting operator ~p was found; prefer ~p",
+            "unexpected weak comparison operator ~p was found; prefer ~p",
             [
                 ktn_code:attr(operation, OpNode),
                 maps:get(ktn_code:attr(operation, OpNode), Operators)
@@ -1842,7 +1842,7 @@ result_discarded(Zipper) ->
     case ktn_code:type(Parent) of
         match ->
             [LeftSide | _] = ktn_code:content(Parent),
-            ktn_code:type(LeftSide) == var andalso ktn_code:attr(name, LeftSide) == '_';
+            ktn_code:type(LeftSide) =:= var andalso ktn_code:attr(name, LeftSide) =:= '_';
         _ ->
             false
     end.
@@ -2110,7 +2110,7 @@ has_guards(ClauseNode) ->
 %%      If they only use words, then we just have [[#{type := op, attrs := #{operation = '...'}}]]
 has_guard_defined_with_punctuation(ClauseNode) ->
     length(ktn_code:node_attr(guards, ClauseNode)) > 1 orelse
-        length(ktn_code:node_attr(guards, ClauseNode)) == 1 andalso
+        length(ktn_code:node_attr(guards, ClauseNode)) =:= 1 andalso
             length(hd(ktn_code:node_attr(guards, ClauseNode))) > 1.
 
 has_guard_defined_with_words(ClauseNode) ->
@@ -2126,9 +2126,9 @@ has_guard_defined_with_words(ClauseNode) ->
 %%      It also returns true for not not not not X andalso Y
 %%      But it returns false for not not not X.
 is_two_sided_boolean_op(Node) ->
-    op == ktn_code:type(Node) andalso
+    op =:= ktn_code:type(Node) andalso
         lists:member(ktn_code:attr(operation, Node), ['and', 'or', 'andalso', 'orelse']) orelse
-        ktn_code:attr(operation, Node) == 'not' andalso
+        ktn_code:attr(operation, Node) =:= 'not' andalso
             is_two_sided_boolean_op(hd(ktn_code:content(Node))).
 
 param_pattern_matching(Rule, ElvisConfig) ->
@@ -2303,7 +2303,7 @@ prefer_include(Rule, ElvisConfig) ->
         inside => elvis_code:root(Rule, ElvisConfig),
         filtered_by =>
             fun(#{attrs := #{value := Value}}) ->
-                filename:basename(Value) == Value
+                filename:basename(Value) =:= Value
             end,
         traverse => all
     }),

--- a/src/elvis_text_style.erl
+++ b/src/elvis_text_style.erl
@@ -86,7 +86,7 @@ no_redundant_blank_lines(Rule, _ElvisConfig) ->
 redundant_blank_lines([], {_, Result}) ->
     Result;
 redundant_blank_lines(Lines, {CurrentLineNum, ResultList}) ->
-    BlankLines = lists:takewhile(fun(X) -> X == <<>> end, Lines),
+    BlankLines = lists:takewhile(fun(X) -> X =:= <<>> end, Lines),
     BlankElements = length(BlankLines),
     Index =
         case BlankElements of

--- a/test/examples/fail_strict_term_equivalence.erl
+++ b/test/examples/fail_strict_term_equivalence.erl
@@ -1,0 +1,17 @@
+-module(fail_strict_term_equivalence).
+
+-export([guards/2, body/2]).
+
+-record(a_record, {
+    equals = 1 == 1.0,
+    different = 1 /= 1.0
+    }).
+
+guards(A, B) when A == B -> equals;
+guards(A, B) when A /= B -> different.
+
+body(A, B) ->
+    case A of
+        B -> #a_record{equals = A == B};
+        _ -> A /= B orelse A == B
+    end.

--- a/test/examples/fail_strict_term_equivalence.erl
+++ b/test/examples/fail_strict_term_equivalence.erl
@@ -13,5 +13,5 @@ guards(A, B) when A /= B -> different.
 body(A, B) ->
     case A of
         B -> #a_record{equals = A == B};
-        _ -> A /= B orelse A == B
+        C -> A /= B orelse (A == B) == C
     end.

--- a/test/examples/pass_strict_term_equivalence.erl
+++ b/test/examples/pass_strict_term_equivalence.erl
@@ -1,0 +1,18 @@
+-module(pass_strict_term_equivalence).
+
+-export([guards/2, body/2]).
+
+-record(a_record, {
+    equals = 1 =:= 1.0,
+    different = 1 =/= 1.0
+    }).
+
+guards(A, B) when A =:= B -> equals;
+guards(A, B) when A =/= B -> different.
+
+body(A, B) ->
+    case A of
+        as_an_atom -> #{"this is valid" => '==', "This /= is also valid" => '/='};
+        B -> #a_record{equals = A =:= B};
+        _ -> A =/= B orelse A =:= B
+    end.

--- a/test/examples/pass_strict_term_equivalence.erl
+++ b/test/examples/pass_strict_term_equivalence.erl
@@ -14,5 +14,5 @@ body(A, B) ->
     case A of
         as_an_atom -> #{"this is valid" => '==', "This /= is also valid" => '/='};
         B -> #a_record{equals = A =:= B};
-        _ -> A =/= B orelse A =:= B
+        C -> A =/= B orelse (A =:= B) =:= C
     end.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -66,7 +66,8 @@
     verify_no_operation_on_same_value/1,
     verify_no_receive_without_timeout/1,
     verify_simplify_anonymous_functions/1,
-    verify_prefer_include/1
+    verify_prefer_include/1,
+    verify_strict_term_equivalence/1
 ]).
 %% -elvis attribute
 -export([
@@ -2078,6 +2079,28 @@ verify_no_operation_on_same_value(Config) ->
     ] =
         elvis_test_utils:elvis_core_apply_rule(
             Config, elvis_style, no_operation_on_same_value, #{operations => ['--', '++']}, FailPath
+        ).
+
+verify_strict_term_equivalence(Config) ->
+    Ext = proplists:get_value(test_file_ext, Config, "erl"),
+
+    PassPath = "pass_strict_term_equivalence." ++ Ext,
+    [] = elvis_test_utils:elvis_core_apply_rule(
+        Config, elvis_style, strict_term_equivalence, #{}, PassPath
+    ),
+
+    FailPath = "fail_strict_term_equivalence." ++ Ext,
+    [
+        #{line_num := 6},
+        #{line_num := 7},
+        #{line_num := 10},
+        #{line_num := 11},
+        #{line_num := 15},
+        #{line_num := 16},
+        #{line_num := 16}
+    ] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config, elvis_style, strict_term_equivalence, #{}, FailPath
         ).
 
 verify_no_boolean_in_comparison(Config) ->

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -2097,6 +2097,7 @@ verify_strict_term_equivalence(Config) ->
         #{line_num := 11},
         #{line_num := 15},
         #{line_num := 16},
+        #{line_num := 16},
         #{line_num := 16}
     ] =
         elvis_test_utils:elvis_core_apply_rule(


### PR DESCRIPTION
# Description

New strict rule: `strict_term_equivalence`

Closes #431.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
