### PR TITLE
Support OTP 28 -nominal types in style rules

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1746,7 +1746,8 @@ max_record_fields(Rule, ElvisConfig) ->
 max_map_type_keys(Rule, ElvisConfig) ->
     Root = elvis_code:root(Rule, ElvisConfig),
     MaxFields = elvis_rule:option(max_keys, Rule),
-    max_map_type_keys_on_types(Root, MaxFields) ++ max_map_type_keys_on_opaques(Root, MaxFields).
+    max_map_type_keys_on_types(Root, MaxFields) ++
+        max_map_type_keys_on_opaques_and_nominals(Root, MaxFields).
 
 max_map_type_keys_on_types(Root, MaxFields) ->
     {nodes, MapTypeNodes} =
@@ -1786,40 +1787,40 @@ all_type_keys_are_atoms(TypeNodes) ->
         TypeNodes
     ).
 
-max_map_type_keys_on_opaques(Root, MaxFields) ->
-    {nodes, MapOpaqueNodes} =
+max_map_type_keys_on_opaques_and_nominals(Root, MaxFields) ->
+    {nodes, MapNodes} =
         elvis_code:find(#{
-            of_types => [opaque],
+            of_types => [opaque, nominal],
             inside => Root,
-            filtered_by => fun is_map_opaque_with_atom_keys/1
+            filtered_by => fun is_map_opaque_or_nominal_with_atom_keys/1
         }),
 
     [
         elvis_result:new_item(
             "map type ~p has ~p fields, which is higher than the configured limit",
-            [MapOpaqueName, FieldCount],
-            #{node => MapOpaqueNode, limit => MaxFields}
+            [MapName, FieldCount],
+            #{node => MapNode, limit => MaxFields}
         )
-     || MapOpaqueNode <- MapOpaqueNodes,
-        {MapOpaqueName, MapOpaqueTypeAST, _} <- [ktn_code:attr(value, MapOpaqueNode)],
-        FieldCount <- [length(erl_syntax:type_application_arguments(MapOpaqueTypeAST))],
+     || MapNode <- MapNodes,
+        {MapName, MapTypeAST, _} <- [ktn_code:attr(value, MapNode)],
+        FieldCount <- [length(erl_syntax:type_application_arguments(MapTypeAST))],
         FieldCount > MaxFields
     ].
 
-is_map_opaque_with_atom_keys(OpaqueNode) ->
-    {_Name, TypeAST, _Params} = ktn_code:attr(value, OpaqueNode),
+is_map_opaque_or_nominal_with_atom_keys(Node) ->
+    {_Name, TypeAST, _Params} = ktn_code:attr(value, Node),
     erl_syntax:type(TypeAST) =:= map_type andalso
-        all_opaque_keys_are_atoms(erl_syntax:type_application_arguments(TypeAST)).
+        all_opaque_or_nominal_keys_are_atoms(erl_syntax:type_application_arguments(TypeAST)).
 
-all_opaque_keys_are_atoms(OpaqueASTs) ->
-    %% for -opaque t() :: map()., OpaqueASTs =:= any.
-    is_list(OpaqueASTs) andalso
+all_opaque_or_nominal_keys_are_atoms(KeyASTs) ->
+    %% for -opaque/-nominal t() :: map()., KeyASTs =:= any.
+    is_list(KeyASTs) andalso
         lists:all(
-            fun(OpaqueAST) ->
-                [KeyType | _] = erl_syntax:type_application_arguments(OpaqueAST),
+            fun(KeyAST) ->
+                [KeyType | _] = erl_syntax:type_application_arguments(KeyAST),
                 erl_syntax:type(KeyType) =:= atom
             end,
-            OpaqueASTs
+            KeyASTs
         ).
 
 -spec no_call(elvis_rule:t(), elvis_config:t()) -> [elvis_result:item()].

--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1077,7 +1077,7 @@ state_record_and_type(Rule, ElvisConfig) ->
     Root = elvis_code:root(Rule, ElvisConfig),
 
     {nodes, AllNodes} = elvis_code:find(#{
-        of_types => [behaviour, behavior, record_attr, type_attr, opaque],
+        of_types => [behaviour, behavior, record_attr, type_attr, opaque, nominal],
         inside => Root
     }),
     #{behaviours := BehaviourNodes, records := RecordAttrNodes, types := TypeOrOpaqueNodes} =
@@ -1086,13 +1086,14 @@ state_record_and_type(Rule, ElvisConfig) ->
             behavior => behaviours,
             record_attr => records,
             type_attr => types,
-            opaque => types
+            opaque => types,
+            nominal => types
         }),
 
     case is_otp_behaviour(BehaviourNodes) of
         true ->
             HasStateRecord = lists:any(fun is_state_record/1, RecordAttrNodes),
-            HasStateType = lists:any(fun is_type_or_opaque_state/1, TypeOrOpaqueNodes),
+            HasStateType = lists:any(fun is_state_type/1, TypeOrOpaqueNodes),
 
             case {HasStateRecord, HasStateType} of
                 {true, true} ->
@@ -1119,23 +1120,17 @@ state_record_and_type(Rule, ElvisConfig) ->
 is_state_record(RecordAttrNode) ->
     ktn_code:attr(name, RecordAttrNode) =:= state.
 
-is_type_or_opaque_state(TypeAttrOrOpaqueNode) ->
-    case ktn_code:type(TypeAttrOrOpaqueNode) of
+is_state_type(Node) ->
+    case ktn_code:type(Node) of
         type_attr ->
-            is_type_state(TypeAttrOrOpaqueNode);
-        opaque ->
-            is_opaque_state(TypeAttrOrOpaqueNode)
-    end.
-
-is_type_state(TypeAttrOrOpaqueNode) ->
-    ktn_code:attr(name, TypeAttrOrOpaqueNode) =:= state.
-
-is_opaque_state(TypeAttrOrOpaqueNode) ->
-    case ktn_code:attr(value, TypeAttrOrOpaqueNode) of
-        {state, _, _} ->
-            true;
-        _ ->
-            false
+            ktn_code:attr(name, Node) =:= state;
+        Type when Type =:= opaque; Type =:= nominal ->
+            case ktn_code:attr(value, Node) of
+                {state, _, _} ->
+                    true;
+                _ ->
+                    false
+            end
     end.
 
 -spec consistent_ok_error_spec(elvis_rule:t(), elvis_config:t()) -> [elvis_result:item()].

--- a/test/examples/fail_max_map_type_keys_nominal.erl
+++ b/test/examples/fail_max_map_type_keys_nominal.erl
@@ -1,0 +1,20 @@
+-module(fail_max_map_type_keys_nominal).
+
+-if(?OTP_RELEASE >= 28).
+
+-export_type([
+    n2/0,
+    n5/0
+]).
+
+-nominal n2() :: #{one := field, two := fields}.
+
+-nominal n5() :: #{
+    f1 => optional_field,
+    f2 => optional_field,
+    f3 => optional_field,
+    f4 => optional_field,
+    f5 => field
+}.
+
+-endif.

--- a/test/examples/pass_state_record_and_type_nominal.erl
+++ b/test/examples/pass_state_record_and_type_nominal.erl
@@ -1,0 +1,31 @@
+-module(pass_state_record_and_type_nominal).
+
+-if(?OTP_RELEASE >= 28).
+
+-dialyzer(no_behaviours).
+
+-behaviour(gen_server).
+
+-export([
+         init/1,
+         handle_call/3,
+         handle_cast/2
+        ]).
+
+-record(state, {}).
+
+-nominal state() :: #state{}.
+
+-spec init(term()) -> state().
+init(_Args) ->
+    #state{}.
+
+-spec handle_call(term(), term(), state()) -> {noreply, state()}.
+handle_call(_Request, _From, State) ->
+    {noreply, State}.
+
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+-endif.

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -128,7 +128,8 @@
 -if(?OTP_RELEASE >= 28).
 -export([
     verify_operator_spaces_otp28/1,
-    verify_state_record_and_type_otp28/1
+    verify_state_record_and_type_otp28/1,
+    verify_max_map_type_keys_otp28/1
 ]).
 -endif.
 %% Non-rule
@@ -2010,6 +2011,30 @@ verify_max_map_type_keys(Config) ->
         ),
 
     {comment, ""}.
+
+-if(?OTP_RELEASE >= 28).
+verify_max_map_type_keys_otp28(Config) ->
+    Ext = proplists:get_value(test_file_ext, Config, "erl"),
+
+    PathFail = "fail_max_map_type_keys_nominal." ++ Ext,
+
+    [_, _] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config, elvis_style, max_map_type_keys, #{max_keys => 1}, PathFail
+        ),
+
+    [_] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config, elvis_style, max_map_type_keys, #{max_keys => 2}, PathFail
+        ),
+
+    [] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config, elvis_style, max_map_type_keys, #{max_keys => 5}, PathFail
+        ),
+
+    {comment, ""}.
+-endif.
 
 verify_max_function_clause_length(Config) ->
     Ext = proplists:get_value(test_file_ext, Config, "erl"),

--- a/test/style_SUITE.erl
+++ b/test/style_SUITE.erl
@@ -127,7 +127,8 @@
 
 -if(?OTP_RELEASE >= 28).
 -export([
-    verify_operator_spaces_otp28/1
+    verify_operator_spaces_otp28/1,
+    verify_state_record_and_type_otp28/1
 ]).
 -endif.
 %% Non-rule
@@ -1032,6 +1033,21 @@ verify_state_record_and_type(Config) ->
             #{},
             PathPassGenStateMState
         ).
+
+-if(?OTP_RELEASE >= 28).
+verify_state_record_and_type_otp28(Config) ->
+    Ext = proplists:get_value(test_file_ext, Config, "erl"),
+
+    PathPassWithNominal = "pass_state_record_and_type_nominal." ++ Ext,
+    [] =
+        elvis_test_utils:elvis_core_apply_rule(
+            Config,
+            elvis_style,
+            state_record_and_type,
+            #{},
+            PathPassWithNominal
+        ).
+-endif.
 
 verify_state_record_and_type_plus_export_used_types(Config) ->
     Ext = proplists:get_value(test_file_ext, Config, "erl"),


### PR DESCRIPTION
# Description

`-nominal` ([EEP-69](https://www.erlang.org/eeps/eep-0069)) is OTP 28's third type-defining attribute alongside `-type` and `-opaque`. Two style rules special-cased `-opaque` but not `-nominal`; this teaches both to treat them alike.

- **`state_record_and_type`**: now recognizes a `state()` type declared with `-nominal`, so it no longer false-flags valid OTP 28 modules as "missing a `state()` type"
- **`max_map_type_keys`**: now also checks `-nominal` map types, mirroring its existing `-opaque` handling

All OTP-28-only syntax in the test examples and suite is gated behind `-if(?OTP_RELEASE >= 28)`, so the build/tests stay green on OTP 26 and 27.

Relates to #460. This only makes existing rules nominal-aware (parity with `-type`/`-opaque`).

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
