### PR TITLE
Add a regression test for #545

### DIFF
--- a/test/examples/pass_unquoted_atoms.erl
+++ b/test/examples/pass_unquoted_atoms.erl
@@ -1,6 +1,6 @@
 -module(pass_unquoted_atoms).
 
--export([test/1, test/2]).
+-export([test/1, test/2, test_unicode/0]).
 
 test(_Test) -> ok.
 
@@ -9,3 +9,5 @@ test(_Reserved, _Words) -> ['after', 'and', 'andalso', 'band', 'begin', 'bnot', 
          'catch', 'cond', 'div', 'end', 'fun', 'if', 'let', 'not', 'of', 'or', 'orelse', 'receive',
          'rem', 'try', 'when', 'xor', 'maybe'].
 
+%% Unicode atoms that genuinely need quotes should not crash the rule (GH-545)
+test_unicode() -> 'Πλάτων'.


### PR DESCRIPTION
Closes #545 

This was coincidentally fixed by https://github.com/inaka/elvis_core/pull/548 😄 

As in that PR I moved all regexes to be precompiled with the `re_compile` helper, turns out, that helper is compiling with `unicode` support, so now Greek and any other unicode codepoint passes correctly 🎉 