### PR TITLE
Strict module layout

### DIFF
--- a/doc_rules/elvis_style/strict_module_layout.md
+++ b/doc_rules/elvis_style/strict_module_layout.md
@@ -1,4 +1,4 @@
-# Strict Module Layout ![](https://img.shields.io/badge/BEAM-yes-orange)
+# Strict Module Layout [![](https://img.shields.io/badge/since-4.2.0-blue)](https://github.com/inaka/elvis_core/releases/tag/4.2.0) ![](https://img.shields.io/badge/BEAM-yes-orange)
 
 Prefer sticking an exact order of the different parts in a module.
 

--- a/doc_rules/elvis_style/strict_module_layout.md
+++ b/doc_rules/elvis_style/strict_module_layout.md
@@ -11,6 +11,7 @@ Prefer sticking an exact order of the different parts in a module.
 
 -include[_lib](…).
 ```
+
 > with a configuration that describes an order: [module, include, dialyzer]
 
 ## Prefer
@@ -22,11 +23,13 @@ Prefer sticking an exact order of the different parts in a module.
 
 -dialyzer(…).
 ```
+
 > with a configuration that describes an order: [module, include, dialyzer]
 
 ## Rationale
 
-This is a readability issue. It can improve the odds of others reading and liking your code by making it easier to follow.
+This is a readability issue. It can improve the odds of others reading and
+liking your code by making it easier to follow.
 
 ## Options
 
@@ -39,5 +42,6 @@ This is a readability issue. It can improve the odds of others reading and likin
 ## Example configuration
 
 ```erlang
-{elvis_style, strict_module_layout, #{order => [module, inclue, dialyzer, type, export_type, export, function_call]}}
+{elvis_style, strict_module_layout,
+  #{order => [module, inclue, dialyzer, type, export_type, export, function_call]}}
 ```

--- a/doc_rules/elvis_style/strict_module_layout.md
+++ b/doc_rules/elvis_style/strict_module_layout.md
@@ -1,0 +1,43 @@
+# Strict Module Layout ![](https://img.shields.io/badge/BEAM-yes-orange)
+
+Prefer sticking an exact order of the different parts in a module.
+
+## Avoid
+
+```erlang
+-module(…).
+
+-dialyzer(…).
+
+-include[_lib](…).
+```
+> with a configuration that describes an order: [module, include, dialyzer]
+
+## Prefer
+
+```erlang
+-module(…).
+
+-include[_lib](…).
+
+-dialyzer(…).
+```
+> with a configuration that describes an order: [module, include, dialyzer]
+
+## Rationale
+
+This is a readability issue. It can improve the odds of others reading and liking your code by making it easier to follow.
+
+## Options
+
+- order :: [atom]
+  - default: [module, include, dialyzer, elvis, mixin, type_attr, export_type, export, function]
+
+- ignore_mod_parts :: [atom]
+  - default :: []
+
+## Example configuration
+
+```erlang
+{elvis_style, strict_module_layout, #{order => [module, inclue, dialyzer, type, export_type, export, function_call]}}
+```

--- a/doc_rules/elvis_style/strict_module_layout.md
+++ b/doc_rules/elvis_style/strict_module_layout.md
@@ -43,5 +43,5 @@ liking your code by making it easier to follow.
 
 ```erlang
 {elvis_style, strict_module_layout,
-  #{order => [module, inclue, dialyzer, type, export_type, export, function_call]}}
+  #{order => [module, include, dialyzer, type, export_type, export, function_call]}}
 ```

--- a/elvis.config
+++ b/elvis.config
@@ -26,9 +26,6 @@
                                 {elvis_style, is_allowed_macro, 2},
                                 {elvis_style, doesnt_need_quotes, 1}
                             ]
-                        }},
-                        {elvis_style, prefer_unquoted_atoms, #{
-                            ignore => [{elvis_style, ignore, 3}]
                         }}
                     ],
                 ruleset => erl_files_strict
@@ -44,10 +41,7 @@
                         {elvis_style, no_god_modules, #{ignore => [elvis_style]}},
                         {elvis_style, prefer_strict_generators, disable},
                         {elvis_style, no_throw, disable},
-                        {elvis_style, no_common_caveats_call, disable},
-                        {elvis_style, prefer_unquoted_atoms, #{
-                            ignore => [elvis_style]
-                        }}
+                        {elvis_style, no_common_caveats_call, disable}
                     ],
                 ruleset => beam_files_strict
             },

--- a/elvis.config
+++ b/elvis.config
@@ -44,7 +44,10 @@
                         {elvis_style, no_god_modules, #{ignore => [elvis_style]}},
                         {elvis_style, prefer_strict_generators, disable},
                         {elvis_style, no_throw, disable},
-                        {elvis_style, no_common_caveats_call, disable}
+                        {elvis_style, no_common_caveats_call, disable},
+                        {elvis_style, prefer_unquoted_atoms, #{
+                            ignore => [{elvis_style, ignore, 3}]
+                        }}
                     ],
                 ruleset => beam_files_strict
             },

--- a/elvis.config
+++ b/elvis.config
@@ -46,7 +46,7 @@
                         {elvis_style, no_throw, disable},
                         {elvis_style, no_common_caveats_call, disable},
                         {elvis_style, prefer_unquoted_atoms, #{
-                            ignore => [{elvis_style, ignore, 3}]
+                            ignore => [elvis_style]
                         }}
                     ],
                 ruleset => beam_files_strict

--- a/elvis.config
+++ b/elvis.config
@@ -26,6 +26,9 @@
                                 {elvis_style, is_allowed_macro, 2},
                                 {elvis_style, doesnt_need_quotes, 1}
                             ]
+                        }},
+                        {elvis_style, prefer_unquoted_atoms, #{
+                            ignore => [{elvis_style, ignore, 3}]
                         }}
                     ],
                 ruleset => erl_files_strict

--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -1,5 +1,10 @@
 -module(elvis_code).
 
+-type tree_node() :: ktn_code:tree_node().
+-type tree_node_zipper() :: zipper:zipper(tree_node()).
+
+-export_type([tree_node/0, tree_node_zipper/0]).
+
 %% General
 -export([
     find/1,
@@ -15,11 +20,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Public API
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
--type tree_node() :: ktn_code:tree_node().
--type tree_node_zipper() :: zipper:zipper(tree_node()).
-
--export_type([tree_node/0, tree_node_zipper/0]).
 
 -spec find(Options) -> {nodes, [Node]} | {zippers, [Zipper]} when
     Options :: #{

--- a/src/elvis_ruleset.erl
+++ b/src/elvis_ruleset.erl
@@ -140,7 +140,6 @@ elvis_style_rules() ->
         elvis_rule:new(elvis_style, variable_naming_convention),
         elvis_rule:new(elvis_style, guard_operators),
         elvis_rule:new(elvis_style, simplify_anonymous_functions)
-        % elvis_rule:new(elvis_style, strict_module_layout)
     ].
 
 erl_files_test_rules() ->
@@ -183,7 +182,8 @@ elvis_style_stricter_rules() ->
         elvis_rule:new(elvis_style, state_record_and_type),
         elvis_rule:new(elvis_style, prefer_include),
         elvis_rule:new(elvis_style, strict_term_equivalence),
-        elvis_rule:new(elvis_style, macro_definition_parentheses)
+        elvis_rule:new(elvis_style, macro_definition_parentheses),
+        elvis_rule:new(elvis_style, strict_module_layout)
     ].
 
 elvis_text_style_stricter_rules() ->

--- a/src/elvis_ruleset.erl
+++ b/src/elvis_ruleset.erl
@@ -139,8 +139,8 @@ elvis_style_rules() ->
         elvis_rule:new(elvis_style, no_used_ignored_variables),
         elvis_rule:new(elvis_style, variable_naming_convention),
         elvis_rule:new(elvis_style, guard_operators),
-        elvis_rule:new(elvis_style, simplify_anonymous_functions),
-        elvis_rule:new(elvis_style, strict_module_layout)
+        elvis_rule:new(elvis_style, simplify_anonymous_functions)
+        % elvis_rule:new(elvis_style, strict_module_layout)
     ].
 
 erl_files_test_rules() ->

--- a/src/elvis_ruleset.erl
+++ b/src/elvis_ruleset.erl
@@ -139,7 +139,8 @@ elvis_style_rules() ->
         elvis_rule:new(elvis_style, no_used_ignored_variables),
         elvis_rule:new(elvis_style, variable_naming_convention),
         elvis_rule:new(elvis_style, guard_operators),
-        elvis_rule:new(elvis_style, simplify_anonymous_functions)
+        elvis_rule:new(elvis_style, simplify_anonymous_functions),
+        elvis_rule:new(elvis_style, strict_module_layout)
     ].
 
 erl_files_test_rules() ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2812,7 +2812,7 @@ valid_order(Category, Prev, Node, Result, Order) ->
     end.
 
 ignore(Type, Category, Order) ->
-    lists:member(Type, [comment, ifdef, ifndef, 'else', 'if', elif, endif]) orelse
+    lists:member(Type, [comment, ifdef, ifndef, else, 'if', elif, endif]) orelse
         not lists:member(Category, Order).
 
 get_category(Type) ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2788,9 +2788,9 @@ strict_module_layout(Rule, ElvisConfig) ->
     lists:map(
         fun({CorrectPrev, ActualPrev, NodeTypeCategory, Node}) ->
             elvis_result:new_item(
-                "A ~p type element was found after a ~p type element,"
-                "but it should follow a type ~p",
-                [NodeTypeCategory, ActualPrev, CorrectPrev],
+                "A ~p type element was found after a ~p type element."
+                " That doesn't respect the expected module layout: ~p",
+                [NodeTypeCategory, ActualPrev, Order],
                 #{node => Node}
             )
         end,

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2774,6 +2774,7 @@ strict_module_layout(Rule, ElvisConfig) ->
         inside => elvis_code:root(Rule, ElvisConfig)
     }),
 
+    % drop consecutives
     {_, NodeTypeList} = lists:foldr(
         fun(Node, {Prev, Result}) ->
             Type = ktn_code:type(Node),
@@ -2786,7 +2787,8 @@ strict_module_layout(Rule, ElvisConfig) ->
         Nodes
     ),
 
-    FilteredTypeList = lists:filter(
+    % drop unused ones
+    FilteredOrderList = lists:filter(
         fun(Type) ->
             lists:keymember(Type, 1, NodeTypeList)
         end,
@@ -2806,7 +2808,7 @@ strict_module_layout(Rule, ElvisConfig) ->
                         #{node => Node}
                     )}
         end,
-        lists:zip(NodeTypeList, FilteredTypeList, {pad, {nil, nil}})
+        lists:zip(NodeTypeList, FilteredOrderList, {pad, {nil, nil}})
     ).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2812,7 +2812,7 @@ valid_order(Category, Prev, Node, Result, Order) ->
     end.
 
 ignore(Type, Category, Order) ->
-    lists:member(Type, [comment, ifdef, ifndef, else, 'if', elif, endif]) orelse
+    lists:member(Type, [comment, ifdef, ifndef, 'else', 'if', elif, endif]) orelse
         not lists:member(Category, Order).
 
 get_category(Type) ->

--- a/test/examples/fail_strict_module_layout.erl
+++ b/test/examples/fail_strict_module_layout.erl
@@ -5,13 +5,27 @@
 -export_type([my_type/0]).
 
 -export([some_fun/0]).
+-import(test_module, []).
+
+-behaviour(gen_event).
+-export([init/1, handle_event/2]).
 
 -type my_type() :: ok.
+-export([handle_call/2]).
 
 -mixin([]).
+-doc("doc").
+-vsn(1.0).
+-moduledoc("").
 
 -spec some_fun() -> my_type().
 some_fun() -> ok.
 
 -dialyzer({nowarn_function, []}).
+
+-compile("").
+
+handle_call(_, _) -> ok.
+handle_event(_, _) -> ok.
+init(_) -> ok.
 

--- a/test/examples/fail_strict_module_layout.erl
+++ b/test/examples/fail_strict_module_layout.erl
@@ -1,0 +1,17 @@
+-module(fail_strict_module_layout).
+
+-elvis([{elvis_style, no_macros, #{allow => ['__']}}]).
+
+-export_type([my_type/0]).
+
+-export([some_fun/0]).
+
+-type my_type() :: ok.
+
+-mixin([]).
+
+-spec some_fun() -> my_type().
+some_fun() -> ok.
+
+-dialyzer({nowarn_function, []}).
+

--- a/test/examples/fail_strict_module_layout_allways.erl
+++ b/test/examples/fail_strict_module_layout_allways.erl
@@ -1,0 +1,6 @@
+-module(fail_strict_module_layout_allways).
+
+-type bananas() :: bananas.
+-export_type([bananas/0, tomatoes/0]).
+-type tomatoes() :: tomatoes.
+

--- a/test/examples/pass_strict_module_layout.erl
+++ b/test/examples/pass_strict_module_layout.erl
@@ -1,4 +1,7 @@
 -module(pass_strict_module_layout).
+-moduledoc("").
+
+-vsn(1.0).
 
 -include("./prefer_include.hrl").
 
@@ -8,6 +11,8 @@
 -hank([]).
 -import(test_module, []).
 
+-behaviour(gen_event).
+
 -type my_type() :: ok.
 -opaque my_opaque() :: definition.
 
@@ -16,10 +21,25 @@
 -export_type([name/0]).
 -endif.
 
+-if(ok).
+-type apple() :: apple.
+-export_type([apple/0]).
+-elif(notok).
+-type orange() :: orange.
+-export_type([orange/0]).
+-else.
+-type banana() :: banana.
+-export_type([banana/0]).
+-endif.
+
 -export_type([my_opaque/0]).
 -export([some_fun/0, some_fun_2/0, some_fun_3/0, some_fun_4/0]).
+-export([init/1, handle_call/2, handle_event/2]).
+
 
 -define(MACRO, ok).
+
+-doc("doc").
 
 -spec some_fun() -> my_type().
 some_fun() -> ?MACRO.
@@ -32,3 +52,7 @@ some_fun_3() -> ok.
 
 -spec some_fun_4() -> my_type().
 some_fun_4() -> ok.
+
+handle_call(_, _) -> ok.
+handle_event(_, _) -> ok.
+init(_) -> ok.

--- a/test/examples/pass_strict_module_layout.erl
+++ b/test/examples/pass_strict_module_layout.erl
@@ -3,36 +3,32 @@
 -include("./prefer_include.hrl").
 
 -dialyzer(no_match).
--elvis([{elvis_style, no_macros, #{allow => ['__']}}]).
+-elvis([{elvis_style, no_macros, disable}]).
 -mixin([]).
+-hank([]).
+-import(test_module, []).
 
 -type my_type() :: ok.
+-opaque my_opaque() :: definition.
+
 -ifdef(TEST).
 -type name() :: definition.
--endif.
-
--export_type([my_type/0, my_type_2/0]).
--ifdef(TEST).
 -export_type([name/0]).
 -endif.
 
+-export_type([my_opaque/0]).
 -export([some_fun/0, some_fun_2/0, some_fun_3/0, some_fun_4/0]).
 
-% -ifdef(TEST).
-% -type name() :: definition.
-% -export_type([name/0]).
-% -endif.
+-define(MACRO, ok).
 
 -spec some_fun() -> my_type().
-some_fun() -> ok.
+some_fun() -> ?MACRO.
 
 -spec some_fun_2() -> my_type().
 some_fun_2() -> ok.
 
 -spec some_fun_3() -> my_type().
 some_fun_3() -> ok.
-
--type my_type_2() :: ok.
 
 -spec some_fun_4() -> my_type().
 some_fun_4() -> ok.

--- a/test/examples/pass_strict_module_layout.erl
+++ b/test/examples/pass_strict_module_layout.erl
@@ -1,0 +1,38 @@
+-module(pass_strict_module_layout).
+
+-include("./prefer_include.hrl").
+
+-dialyzer(no_match).
+-elvis([{elvis_style, no_macros, #{allow => ['__']}}]).
+-mixin([]).
+
+-type my_type() :: ok.
+-ifdef(TEST).
+-type name() :: definition.
+-endif.
+
+-export_type([my_type/0, my_type_2/0]).
+-ifdef(TEST).
+-export_type([name/0]).
+-endif.
+
+-export([some_fun/0, some_fun_2/0, some_fun_3/0, some_fun_4/0]).
+
+% -ifdef(TEST).
+% -type name() :: definition.
+% -export_type([name/0]).
+% -endif.
+
+-spec some_fun() -> my_type().
+some_fun() -> ok.
+
+-spec some_fun_2() -> my_type().
+some_fun_2() -> ok.
+
+-spec some_fun_3() -> my_type().
+some_fun_3() -> ok.
+
+-type my_type_2() :: ok.
+
+-spec some_fun_4() -> my_type().
+some_fun_4() -> ok.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -73,7 +73,8 @@
     verify_prefer_include/1,
     verify_prefer_strict_generators/1,
     verify_strict_term_equivalence/1,
-    verify_macro_definition_parentheses/1
+    verify_macro_definition_parentheses/1,
+    verify_strict_module_layout/1
 ]).
 %% -elvis attribute
 -export([
@@ -3208,6 +3209,40 @@ verify_macro_definition_parentheses(Config) ->
     [#{line_num := 5}, #{line_num := 6}, #{line_num := 7}, #{line_num := 8}] =
         elvis_test_utils:elvis_core_apply_rule(
             Config, elvis_style, macro_definition_parentheses, #{}, FailPath
+        ).
+
+verify_strict_module_layout(Config) ->
+    Ext = proplists:get_value(test_file_ext, Config, "erl"),
+    #{order := Order} = elvis_style:default(strict_module_layout),
+
+    PassModule = pass_strict_module_layout,
+    PassPath = atom_to_list(PassModule) ++ "." ++ Ext,
+
+    [_, _] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config, elvis_style, strict_module_layout, #{order => Order}, PassPath
+        ),
+
+    FailModule = fail_strict_module_layout,
+    FailPath = atom_to_list(FailModule) ++ "." ++ Ext,
+
+    [_, _, _, _, _, _] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config, elvis_style, strict_module_layout, #{order => Order}, FailPath
+        ),
+
+    [] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config, elvis_style, strict_module_layout, #{order => [module]}, FailPath
+        ),
+
+    [] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            strict_module_layout,
+            #{order => [module, export, function]},
+            FailPath
         ).
 
 verify_elvis_attr_atom_naming_convention(Config) ->

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -3218,7 +3218,7 @@ verify_strict_module_layout(Config) ->
     PassModule = pass_strict_module_layout,
     PassPath = atom_to_list(PassModule) ++ "." ++ Ext,
 
-    [_, _] =
+    [] =
         elvis_test_utils:elvis_core_apply_rule(
             Config, elvis_style, strict_module_layout, #{order => Order}, PassPath
         ),
@@ -3241,7 +3241,7 @@ verify_strict_module_layout(Config) ->
             Config,
             elvis_style,
             strict_module_layout,
-            #{order => [module, export, function]},
+            #{order => [module, exports, body]},
             FailPath
         ).
 

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -3223,14 +3223,62 @@ verify_strict_module_layout(Config) ->
             Config, elvis_style, strict_module_layout, #{order => Order}, PassPath
         ),
 
+    % causing trouble with a poor order
+    [
+        #{line_num := 2},
+        #{line_num := 4},
+        #{line_num := 14},
+        #{line_num := 21},
+        #{line_num := 42},
+        #{line_num := 44}
+    ] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            strict_module_layout,
+            #{order => [module, vsn, moduledoc, behaviour, comment, export_types, exports, body]},
+            PassPath
+        ),
+
+    % empty order list, same as disabling thiss rule
+    [] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config, elvis_style, strict_module_layout, #{order => []}, PassPath
+        ),
+
     FailModule = fail_strict_module_layout,
     FailPath = atom_to_list(FailModule) ++ "." ++ Ext,
 
-    [_, _, _, _, _, _] =
+    [_, _, _, _, _, _, _] =
         elvis_test_utils:elvis_core_apply_rule(
             Config, elvis_style, strict_module_layout, #{order => Order}, FailPath
         ),
 
+    % check a lot of stuff
+    [_, _, _, _, _, _, _, _, _, _, _, _] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            strict_module_layout,
+            #{
+                order => [
+                    module,
+                    moduledoc,
+                    vsn,
+                    compile,
+                    behaviour,
+                    record,
+                    import,
+                    types,
+                    comment,
+                    exports,
+                    body
+                ]
+            },
+            FailPath
+        ),
+
+    % let's check just a few parts
     [] =
         elvis_test_utils:elvis_core_apply_rule(
             Config, elvis_style, strict_module_layout, #{order => [module]}, FailPath
@@ -3243,6 +3291,58 @@ verify_strict_module_layout(Config) ->
             strict_module_layout,
             #{order => [module, exports, body]},
             FailPath
+        ),
+
+    % empty order list, same as disabling thiss rule
+    [] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config, elvis_style, strict_module_layout, #{order => []}, FailPath
+        ),
+
+    % this allways will fail
+    AllwaysFailModule = fail_strict_module_layout_allways,
+    AllwaysFailPath = atom_to_list(AllwaysFailModule) ++ "." ++ Ext,
+
+    [#{line_num := 5}] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            strict_module_layout,
+            #{order => [module, types, export_types]},
+            AllwaysFailPath
+        ),
+
+    [#{line_num := 3}, #{line_num := 4}] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            strict_module_layout,
+            #{order => [module, export_types, types]},
+            AllwaysFailPath
+        ),
+
+    % if we don't add the module part, this will not fail
+    % because 'type' will not have any defined previous elements,
+    % so it basically not violate the rule
+    [] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            strict_module_layout,
+            #{order => [types, export_types]},
+            AllwaysFailPath
+        ),
+
+    % repeating a keyword does not have any effect,
+    % because we get the first entry from the order list when checking
+    % if the the previous element matches with the right order or not
+    [#{line_num := 5}] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            strict_module_layout,
+            #{order => [module, types, export_types, types]},
+            AllwaysFailPath
         ).
 
 verify_elvis_attr_atom_naming_convention(Config) ->


### PR DESCRIPTION
# Description

A new rule for making a strict layout order for Erlang modules.
Now, the user can define an order by creating a list of ot atoms like this: `[module, export, function]`

This rule will examine the modules and verify if the actual order is correct or not.

Three open questions I have:
  - Is the default list good enough? We could define a simpler one. (that contains just a basic 3-4 types)
  - Do we want to make result error messages at every wrong node (now we have), or do we want just one error message pre module that describes the module is incorrect in its order of parts?
  - How to handle `-ifdef`? I have two possible solutions, one of which is working with this code, and the other would require some additional logic. I describe these two below with examples.

Closes #288;.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
