### PR TITLE
Fix #527: Remove duplicate results

### DIFF
--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -93,7 +93,11 @@ find(#{of_types := OfTypes, inside := Inside} = Options) ->
 find(Pred, Root, FilteredFrom, Traverse) ->
     Zipper = zipper(Root, Traverse),
     Results = find_with_zipper(Pred, Zipper, [], FilteredFrom),
-    lists:reverse(Results).
+    %% Note: I'm not sure why, sometimes, traversing a zipper may result in going through the same
+    %%       node twice, but it has happened. If you remove the call to lists:uniq/1 in the next
+    %%       line, you can see it for yourself: Just run the tests and the one for
+    %%       simplify_anonymous_functions will fail because it will emit duplicate results.
+    lists:reverse(lists:uniq(Results)).
 
 -spec zipper(tree_node()) -> tree_node_zipper().
 zipper(Root) ->

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -213,7 +213,7 @@ rock_without_errors_has_no_output(_Config) ->
     %% and CT will capture it.
     %% Thus, we remove it from the list of captures before doing the actual check
     RemoveSearchPattern = "fail_non_parsable_file.erl",
-    ct:pal("Output=~p~n", [Output]),
+    ct:log("Output=~p~n", [Output]),
     [] =
         lists:filter(
             fun(String) -> string:find(String, RemoveSearchPattern) == nomatch end,

--- a/test/examples/fail_simplify_anonymous_functions.erl
+++ b/test/examples/fail_simplify_anonymous_functions.erl
@@ -8,7 +8,8 @@ functions() ->
         one_arg => fun(X) -> erlang:display(X) end,
         two_args => fun(A, B) -> io:format(A, B) end,
         local => fun() -> local() end,
-        auto_import => fun(A) -> atom_to_list(A) end
+        auto_import => fun(A) -> atom_to_list(A) end,
+        in_a_case => case spawn(fun() -> erlang:halt() end) of Pid -> Pid end
     }.
 
 local() -> local.

--- a/test/examples/pass_simplify_anonymous_functions.erl
+++ b/test/examples/pass_simplify_anonymous_functions.erl
@@ -17,7 +17,8 @@ functions() ->
         with_guards => fun(X) when is_binary(X) -> binary_to_list(X) end,
         with_matching => fun(<<X/binary>>) -> erlang:binary_to_atom(X) end,
         multiple_clauses => fun (x) -> atom_to_list(x); (X) -> binary_to_list(X) end,
-        ignored_arg => fun(X, _) -> erlang:display(X) end
+        ignored_arg => fun(X, _) -> erlang:display(X) end,
+        in_a_case => case spawn(fun erlang:halt/0) of Pid -> Pid end
     }.
 
 local() -> local.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -1257,14 +1257,15 @@ verify_simplify_anonymous_functions(Config) ->
 
     case Group of
         beam_files ->
-            [_, _, _, _, _] = Warnings;
+            [_, _, _, _, _, _] = Warnings;
         _ ->
             [
                 #{line_num := 7},
                 #{line_num := 8},
                 #{line_num := 9},
                 #{line_num := 10},
-                #{line_num := 11}
+                #{line_num := 11},
+                #{line_num := 12}
             ] = Warnings
     end,
 


### PR DESCRIPTION
# Description

I'm not sure what's the root cause of the duplicates, but… in any case… we always want `elvis_code:find/4` results to be unique, anyway.

Closes #527.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
