### PR TITLE
Fix: Allow string patterns in ignore lists

### DIFF
--- a/src/elvis_rule.erl
+++ b/src/elvis_rule.erl
@@ -109,6 +109,9 @@ maybe_ensure_loaded(NS) ->
     code:ensure_loaded(NS).
 
 -spec is_ignorable(term()) -> boolean().
+% String (file path / regex pattern)
+is_ignorable(String) when is_list(String) ->
+    io_lib:char_list(String) andalso length(String) > 0;
 % Module - invalid type
 is_ignorable(Module) when not is_tuple(Module) andalso not is_atom(Module) ->
     false;

--- a/test/elvis_config_SUITE.erl
+++ b/test/elvis_config_SUITE.erl
@@ -9,6 +9,7 @@
 -export([rock_with_file_config/1]).
 -export([rock_with_rebar_default_config/1]).
 -export([throw_configuration/1]).
+-export([validate_config_with_string_ignore/1]).
 
 % ct_suite
 all() ->
@@ -60,3 +61,16 @@ throw_configuration(_Config) ->
                 ok
         end,
     _ = file:delete(Filename).
+
+%% @doc Regression test for https://github.com/inaka/elvis_core/issues/544
+%%      String patterns (e.g. .hrl file paths) must be accepted in ignore lists.
+validate_config_with_string_ignore(_Config) ->
+    Config = [
+        #{
+            dirs => ["../../../../_build/test/lib/elvis_core/test/examples/"],
+            filter => "*.erl",
+            ignore => ["include/file_that_i_want_to_ignore.hrl"],
+            ruleset => erl_files
+        }
+    ],
+    ok = elvis_config:validate_config(Config).


### PR DESCRIPTION
The config validation added in #515 rejected strings in ignore lists (e.g. "include/file.hrl") because `is_ignorable/1` only accepted atoms and tuples. Strings were already valid ignore values handled by `ignore_to_regexp/1`, so this adds a clause to accept non-empty char lists and a regression test.

Fixes #544 