### PR TITLE
Fix: Crash in macro_definition_parentheses rule and relax its logic

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -2733,6 +2733,8 @@ macro_definition_parentheses(Rule, ElvisConfig) ->
             case {macro_attr_type(Elem1), macro_attr_type(Elem2)} of
                 {call, call} ->
                     false;
+                {call, op} ->
+                    false;
                 {call, _} ->
                     true;
                 {var, tree} ->
@@ -2765,6 +2767,8 @@ macro_definition_parentheses(Rule, ElvisConfig) ->
 macro_attr_type({Type, _, _}) ->
     Type;
 macro_attr_type({Type, _, _, _}) ->
+    Type;
+macro_attr_type({Type, _, _, _, _}) ->
     Type.
 
 is_stringified_function(Tree) ->

--- a/test/examples/pass_macro_definition_parentheses.erl
+++ b/test/examples/pass_macro_definition_parentheses.erl
@@ -7,6 +7,11 @@
 -define(GET_NAME(), get_attr(name)).
 -define(GET_AGE(), get_attr(age)).
 -define(GET_ACTIONS(), actions_module:get_actions()).
+-define(SOCKET_ERROR(State),
+    ((Error =:= tcp_error andalso element(2, State) =:= tcp) orelse
+        (Error =:= ssl_error andalso element(2, State) =:= ssl))
+).
+
 -define(SOMETHING(), something:poorly(written).
 
 -define(THE_MACRO, io:format("~p\n", [).


### PR DESCRIPTION
This code https://github.com/dnsimple/erldns/blob/main/src/listeners/tcp/erldns_proto_tcp.erl#L8 crashed on the latest version of elvis (4.2), wasn't crashing on 4.1.

Fixes a 'function_clause' crash in the rule when processing complex expressions in macro bodies. The function is made more robust to handle various AST node types.

Coming from this crashlog:
```erl
{elvis_style, macro_attr_type,
    [
        {op, [{text, "orelse"}, {location, {9, 68}}], 'orelse',
            {op,
                [
                    {text, "andalso"},
                    {location, {9, 27}}
                ],
                'andalso',
                {op,
                    [
                        {text, "=:="},
                        {location, {9, 13}}
                    ],
                    '=:=',
                    {var,
                        [
                            {text, "Error"},
                            {location, {9, 7}}
                        ],
                        'Error'},
                    {atom,
                        [
                            {text, "tcp_error"},
                            {location, {9, 17}}
                        ],
                        tcp_error}},
                {op,
                    [
                        {text, "=:="},
                        {location, {9, 59}}
                    ],
                    '=:=',
                    {record_field,
                        [
                            {text, "#"},
                            {location, {9, 40}}
                        ],
                        {var,
                            [
                                {text, "State"},
                                {location, {9, 35}}
                            ],
                            'State'},
                        state,
                        {atom,
                            [
                                {text, "socket_type"},
                                {location, {9, 47}}
                            ],
                            socket_type}},
                    {atom,
                        [
                            {text, "tcp"},
                            {location, {9, 63}}
                        ],
                        tcp}}},
            {op, [{text, "andalso"}, {location, {10, 30}}], 'andalso',
                {op,
                    [
                        {text, "=:="},
                        {location, {10, 16}}
                    ],
                    '=:=',
                    {var,
                        [
                            {text, "Error"},
                            {location, {10, 10}}
                        ],
                        'Error'},
                    {atom,
                        [
                            {text, "ssl_error"},
                            {location, {10, 20}}
                        ],
                        ssl_error}},
                {op, [{text, "=:="}, {location, {10, 62}}], '=:=',
                    {record_field,
                        [
                            {text, "#"},
                            {location, {10, 43}}
                        ],
                        {var,
                            [
                                {text, "State"},
                                {location, {10, 38}}
                            ],
                            'State'},
                        state,
                        {atom,
                            [
                                {text, "socket_type"},
                                {location, {10, 50}}
                            ],
                            socket_type}},
                    {atom, [{text, "ssl"}, {location, {10, 66}}], ssl}}}}
    ],
    [{file, "erldns/_build/default/plugins/elvis_core/src/elvis_style.erl"}, {line, 2765}]},
```

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
