### PR TITLE
Fix: Allow glob dir patterns that match nothing

### DIFF
--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -626,10 +626,9 @@ config_is_valid(CustomRulesetNames, Config) ->
         % and the fact it knows about elvis_core's internals, but we
         % should shortly revisit this
         ok ?= map_keys_are_in(Config, [dirs, filter, ignore, ruleset, rules, files]),
-        Dirs = get_config_opt(dirs, Config),
-        ok ?= is_nonempty_list_of_dirs(dirs, Dirs),
         Filter = get_config_opt(filter, Config),
         ok ?= is_nonempty_string(filter, Filter),
+        Dirs = get_config_opt(dirs, Config),
         ok ?= all_dirs_filter_combos_are_valid(Dirs, Filter),
         Ignore = get_config_opt(ignore, Config),
         ok ?= is_list_of_ignorables(ignore, Ignore),
@@ -657,29 +656,6 @@ map_keys_are_in(Map, Keys) ->
                 ])}
     end.
 
-is_nonempty_list_of_dirs(What, List) when not is_list(List) orelse List =:= [] ->
-    {error, io_lib:format("'~s' is expected to be a non-empty list.", [What])};
-is_nonempty_list_of_dirs(What, List) ->
-    Filtered = [
-        Element
-     || Element <- List, not io_lib:char_list(Element) orelse not holds_dir(Element)
-    ],
-    case Filtered of
-        [] ->
-            ok;
-        _ ->
-            {error,
-                io_lib:format(
-                    "in '~s', the following elements are not (or don't contain) directories: ~s.",
-                    [What, elvis_utils:list_to_str(Filtered)]
-                )}
-    end.
-
-holds_dir(Element) ->
-    Dirs = filelib:wildcard(Element),
-    Filtered = [Dir || Dir <- Dirs, filelib:is_dir(Dir)],
-    Filtered =/= [].
-
 is_nonempty_string(What, String) ->
     case io_lib:char_list(String) andalso length(String) > 0 of
         true ->
@@ -689,30 +665,15 @@ is_nonempty_string(What, String) ->
     end.
 
 all_dirs_filter_combos_are_valid(Dirs, Filter) ->
-    AccOut = lists:foldl(
-        fun(Dir, AccIn) ->
-            case filelib:wildcard(filename:join(Dir, Filter)) of
-                [_ | _] ->
-                    AccIn;
-                _ ->
-                    [
-                        io_lib:format(
-                            "'<dir>' + '<filter>' combo '~s' + '~s' yielded no files to analyse.", [
-                                Dir, Filter
-                            ]
-                        )
-                        | AccIn
-                    ]
-            end
-        end,
-        [],
-        Dirs
-    ),
-    case AccOut of
-        [] ->
+    case lists:any(fun(Dir) -> filelib:wildcard(filename:join(Dir, Filter)) =/= [] end, Dirs) of
+        true ->
             ok;
-        _ ->
-            {error, lists:reverse(AccOut)}
+        false ->
+            {error,
+                io_lib:format(
+                    "no '<dir>' + '<filter>' combo in ~s + '~s' yielded any files to analyse.",
+                    [elvis_utils:list_to_str(Dirs), Filter]
+                )}
     end.
 
 is_list_of_ignorables(What, List) when not is_list(List) ->

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -19,6 +19,7 @@
     rock_with_rule_groups/1,
     rock_this_skipping_files/1,
     rock_this_not_skipping_files/1,
+    rock_with_glob_dirs_not_matching/1,
     rock_with_umbrella_apps/1,
     custom_ruleset/1,
     hrl_ruleset/1,
@@ -75,6 +76,19 @@ rock_with_list_config(_Config) ->
     ElvisConfig = [
         #{
             dirs => ["../../../../test/dirs/src"],
+            rules => [{elvis_text_style, line_length, disable}],
+            filter => "*.erl"
+        }
+    ],
+    ok = elvis_core:rock(ElvisConfig).
+
+%% Regression test for https://github.com/inaka/elvis_core/issues/543
+%% Glob patterns that don't match any existing directories should not cause
+%% a validation error.
+rock_with_glob_dirs_not_matching(_Config) ->
+    ElvisConfig = [
+        #{
+            dirs => ["absolutely/very/nonexistent/**/src", "../../../../test/dirs/src"],
             rules => [{elvis_text_style, line_length, disable}],
             filter => "*.erl"
         }


### PR DESCRIPTION
Fixes #543

The dirs validation introduced in #515 rejected glob patterns like
`"apps/**/src"` when they didn't match any existing directories,
breaking non-umbrella projects using the default config.

Remove the per-element directory existence check entirely, and relax the
dir+filter combo validation to require that at least one combination
yields files, rather than all of them.