### PR TITLE
revisit  types

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2730,7 +2730,7 @@ level_increment(#{type := 'fun', content := _}) ->
 level_increment(#{type := 'fun'}) ->
     0;
 level_increment(#{type := Type}) ->
-    IncrementOne = [function, 'case', 'if', try_case, try_catch, named_fun, receive_case],
+    IncrementOne = [function, 'case', 'if', try_case, try_catch, named_fun, receive_case, 'maybe'],
     case lists:member(Type, IncrementOne) of
         true ->
             1;

--- a/test/examples/fail_nesting_level.erl
+++ b/test/examples/fail_nesting_level.erl
@@ -1,5 +1,7 @@
 -module(fail_nesting_level).
 
+-feature(maybe_expr, enable).
+
 -dialyzer(no_match).
 
 %% Used so that the line positions don't change for tests.
@@ -194,5 +196,19 @@ dont_exceed_with_fun() ->
                  3 -> fun erlang:display/1;
                  4 -> ok
              end;
+        3 -> 3
+    end.
+
+exceed_with_maybe() ->
+    case 1 of
+        1 -> ok;
+        2 ->
+            maybe
+                1 ?= 2,
+                fun() -> ok end
+            else
+                false ->
+                    notok
+            end;
         3 -> 3
     end.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -742,21 +742,23 @@ verify_nesting_level(Config) ->
                     #{line_num := 69},
                     #{line_num := 108},
                     #{line_num := 153},
-                    #{line_num := 170}
+                    #{line_num := 170},
+                    _
                 ] =
                     elvis_test_utils:elvis_core_apply_rule(
                         Config, elvis_style, no_deep_nesting, #{level => 3}, Path
                     );
             erl_files ->
                 [
-                    #{line_num := 11},
-                    #{line_num := 18},
-                    #{line_num := 30},
-                    #{line_num := 45},
-                    #{line_num := 78},
-                    #{line_num := 120},
-                    #{line_num := 166},
-                    #{line_num := 182}
+                    #{line_num := 13},
+                    #{line_num := 20},
+                    #{line_num := 32},
+                    #{line_num := 47},
+                    #{line_num := 80},
+                    #{line_num := 122},
+                    #{line_num := 168},
+                    #{line_num := 184},
+                    _
                 ] =
                     elvis_test_utils:elvis_core_apply_rule(
                         Config, elvis_style, no_deep_nesting, #{level => 3}, Path


### PR DESCRIPTION
# Revisit `nesting_level` types

I added the 'maybe' to the list, with a test that verifies it's working fine.

I'm not sure if there are any others to add, but the one I'm thinking of is `begin`.

Closes #498;.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
