### PR TITLE
fix no files found causes an error

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -143,8 +143,8 @@ subdirs).
 , #{ files => [".gitignore"], ruleset => gitignore }
 ```
 
-Allowed config keys per rule group are now: `files`, `ignore`, `ruleset`, `rules`. At least one glob
-in `files` must match at least one file.
+Allowed config keys per rule group are now: `files`, `ignore`, `allow_no_files`, `ruleset`, `rules`.
+At least one glob in `files` must match at least one file unless `allow_no_files => true` is set.
 
 ### Rule renames
 
@@ -187,9 +187,10 @@ Referenced removed rules are skipped with a warning.
 
 ### Stricter configuration validation
 
-Configuration is validated more strictly: only the keys `files`, `ignore`, `ruleset`, and `rules` are
-allowed per rule group; unknown keys cause validation to fail. Non‑existing rules or rulesets also
-fail validation (renamed/removed rules are handled as above and do not fail validation).
+Configuration is validated more strictly: only the keys `files`, `ignore`, `allow_no_files`,
+`ruleset`, and `rules` are allowed per rule group; unknown keys cause validation to fail.
+Non‑existing rules or rulesets also fail validation (renamed/removed rules are handled as above and
+do not fail validation).
 
 ### Parallelism default
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ documentation was updated.
 The `files` key is a list of glob patterns that tell `elvis_core` which files to analyse. Each
 pattern uses [`filelib:wildcard/1`](https://erlang.org/doc/man/filelib.html#wildcard-1), so you can
 use patterns like `"src/*.erl"` or `"apps/**/src/*.erl"`. Matching files are run through the
-pre-defined rules in the specified `ruleset`.
+pre-defined rules in the specified `ruleset`. By default, at least one glob must match a file; set
+`allow_no_files => true` on a config section to allow shared optional sections, such as header-file
+checks, to match no files.
 
 If you want to override the [pre-defined rules](#pre-defined-rules), for a given ruleset, you need
 to specify them in a `rules` key which is a list of items with the following structure

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ documentation was updated.
 The `files` key is a list of glob patterns that tell `elvis_core` which files to analyse. Each
 pattern uses [`filelib:wildcard/1`](https://erlang.org/doc/man/filelib.html#wildcard-1), so you can
 use patterns like `"src/*.erl"` or `"apps/**/src/*.erl"`. Matching files are run through the
-pre-defined rules in the specified `ruleset`. By default, at least one glob must match a file; set
-`allow_no_files => true` on a config section to allow shared optional sections, such as header-file
-checks, to match no files.
+pre-defined rules in the specified `ruleset`. By default, at least one glob must match a file.
+To allow a config section to match no files - which is useful for shared optional sections like
+header-file checks - set `allow_no_files => true`.
 
 If you want to override the [pre-defined rules](#pre-defined-rules), for a given ruleset, you need
 to specify them in a `rules` key which is a list of items with the following structure

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -567,10 +567,13 @@ is_one_of(What, Value, Possibilities, File) ->
                 ]}}
     end.
 
-is_boolean(_What, Value, _File) when is_boolean(Value) ->
-    ok;
-is_boolean(What, _Value, File) ->
-    {error, {"in file '~s', key '~s' is expected to be a boolean.", [File, What]}}.
+is_boolean(What, Value, File) ->
+    case is_boolean_opt(What, Value) of
+        ok ->
+            ok;
+        {error, _} ->
+            {error, {"in file '~s', key '~s' is expected to be a boolean.", [File, What]}}
+    end.
 
 is_pos_integer(_What, Value, _File) when is_integer(Value) andalso Value > 0 ->
     ok;
@@ -719,7 +722,7 @@ config_is_valid(CustomRulesetNames, Config) ->
         ok ?= map_keys_are_in(Config, [files, ignore, allow_no_files, ruleset, rules]),
         {ok, FileGlobs} ?= get_config_opt(files, Config, true),
         {ok, AllowNoFiles} ?= get_config_opt(allow_no_files, Config, false),
-        ok ?= is_config_boolean(allow_no_files, AllowNoFiles),
+        ok ?= is_boolean_opt(allow_no_files, AllowNoFiles),
         ok ?= all_files_globs_are_valid(FileGlobs, AllowNoFiles),
         {ok, Ignore} ?= get_config_opt(ignore, Config, false),
         ok ?= is_list_of_ignorables(ignore, Ignore),
@@ -771,9 +774,9 @@ all_files_globs_are_valid(FileGlobs, AllowNoFiles) ->
             {error, "'files' is expected to be a non-empty list of non-empty strings."}
     end.
 
-is_config_boolean(_What, Value) when is_boolean(Value) ->
+is_boolean_opt(_What, Value) when is_boolean(Value) ->
     ok;
-is_config_boolean(What, _Value) ->
+is_boolean_opt(What, _Value) ->
     {error, io_lib:format("'~s' is expected to be a boolean.", [What])}.
 
 is_list_of_ignorables(What, List) when not is_list(List) ->

--- a/src/elvis_config.erl
+++ b/src/elvis_config.erl
@@ -28,7 +28,8 @@
         ruleset := atom(),
         rules => [tuple()],
         resolved_files => dynamic(),
-        ignore => [string()]
+        ignore => [string()],
+        allow_no_files => boolean()
     }.
 -export_type([t/0]).
 
@@ -280,6 +281,8 @@ default_for([config, files]) ->
     [];
 default_for([config, ignore]) ->
     [];
+default_for([config, allow_no_files]) ->
+    false;
 default_for([config, ruleset]) ->
     undefined;
 default_for([config, rules]) ->
@@ -713,9 +716,11 @@ get_config_opt(OptName, Config, true = _Compulsory) ->
 
 config_is_valid(CustomRulesetNames, Config) ->
     maybe
-        ok ?= map_keys_are_in(Config, [files, ignore, ruleset, rules]),
+        ok ?= map_keys_are_in(Config, [files, ignore, allow_no_files, ruleset, rules]),
         {ok, FileGlobs} ?= get_config_opt(files, Config, true),
-        ok ?= all_files_globs_are_valid(FileGlobs),
+        {ok, AllowNoFiles} ?= get_config_opt(allow_no_files, Config, false),
+        ok ?= is_config_boolean(allow_no_files, AllowNoFiles),
+        ok ?= all_files_globs_are_valid(FileGlobs, AllowNoFiles),
         {ok, Ignore} ?= get_config_opt(ignore, Config, false),
         ok ?= is_list_of_ignorables(ignore, Ignore),
         {ok, Ruleset} ?= get_config_opt(ruleset, Config, false),
@@ -744,13 +749,17 @@ map_keys_are_in(Map, Keys) ->
                 ])}
     end.
 
-all_files_globs_are_valid(FileGlobs) when not is_list(FileGlobs) orelse FileGlobs =:= [] ->
+all_files_globs_are_valid(FileGlobs, _AllowNoFiles) when
+    not is_list(FileGlobs) orelse FileGlobs =:= []
+->
     {error, "'files' is expected to be a non-empty list."};
-all_files_globs_are_valid(FileGlobs) ->
+all_files_globs_are_valid(FileGlobs, AllowNoFiles) ->
     case lists:all(fun(G) -> is_list(G) andalso G =/= [] end, FileGlobs) of
         true ->
             case lists:any(fun(G) -> filelib:wildcard(G) =/= [] end, FileGlobs) of
                 true ->
+                    ok;
+                false when AllowNoFiles ->
                     ok;
                 false ->
                     {error,
@@ -761,6 +770,11 @@ all_files_globs_are_valid(FileGlobs) ->
         false ->
             {error, "'files' is expected to be a non-empty list of non-empty strings."}
     end.
+
+is_config_boolean(_What, Value) when is_boolean(Value) ->
+    ok;
+is_config_boolean(What, _Value) ->
+    {error, io_lib:format("'~s' is expected to be a boolean.", [What])}.
 
 is_list_of_ignorables(What, List) when not is_list(List) ->
     {error, io_lib:format("'~s' is expected to be a list.", [What])};

--- a/test/elvis_config_SUITE.erl
+++ b/test/elvis_config_SUITE.erl
@@ -11,6 +11,7 @@
 -export([rock_with_rebar_default_config/1]).
 -export([throw_configuration/1]).
 -export([validate_config_with_string_ignore/1]).
+-export([validate_config_with_allow_no_files/1]).
 -export([validate/1]).
 
 -include_lib("stdlib/include/assert.hrl").
@@ -97,6 +98,43 @@ validate_config_with_string_ignore(_Config) ->
         }
     ],
     ok = elvis_config:validate(Config, undefined).
+
+validate_config_with_allow_no_files(_Config) ->
+    FileGlobs = [
+        "../../../../_build/test/lib/elvis_core/test/dirs/src/**/*.hrl",
+        "../../../../_build/test/lib/elvis_core/test/dirs/test/**/*.hrl"
+    ],
+    ConfigWithoutAllowNoFiles = [
+        #{
+            files => FileGlobs,
+            ruleset => hrl_files
+        }
+    ],
+    ?assertMatch(
+        {error, "key 'config', at list position number 1, yielded no files to analyse in " ++ _},
+        elvis_config:validate(ConfigWithoutAllowNoFiles, undefined)
+    ),
+
+    ConfigWithAllowNoFiles = [
+        #{
+            files => FileGlobs,
+            ruleset => hrl_files,
+            allow_no_files => true
+        }
+    ],
+    ok = elvis_config:validate(ConfigWithAllowNoFiles, undefined),
+    ok = elvis_core:rock({config, ConfigWithAllowNoFiles}),
+
+    ConfigWithInvalidAllowNoFiles = [
+        #{
+            files => FileGlobs,
+            ruleset => hrl_files,
+            allow_no_files => not_a_boolean
+        }
+    ],
+    {error,
+        "key 'config', at list position number 1, 'allow_no_files' is expected to be a boolean."} =
+        elvis_config:validate(ConfigWithInvalidAllowNoFiles, undefined).
 
 validate(_Config) ->
     ConfigDir = filename:join(["test", "examples", "configs"]),


### PR DESCRIPTION
## Summary

Add `allow_no_files` as an optional per-rule-group config key.

This lets shared `elvis.config` files include optional sections, such as `hrl_files`, without failing in applications that do not have matching files.

## Changes

- Add support for `allow_no_files => true` in config rule groups.
- Keep the default behavior unchanged: missing file matches still fail unless explicitly allowed.
- Validate `allow_no_files` as a boolean.
- Add regression coverage for empty `.hrl` glob matches.
- Document the new option in `README.md` and `MIGRATION.md`.

Closes #631 .

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
