### PR TITLE
Fix: Don't crash on deprecated/renamed rules, warn and skip instead

### DIFF
--- a/src/elvis_deprecated_rules.erl
+++ b/src/elvis_deprecated_rules.erl
@@ -1,0 +1,49 @@
+-module(elvis_deprecated_rules).
+
+-export([find/2]).
+
+%% @doc Returns deprecation info for known deprecated or renamed rules.
+%% Returns {deprecated, Message} | {renamed, Message} | valid
+-spec find(module(), atom()) -> {deprecated | renamed, string()} | valid.
+
+%% Deprecated rules (no longer have implementations)
+find(elvis_style, macro_module_names) ->
+    {deprecated, "Rule 'elvis_style:macro_module_names' is deprecated since 4.1.0."};
+find(elvis_project, no_deps_master_erlang_mk) ->
+    {deprecated,
+        "Rule 'elvis_project:no_deps_master_erlang_mk' is deprecated;"
+        " use 'no_branch_deps' instead."};
+find(elvis_project, no_deps_master_rebar) ->
+    {deprecated,
+        "Rule 'elvis_project:no_deps_master_rebar' is deprecated;"
+        " use 'no_branch_deps' instead."};
+find(elvis_project, old_configuration_format) ->
+    {deprecated, "Rule 'elvis_project:old_configuration_format' is deprecated."};
+find(elvis_project, protocol_for_deps_rebar) ->
+    {deprecated,
+        "Rule 'elvis_project:protocol_for_deps_rebar' is deprecated;"
+        " use 'protocol_for_deps' instead."};
+find(elvis_project, protocol_for_deps_erlang_mk) ->
+    {deprecated, "Rule 'elvis_project:protocol_for_deps_erlang_mk' is deprecated."};
+%% Renamed rules (from PR #505)
+find(elvis_style, god_modules) ->
+    {renamed, "Rule 'elvis_style:god_modules' has been renamed to 'no_god_modules'."};
+find(elvis_style, nesting_level) ->
+    {renamed, "Rule 'elvis_style:nesting_level' has been renamed to 'no_deep_nesting'."};
+find(elvis_style, invalid_dynamic_call) ->
+    {renamed,
+        "Rule 'elvis_style:invalid_dynamic_call' has been renamed to 'no_invalid_dynamic_calls'."};
+find(elvis_style, used_ignored_variable) ->
+    {
+        renamed,
+        "Rule 'elvis_style:used_ignored_variable' has been renamed to 'no_used_ignored_variables'."
+    };
+find(elvis_style, macro_names) ->
+    {renamed, "Rule 'elvis_style:macro_names' has been renamed to 'macro_naming_convention'."};
+find(elvis_style, consistent_generic_type) ->
+    {renamed, "Rule 'elvis_style:consistent_generic_type' has been renamed to 'generic_type'."};
+find(elvis_style, consistent_variable_casing) ->
+    {renamed,
+        "Rule 'elvis_style:consistent_variable_casing' has been renamed to 'variable_casing'."};
+find(_, _) ->
+    valid.

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -28,7 +28,8 @@
     invalid_file/1,
     to_string/1,
     chunk_fold/1,
-    rock_with_invalid_rules/1
+    rock_with_invalid_rules/1,
+    rock_with_deprecated_rules/1
 ]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -324,6 +325,12 @@ rock_with_invalid_rules(_Config) ->
     ConfigPath = "../../../../test/examples/invalid_rules.elvis.config",
     {fail, [{throw, {invalid_config, _}}]} = elvis_config:from_file(ConfigPath),
     ok.
+
+rock_with_deprecated_rules(_Config) ->
+    ConfigPath = "../../../../test/examples/deprecated_rules.elvis.config",
+    ElvisConfig = elvis_config:from_file(ConfigPath),
+    %% Should not crash; deprecated rules are skipped with a warning
+    ok = elvis_core:rock(ElvisConfig).
 
 %%%%%%%%%%%%%%%
 %%% Utils

--- a/test/examples/deprecated_rules.elvis.config
+++ b/test/examples/deprecated_rules.elvis.config
@@ -1,0 +1,21 @@
+[
+    {elvis, [
+        {config, [
+            #{
+                dirs => ["../../../../_build/test/lib/elvis_core/test/examples"],
+                filter => "*.erl",
+                rules =>
+                    [
+                        {elvis_style, macro_module_names},
+                        {elvis_style, god_modules},
+                        {elvis_style, nesting_level},
+                        {elvis_style, invalid_dynamic_call},
+                        {elvis_style, used_ignored_variable},
+                        {elvis_style, macro_names},
+                        {elvis_style, consistent_generic_type},
+                        {elvis_style, consistent_variable_casing}
+                    ]
+            }
+        ]}
+    ]}
+].


### PR DESCRIPTION
Closes #482.

When users reference a deprecated or renamed rule in their elvis.config (e.g. macro_module_names, god_modules, nesting_level), elvis would crash with {invalid_config, ...} because the rule function no longer exists.

Now these rules produce a warning message and are silently skipped.

- Add elvis_deprecated_rules module as a registry for all known deprecated rules (e.g. macro_module_names) and renamed rules (e.g. god_modules -> no_god_modules) from PR #505
- Restructure elvis_rule:is_valid_from_tuple/1 to check function_exported before calling from_tuple, avoiding a badarg crash when creating fun references for non-existent functions
- Handle the new {deprecated, Msg} return value in elvis_config validation (all_rules_are_valid, all_custom_rulesets_have_valid_rules) to print a warning and skip rather than accumulate an error
- Filter deprecated rules in merge_rules/2 and rules/1 so they don't reach from_tuple/new during rule execution