### PR TITLE
Support OTP 29 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        otp_vsn: ['26', '27', '28']
+        otp_vsn: ['26', '27', '28', '29']
         rebar3_vsn: ['3.25']
         os: [ubuntu-24.04, windows-2022]
     steps:

--- a/rebar.config
+++ b/rebar.config
@@ -50,6 +50,14 @@
 
 {deps, [{katana_code, "~> 2.4.3"}]}.
 
+%% erlware_commons (pulled in by the rebar_safe plugin) builds with its own
+%% `warnings_as_errors` and does not yet compile under OTP 29's new warnings.
+%% Drop `warnings_as_errors` for that dependency so plugin loading works; its
+%% warnings stay visible but no longer break the build.
+{overrides, [
+    {del, erlware_commons, [{erl_opts, [warnings_as_errors]}]}
+]}.
+
 {project_plugins, [
     {rebar3_hank, "~> 1.6.1"},
     {rebar3_hex, "~> 7.1.0"},

--- a/rebar.config
+++ b/rebar.config
@@ -15,7 +15,13 @@
     {test, [
         {extra_src_dirs, ["test/examples"]},
         {deps, [{meck, "1.1.1"}]},
-        {erl_opts, [nowarn_missing_spec, nowarn_export_all]},
+        {erl_opts, [
+            nowarn_missing_spec,
+            nowarn_export_all,
+            nowarn_deprecated_catch,
+            nowarn_export_vars,
+            nowarn_match_alias_pats
+        ]},
         {dialyzer, [{warnings, [no_return, error_handling]}, {plt_extra_apps, [common_test]}]},
         {ct_opts, [{sys_config, ["./config/test.config"]}, {verbose, true}]},
         {cover_enabled, true},


### PR DESCRIPTION
# Description

Adds OTP 29 to the CI matrix.

OTP 29 adds new compiler warnings that some `test/examples` fixtures trigger on purpose, so they're suppressed in the test profile (`nowarn_deprecated_catch`, `nowarn_export_vars`, `nowarn_match_alias_pats`); `src` is unaffected.

Follow-up: maybe open a tracking issue per warning to fix the fixtures rather than suppress indefinitely.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
