### PR TITLE
Only run SAFE on local repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-24.04' }}
         run: rebar3 fmt --check
       - name: SAFE check
-        if: ${{ matrix.os == 'ubuntu-24.04' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' && github.repository == 'inaka/elvis_core' }}
         env:
           SAFE_LICENSE: ${{ secrets.SAFE_LICENSE }}
         run: rebar3 safe analyse


### PR DESCRIPTION
# Description

As seen in #633, #634, and #635... we can't run SAFE for contributions coming from external repositories. They lack the secrets that this repo has.

Closes #&lt;issue&gt;.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
