### PR TITLE
fix crach when macro in specs

### DIFF
--- a/src/elvis_style.erl
+++ b/src/elvis_style.erl
@@ -1207,6 +1207,13 @@ is_behaviour_callback_spec(SpecNode, BehaviourCallbacks) ->
     ).
 
 spec_has_just_ok_result(SpecNode) ->
+    do_all_have_ok_result(ktn_code:node_attr(types, SpecNode)).
+
+%% The `types` attr is undefined when the result type couldn't be parsed as a
+%% regular type, e.g. when it's a macro (like `-spec f() -> ?A_MACRO.`).
+do_all_have_ok_result(undefined) ->
+    false;
+do_all_have_ok_result(Types) ->
     lists:all(
         fun(SpecType) ->
             [Result | _] = lists:reverse(ktn_code:content(SpecType)),
@@ -1219,7 +1226,7 @@ spec_has_just_ok_result(SpecNode) ->
                     false
             end
         end,
-        ktn_code:node_attr(types, SpecNode)
+        Types
     ).
 
 -spec no_spec_with_records(elvis_rule:t(), elvis_config:t()) -> [elvis_result:item()].

--- a/test/examples/pass_consistent_ok_error_spec.erl
+++ b/test/examples/pass_consistent_ok_error_spec.erl
@@ -3,6 +3,8 @@
 -behaviour(supervisor).
 -behaviour(pass_invalid_dynamic_call_callback).
 
+-define(A_MACRO, a_macro_value).
+
 -export([
          init/1,
          arity_two/0,
@@ -10,6 +12,7 @@
          disabled_by_dynamic_behaviour/0,
          call/0,
          macro_function_name_call/0,
+         macro_result/0,
          list/0,
          ok/0,
          map/0,
@@ -34,6 +37,9 @@ call() -> {ok, callback}.
 
 -spec macro_function_name_call() -> {ok, term()}.
 macro_function_name_call() -> {ok, callback}.
+
+-spec macro_result() -> ?A_MACRO.
+macro_result() -> ?A_MACRO.
 
 -spec list() -> [ok | number()].
 list() -> [ok].


### PR DESCRIPTION
# Description

Added a function clause to ignore these cases to prevent a crash.

Closes #625.

- [x] I have read and understood the [contributing guidelines](/inaka/elvis_core/blob/main/CONTRIBUTING.md)
