### PR TITLE
fix cutom rulesets

### DIFF
--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -135,24 +135,65 @@ default(Key) ->
             Value
     end.
 
+for(config) ->
+    maybe
+        {ok, {Source, AppConfig}} ?= default_app_config(),
+        case Source of
+            {file, File} ->
+                fetch_elvis_config_from(AppConfig, File);
+            fallback ->
+                from_static(config, {app, AppConfig})
+        end
+    else
+        {error, _} = Error -> Error
+    end;
 for(Key) ->
     maybe
-        AppDefault = default_for(app),
-        {ok, ElvisConfig} ?= consult_elvis_config("elvis.config"),
-        {ok, AppConfig} ?=
-            case ElvisConfig of
-                AppDefault ->
-                    % This might happen whether we fail to parse the file or it actually is []
-                    _ = elvis_utils:debug(
-                        "elvis.config is unusable; falling back to rebar.config", []
-                    ),
-                    consult_rebar_config("rebar.config");
-                AppConfig0 ->
-                    {ok, AppConfig0}
-            end,
+        {ok, {_Source, AppConfig}} ?= default_app_config(),
         from_static(Key, {app, AppConfig})
     else
         {error, _} = Error -> Error
+    end.
+
+default_app_config() ->
+    maybe
+        AppDefault = default_for(app),
+        {ok, ElvisConfig} ?= consult_elvis_config("elvis.config"),
+        case ElvisConfig of
+            AppDefault ->
+                % This might happen whether we fail to parse the file or it actually is []
+                _ = elvis_utils:debug(
+                    "elvis.config is unusable; falling back to rebar.config", []
+                ),
+                default_app_config_from_rebar("rebar.config");
+            AppConfig ->
+                {ok, {{file, "elvis.config"}, AppConfig}}
+        end
+    else
+        {error, _} = Error -> Error
+    end.
+
+default_app_config_from_rebar(File) ->
+    % safe-ignore file:consult/1
+    case file:consult(File) of
+        {ok, RebarConfig} when is_list(RebarConfig) ->
+            _ = elvis_utils:debug("rebar.config is consultable; using it", []),
+            case proplists:get_value(elvis, RebarConfig, undefined) of
+                undefined ->
+                    {ok, {fallback, default(elvis)}};
+                [] ->
+                    {ok, {fallback, default_for(elvis)}};
+                AppConfig ->
+                    {ok, {{file, File}, AppConfig}}
+            end;
+        {error, {Line, Mod, Term}} ->
+            {error,
+                lists:flatten(
+                    io_lib:format("rebar.config is unconsultable: ~p, ~p, ~p", [Line, Mod, Term])
+                )};
+        _ ->
+            _ = elvis_utils:debug("rebar.config is unconsultable", []),
+            {ok, {fallback, default_for('rebar.config')}}
     end.
 
 consult_elvis_config(File) ->

--- a/src/elvis_core.erl
+++ b/src/elvis_core.erl
@@ -60,34 +60,37 @@ rock(FileOrConfig) ->
     FileOrConfig :: {config_file, default | string()} | {config, [elvis_config:t()]},
     Files :: {files, undefined | [string()]}.
 rock(FileOrConfig, {files, Files}) ->
-    maybe
-        {File, {ok, ElvisConfig0}} ?=
-            case FileOrConfig of
-                {config_file, default} ->
-                    {"elvis.config/rebar.config", config()};
-                {config_file, ConfigFilePath} ->
-                    {ConfigFilePath, from_file(ConfigFilePath)};
-                {config, Config} ->
-                    {undefined, {ok, Config}}
-            end,
-        {validate, ok} ?= {validate, elvis_config:validate(ElvisConfig0, File)},
-        ElvisConfig1 =
-            case Files of
-                undefined ->
-                    ElvisConfig0;
-                _ ->
-                    Paths = lists:map(fun file_to_path/1, Files),
-                    elvis_config:resolve_files(ElvisConfig0, Paths)
-            end,
-        _ = elvis_ruleset:drop_custom(),
-        Results = lists:map(fun do_parallel_rock/1, ElvisConfig1),
-        ok ?= lists:foldl(fun combine_results/2, ok, Results)
-    else
-        {_, {error, Message}} ->
-            _ = elvis_utils:error(Message, []),
-            {errors, [Message]};
-        {error, Term} ->
-            {errors_or_warnings(), Term}
+    try
+        maybe
+            {File, {ok, ElvisConfig0}} ?=
+                case FileOrConfig of
+                    {config_file, default} ->
+                        {"elvis.config/rebar.config", config()};
+                    {config_file, ConfigFilePath} ->
+                        {ConfigFilePath, from_file(ConfigFilePath)};
+                    {config, Config} ->
+                        {undefined, {ok, Config}}
+                end,
+            {validate, ok} ?= {validate, elvis_config:validate(ElvisConfig0, File)},
+            ElvisConfig1 =
+                case Files of
+                    undefined ->
+                        ElvisConfig0;
+                    _ ->
+                        Paths = lists:map(fun file_to_path/1, Files),
+                        elvis_config:resolve_files(ElvisConfig0, Paths)
+                end,
+            Results = lists:map(fun do_parallel_rock/1, ElvisConfig1),
+            ok ?= lists:foldl(fun combine_results/2, ok, Results)
+        else
+            {_, {error, Message}} ->
+                _ = elvis_utils:error(Message, []),
+                {errors, [Message]};
+            {error, Term} ->
+                {errors_or_warnings(), Term}
+        end
+    after
+        _ = elvis_ruleset:drop_custom()
     end.
 
 config() ->

--- a/test/elvis_SUITE.erl
+++ b/test/elvis_SUITE.erl
@@ -19,6 +19,7 @@
     rock_with_glob_dirs_not_matching/1,
     rock_with_umbrella_apps/1,
     custom_ruleset/1,
+    rock_with_default_elvis_config_custom_ruleset/1,
     hrl_ruleset/1,
     find_file_and_check_src/1,
     find_file_with_ignore/1,
@@ -319,6 +320,47 @@ custom_ruleset(_Config) ->
         ConfigPathMissing
     ),
     ok.
+
+rock_with_default_elvis_config_custom_ruleset(_Config) ->
+    {ok, OriginalCwd} = file:get_cwd(),
+    TmpDir =
+        case os:getenv("TMPDIR") of
+            false -> "/tmp";
+            Dir -> Dir
+        end,
+    WorkDir = filename:join(
+        TmpDir,
+        "elvis_core_custom_ruleset_default_config_test_" ++
+            integer_to_list(erlang:unique_integer([positive]))
+    ),
+    ok = filelib:ensure_dir(filename:join(WorkDir, "dummy")),
+    ConfigFile = filename:join(WorkDir, "elvis.config"),
+    FileWithTabs = filename:absname(
+        "../../../../_build/test/lib/elvis_core/test/examples/fail_no_tabs.erl"
+    ),
+    Config =
+        io_lib:format(
+            "[~n"
+            "    {rulesets, #{custom_tabs => [{elvis_text_style, no_tabs}]}},~n"
+            "    {config, [#{files => [~p], ruleset => custom_tabs}]}~n"
+            "].~n",
+            [FileWithTabs]
+        ),
+    ok = file:write_file(ConfigFile, Config),
+    try
+        ok = file:set_cwd(WorkDir),
+        {errors, [
+            #{
+                file := FileWithTabs,
+                rules := [#{name := no_tabs}]
+            }
+        ]} = elvis_core:rock({config_file, default})
+    after
+        ok = file:set_cwd(OriginalCwd),
+        _ = file:delete(ConfigFile),
+        _ = file:del_dir(WorkDir),
+        _ = elvis_ruleset:drop_custom()
+    end.
 
 hrl_ruleset(_Config) ->
     ConfigPath = "../../../../config/elvis-test-hrl-files.config",


### PR DESCRIPTION
# Description

Previously, custom rulesets worked when loading a config explicitly with `elvis_config:from_file/1`, but not when running through `elvis_core:rock({config_file, default})`. In that path, Elvis read the config but skipped the app-level validation step that registers `{rulesets, ...}`, so custom rulesets were later rejected as unknown or unavailable during rule execution.

## Changes

- Route discovered `elvis.config` and non-empty `{elvis, [...]}` entries from `rebar.config` through the same validation/loading path used by explicit config files.
- Preserve fallback behavior when no usable Elvis config file exists.
- Keep custom rulesets available during `rock/1` execution and clear them afterward to avoid leaking state between runs.
- Add a regression test proving a custom ruleset from default `elvis.config` is executed.

Closes #632 .

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
