### PR TITLE
Extend `ignore` documentation around using (string) filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,12 @@ You can also `ignore` modules at a _check level_ or at a _ruleset (group of chec
 - at a _check level_, you set the `ignore` option in the rule you want to ignore, e.g.:
 
 ```erlang
-{elvis_style, no_debug_call, #{ ignore => [elvis, elvis_utils] }}
+{elvis_style, no_debug_call, #{ ignore => [elvis, elvis_utils, "not_a_module.hrl"] }}
 ```
 
-(we are telling `elvis` to **ignore** the `elvis` and `elvis_utils` modules when executing
-the `no_debug_call` check.
+(we are telling `elvis` to **ignore** the `elvis` and `elvis_utils` modules and the
+`not_a_module.hrl` file (as a string, since it's not a module) when executing the
+`no_debug_call` check.
 
 - at a _ruleset (group of checks) level_, you set the `ignore` option for the group you want to
 ignore, e.g.:
@@ -204,11 +205,12 @@ ignore, e.g.:
 #{ dirs => ["src"]
  , filter => "*.erl"
  , ruleset => erl_files
- , ignore => [module1, module4]
+ , ignore => [module1, module4, "path/to/header_file.hrl"]
 }.
 ```
 
-With this configuration, none of the checks for `erl_files` is applied to `module1` or `module4`.
+With this configuration, none of the checks for `erl_files` is applied to `module1`, `module4`,
+or `path/to/header_file.hrl`.
 
 ### Formatting
 

--- a/RULES.md
+++ b/RULES.md
@@ -190,6 +190,7 @@ It suffices to add the `ignore` list to your rules, as per the example below.
 
 You can add the exceptions using the following syntax:
 
+- file name: `ignore => ["path/to/header.hrl"]`
 - whole module: `ignore => [mod]`
 - functions (by name only): `ignore => [{mod, fun}]` (available for **`elvis_style`-based rules
 only**)


### PR DESCRIPTION
# Description

Extend docs for ignoring files by path.

Closes #574.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
