### PR TITLE
Dedup `find_nodes_all` results with `lists:uniq` instead of a per-node `Seen` map

### DIFF
--- a/src/elvis_code.erl
+++ b/src/elvis_code.erl
@@ -115,8 +115,11 @@ find_nodes_all_ancestors(_Pred, _Node, _Ancestors, Seen) ->
 find_nodes(Pred, Node, content) ->
     find_nodes_content(Pred, Node);
 find_nodes(Pred, Node, all) ->
-    {Results, _Seen} = find_nodes_all(Pred, Node, #{}),
-    Results.
+    %% The AST is a DAG: a node can be reached via both `content` and `node_attrs`
+    %% (see all_children/1), so the walk may yield duplicates. Dedup the (small)
+    %% result list with lists:uniq/1 instead of tracking a `Seen` set keyed by whole
+    %% node maps, which deep-hashes every node (an O(n^2) hotspot).
+    lists:uniq(find_nodes_all(Pred, Node)).
 
 find_nodes_content(Pred, #{content := Content} = Node) ->
     Match = [Node || Pred(Node)],
@@ -126,26 +129,11 @@ find_nodes_content(Pred, Node) when is_map(Node) ->
 find_nodes_content(_Pred, _Node) ->
     [].
 
-find_nodes_all(Pred, Node, Seen) when is_map(Node) ->
-    case Seen of
-        #{Node := _} ->
-            {[], Seen};
-        #{} ->
-            Seen1 = Seen#{Node => true},
-            Match = [Node || Pred(Node)],
-            {ChildResults, Seen2} =
-                lists:foldl(
-                    fun(Child, {A, S}) ->
-                        {R, S1} = find_nodes_all(Pred, Child, S),
-                        {[R | A], S1}
-                    end,
-                    {[], Seen1},
-                    all_children(Node)
-                ),
-            {Match ++ lists:append(lists:reverse(ChildResults)), Seen2}
-    end;
-find_nodes_all(_Pred, _Node, Seen) ->
-    {[], Seen}.
+find_nodes_all(Pred, Node) when is_map(Node) ->
+    Match = [Node || Pred(Node)],
+    Match ++ lists:flatmap(fun(Child) -> find_nodes_all(Pred, Child) end, all_children(Node));
+find_nodes_all(_Pred, _Node) ->
+    [].
 
 all_children(#{content := Content, node_attrs := NodeAttrs}) ->
     Content ++ lists:flatten(maps:values(NodeAttrs));


### PR DESCRIPTION
# Description

`elvis_code:find/1` with `traverse => all` tracked visited nodes in a `Seen` map keyed by the *whole node map*, which contains its subtree, so every node got deep-hashed (O(n²)-ish). Drop the map and dedup the (small) result list with `lists:uniq/1` instead. The AST is acyclic, so the walk still terminates; results are unchanged. `find_nodes_all` drops from ~20% of a large lint to ~2%.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
