### PR TITLE
fix consistent_ok_error_spec to ignore behaviours

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1194,7 +1194,7 @@ known_behaviours() ->
     ].
 
 callbacks_of_behaviour(Behaviour) ->
-    {module, Behaviour} ?= code:ensure_loaded(Behaviour),
+    {module, Behaviour} = code:ensure_loaded(Behaviour),
     erlang:apply(Behaviour, behaviour_info, [callbacks]).
 
 is_behaviour_callback_spec(SpecNode, BehaviourCallbacks) ->

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1170,7 +1170,7 @@ behaviour_callbacks_from_node(BehaviourNode) ->
     maybe
         {module, Behaviour} ?= code:ensure_loaded(Behaviour),
         true ?= erlang:function_exported(Behaviour, behaviour_info, 1),
-        Callbacks = catch Behaviour:behaviour_info(callbacks),
+        Callbacks = catch apply(Behaviour, behaviour_info, [callbacks]),
         true ?= is_list(Callbacks),
         Callbacks
     else

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1130,10 +1130,17 @@ is_opaque_state(TypeAttrOrOpaqueNode) ->
 
 -spec consistent_ok_error_spec(elvis_rule:t(), elvis_config:t()) -> [elvis_result:item()].
 consistent_ok_error_spec(Rule, ElvisConfig) ->
+    Root = elvis_code:root(Rule, ElvisConfig),
+    BehaviourCallbacks = behaviour_callbacks(Root),
+
     {nodes, SpecsWithJustOkResult} = elvis_code:find(#{
         of_types => [spec],
-        inside => elvis_code:root(Rule, ElvisConfig),
-        filtered_by => fun spec_has_just_ok_result/1
+        inside => Root,
+        filtered_by =>
+            fun(SpecNode) ->
+                spec_has_just_ok_result(SpecNode) andalso
+                    not is_behaviour_callback_spec(SpecNode, BehaviourCallbacks)
+            end
     }),
 
     [
@@ -1145,6 +1152,34 @@ consistent_ok_error_spec(Rule, ElvisConfig) ->
         )
      || SpecWithJustOkResult <- SpecsWithJustOkResult
     ].
+
+behaviour_callbacks(Root) ->
+    {nodes, BehaviourNodes} = elvis_code:find(#{
+        of_types => [behaviour, behavior],
+        inside => Root
+    }),
+    sets:from_list(
+        lists:flatmap(fun behaviour_callbacks_from_node/1, BehaviourNodes),
+        [{version, 2}]
+    ).
+
+behaviour_callbacks_from_node(BehaviourNode) ->
+    Behaviour = ktn_code:attr(value, BehaviourNode),
+    maybe
+        {module, Behaviour} ?= code:ensure_loaded(Behaviour),
+        true ?= erlang:function_exported(Behaviour, behaviour_info, 1),
+        Callbacks = catch Behaviour:behaviour_info(callbacks),
+        true ?= is_list(Callbacks),
+        Callbacks
+    else
+        _ -> []
+    end.
+
+is_behaviour_callback_spec(SpecNode, BehaviourCallbacks) ->
+    sets:is_element(
+        {ktn_code:attr(name, SpecNode), ktn_code:attr(arity, SpecNode)},
+        BehaviourCallbacks
+    ).
 
 spec_has_just_ok_result(SpecNode) ->
     lists:all(

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1194,15 +1194,8 @@ known_behaviours() ->
     ].
 
 callbacks_of_behaviour(Behaviour) ->
-    maybe
-        {module, Behaviour} ?= code:ensure_loaded(Behaviour),
-        true ?= erlang:function_exported(Behaviour, behaviour_info, 1),
-        Callbacks = apply(Behaviour, behaviour_info, [callbacks]),
-        true ?= is_list(Callbacks),
-        Callbacks
-    else
-        _ -> []
-    end.
+    {module, Behaviour} ?= code:ensure_loaded(Behaviour),
+    erlang:apply(Behaviour, behaviour_info, [callbacks]).
 
 is_behaviour_callback_spec(SpecNode, BehaviourCallbacks) ->
     sets:is_element(

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1,7 +1,5 @@
 -module(elvis_style).
 
--feature(maybe_expr, enable).
-
 -elvis([
     {elvis_style, abc_size, #{ignore => [{elvis_style, default, 1}]}},
     {elvis_style, code_complexity, #{ignore => [{elvis_style, default, 1}]}}

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1170,7 +1170,7 @@ behaviour_callbacks_from_node(BehaviourNode) ->
     maybe
         {module, Behaviour} ?= code:ensure_loaded(Behaviour),
         true ?= erlang:function_exported(Behaviour, behaviour_info, 1),
-        Callbacks = catch apply(Behaviour, behaviour_info, [callbacks]),
+        Callbacks = apply(Behaviour, behaviour_info, [callbacks]),
         true ?= is_list(Callbacks),
         Callbacks
     else

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1,5 +1,7 @@
 -module(elvis_style).
 
+-feature(maybe_expr, enable).
+
 -elvis([
     {elvis_style, abc_size, #{ignore => [{elvis_style, default, 1}]}},
     {elvis_style, code_complexity, #{ignore => [{elvis_style, default, 1}]}}

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -86,22 +86,6 @@
 % The whole file is considered to have either callback functions or rules.
 -ignore_xref(elvis_style).
 
--define(KNOWN_BEHAVIOURS, [
-    application,
-    gen_event,
-    gen_server,
-    ssh_channel,
-    ssh_client_channel,
-    ssh_client_key_api,
-    ssh_server_channel,
-    ssh_server_key_api,
-    ssl_crl_cache_api,
-    ssl_session_cache_api,
-    supervisor,
-    supervisor_bridge,
-    tftp
-]).
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Default values
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1182,7 +1166,7 @@ behaviour_callbacks(Root) ->
     Behaviours = lists:map(
         fun(BehaviourNode) -> ktn_code:attr(value, BehaviourNode) end, BehaviourNodes
     ),
-    case lists:all(fun(Behaviour) -> lists:member(Behaviour, ?KNOWN_BEHAVIOURS) end, Behaviours) of
+    case lists:all(fun(Behaviour) -> lists:member(Behaviour, known_behaviours()) end, Behaviours) of
         true ->
             sets:from_list(
                 lists:flatmap(fun callbacks_of_behaviour/1, Behaviours),
@@ -1191,6 +1175,23 @@ behaviour_callbacks(Root) ->
         false ->
             disabled
     end.
+
+known_behaviours() ->
+    [
+        application,
+        gen_event,
+        gen_server,
+        ssh_channel,
+        ssh_client_channel,
+        ssh_client_key_api,
+        ssh_server_channel,
+        ssh_server_key_api,
+        ssl_crl_cache_api,
+        ssl_session_cache_api,
+        supervisor,
+        supervisor_bridge,
+        tftp
+    ].
 
 callbacks_of_behaviour(Behaviour) ->
     maybe

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -86,6 +86,22 @@
 % The whole file is considered to have either callback functions or rules.
 -ignore_xref(elvis_style).
 
+-define(KNOWN_BEHAVIOURS, [
+    application,
+    gen_event,
+    gen_server,
+    ssh_channel,
+    ssh_client_channel,
+    ssh_client_key_api,
+    ssh_server_channel,
+    ssh_server_key_api,
+    ssl_crl_cache_api,
+    ssl_session_cache_api,
+    supervisor,
+    supervisor_bridge,
+    tftp
+]).
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Default values
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1133,40 +1149,50 @@ is_opaque_state(TypeAttrOrOpaqueNode) ->
 -spec consistent_ok_error_spec(elvis_rule:t(), elvis_config:t()) -> [elvis_result:item()].
 consistent_ok_error_spec(Rule, ElvisConfig) ->
     Root = elvis_code:root(Rule, ElvisConfig),
-    BehaviourCallbacks = behaviour_callbacks(Root),
+    case behaviour_callbacks(Root) of
+        disabled ->
+            [];
+        BehaviourCallbacks ->
+            {nodes, SpecsWithJustOkResult} = elvis_code:find(#{
+                of_types => [spec],
+                inside => Root,
+                filtered_by =>
+                    fun(SpecNode) ->
+                        spec_has_just_ok_result(SpecNode) andalso
+                            not is_behaviour_callback_spec(SpecNode, BehaviourCallbacks)
+                    end
+            }),
 
-    {nodes, SpecsWithJustOkResult} = elvis_code:find(#{
-        of_types => [spec],
-        inside => Root,
-        filtered_by =>
-            fun(SpecNode) ->
-                spec_has_just_ok_result(SpecNode) andalso
-                    not is_behaviour_callback_spec(SpecNode, BehaviourCallbacks)
-            end
-    }),
-
-    [
-        elvis_result:new_item(
-            "function ~p unnecessarily wraps its results in a tuple; prefer not "
-            "wrapping them or adding alternative/error results to the spec",
-            [ktn_code:attr(name, SpecWithJustOkResult)],
-            #{node => SpecWithJustOkResult}
-        )
-     || SpecWithJustOkResult <- SpecsWithJustOkResult
-    ].
+            [
+                elvis_result:new_item(
+                    "function ~p unnecessarily wraps its results in a tuple; prefer not "
+                    "wrapping them or adding alternative/error results to the spec",
+                    [ktn_code:attr(name, SpecWithJustOkResult)],
+                    #{node => SpecWithJustOkResult}
+                )
+             || SpecWithJustOkResult <- SpecsWithJustOkResult
+            ]
+    end.
 
 behaviour_callbacks(Root) ->
     {nodes, BehaviourNodes} = elvis_code:find(#{
         of_types => [behaviour, behavior],
         inside => Root
     }),
-    sets:from_list(
-        lists:flatmap(fun behaviour_callbacks_from_node/1, BehaviourNodes),
-        [{version, 2}]
-    ).
+    Behaviours = lists:map(
+        fun(BehaviourNode) -> ktn_code:attr(value, BehaviourNode) end, BehaviourNodes
+    ),
+    case lists:all(fun(Behaviour) -> lists:member(Behaviour, ?KNOWN_BEHAVIOURS) end, Behaviours) of
+        true ->
+            sets:from_list(
+                lists:flatmap(fun callbacks_of_behaviour/1, Behaviours),
+                [{version, 2}]
+            );
+        false ->
+            disabled
+    end.
 
-behaviour_callbacks_from_node(BehaviourNode) ->
-    Behaviour = ktn_code:attr(value, BehaviourNode),
+callbacks_of_behaviour(Behaviour) ->
     maybe
         {module, Behaviour} ?= code:ensure_loaded(Behaviour),
         true ?= erlang:function_exported(Behaviour, behaviour_info, 1),

--- a/test/examples/fail_consistent_ok_error_spec.erl
+++ b/test/examples/fail_consistent_ok_error_spec.erl
@@ -1,6 +1,19 @@
 -module(fail_consistent_ok_error_spec).
 
--export([arity_two/0, arity_three/1, multi/1]).
+-behaviour(gen_server).
+
+-export([init/1, handle_call/3, handle_cast/2, arity_two/0, arity_three/1, multi/1]).
+
+-type state() :: #{}.
+
+-spec init(noargs) -> {ok, state()}.
+init(noargs) -> {ok, #{}}.
+
+-spec handle_call(term(), term(), state()) -> {noreply, state()}.
+handle_call(_Request, _From, State) -> {noreply, State}.
+
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(_Request, State) -> {noreply, State}.
 
 -spec arity_two() -> {ok, number()}.
 arity_two() -> {ok, rand:uniform()}.

--- a/test/examples/pass_consistent_ok_error_spec.erl
+++ b/test/examples/pass_consistent_ok_error_spec.erl
@@ -1,8 +1,20 @@
 -module(pass_consistent_ok_error_spec).
 
 -behaviour(supervisor).
+-behaviour(pass_invalid_dynamic_call_callback).
 
--export([init/1, arity_two/0, arity_three/1, list/0, ok/0, map/0, multi/1]).
+-export([
+         init/1,
+         arity_two/0,
+         arity_three/1,
+         disabled_by_dynamic_behaviour/0,
+         call/0,
+         macro_function_name_call/0,
+         list/0,
+         ok/0,
+         map/0,
+         multi/1
+        ]).
 
 -spec init(term()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init(_Args) -> {ok, {#{strategy => one_for_one}, []}}.
@@ -13,6 +25,15 @@ arity_two() -> rand:uniform().
 -spec arity_three(X) -> {ok, X, X} | {error, X}.
 arity_three(X) when X > 0 -> {ok, X, X};
 arity_three(X) -> {error, X}.
+
+-spec disabled_by_dynamic_behaviour() -> {ok, term()}.
+disabled_by_dynamic_behaviour() -> {ok, disabled}.
+
+-spec call() -> {ok, term()}.
+call() -> {ok, callback}.
+
+-spec macro_function_name_call() -> {ok, term()}.
+macro_function_name_call() -> {ok, callback}.
 
 -spec list() -> [ok | number()].
 list() -> [ok].

--- a/test/examples/pass_consistent_ok_error_spec.erl
+++ b/test/examples/pass_consistent_ok_error_spec.erl
@@ -1,6 +1,11 @@
 -module(pass_consistent_ok_error_spec).
 
--export([arity_two/0, arity_three/1, list/0, ok/0, map/0, multi/1]).
+-behaviour(supervisor).
+
+-export([init/1, arity_two/0, arity_three/1, list/0, ok/0, map/0, multi/1]).
+
+-spec init(term()) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init(_Args) -> {ok, {#{strategy => one_for_one}, []}}.
 
 -spec arity_two() -> number().
 arity_two() -> rand:uniform().


### PR DESCRIPTION
# Description

I added a filter to `elvis_code:find` for the behaviour callbacks.

Closes #623;.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
